### PR TITLE
New `NotEmptyRange` and `Bound` types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -61,8 +61,8 @@ Support for
 
 ### Deprecated
 
-The `min` and the `max` companion's properties of the `StrictlyPositiveInt` and
-the `StrictlyNegativeInt` types (issue
+The `min` and the `max` companion's properties of the `StrictlyPositiveInt`, the
+`StrictlyNegativeInt` and the `PositiveInt` types (issue
 [#56](https://github.com/kotools/types/issues/56)).
 
 ```kotlin

--- a/changelog.md
+++ b/changelog.md
@@ -59,6 +59,21 @@ Support for
 [kotlinx.serialization 1.3.3](https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.3.3)
 (issue [#51](https://github.com/kotools/types/issues/51)).
 
+### Deprecated
+
+The `min` and the `max` companion's properties of the `StrictlyPositiveInt` type
+(issue [#56](https://github.com/kotools/types/issues/56)).
+
+```kotlin
+var result: StrictlyPositiveInt
+// before
+result = StrictlyPositiveInt.min
+result = StrictlyPositiveInt.max
+// after
+result = StrictlyPositiveInt.range.start.value
+result = StrictlyPositiveInt.range.end.value
+```
+
 ## 4.1.0
 
 _Release date: 2023-04-03._

--- a/changelog.md
+++ b/changelog.md
@@ -62,8 +62,8 @@ Support for
 ### Deprecated
 
 The `min` and the `max` companion's properties of the `StrictlyPositiveInt`, the
-`StrictlyNegativeInt`, the `PositiveInt` and the `NegativeInt` types (issue
-[#56](https://github.com/kotools/types/issues/56)).
+`StrictlyNegativeInt`, the `PositiveInt`, the `NegativeInt` and the `NonZeroInt`
+types (issue [#56](https://github.com/kotools/types/issues/56)).
 
 ```kotlin
 var result: StrictlyPositiveInt

--- a/changelog.md
+++ b/changelog.md
@@ -61,8 +61,9 @@ Support for
 
 ### Deprecated
 
-The `min` and the `max` companion's properties of the `StrictlyPositiveInt` type
-(issue [#56](https://github.com/kotools/types/issues/56)).
+The `min` and the `max` companion's properties of the `StrictlyPositiveInt` and
+the `StrictlyNegativeInt` types (issue
+[#56](https://github.com/kotools/types/issues/56)).
 
 ```kotlin
 var result: StrictlyPositiveInt

--- a/changelog.md
+++ b/changelog.md
@@ -22,8 +22,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-The `plus` operations for concatenating a `NotBlankString` with a `String` or a
-`Char` (issue [#53](https://github.com/kotools/types/issues/53)).
+- The `plus` operations for concatenating a `NotBlankString` with a `String` or
+  a `Char` (issue [#53](https://github.com/kotools/types/issues/53)).
 
 ```kotlin
 resultOf {
@@ -39,6 +39,17 @@ resultOf {
     result = firstString + "everyone"
     result = firstString + secondString
 }
+```
+
+- The `NotEmptyRange` and the `Bound` types representing a range of comparable
+  values that contain at least one value (issue
+  [#56](https://github.com/kotools/types/issues/56)).
+
+```kotlin
+val start: InclusiveBound<Int> = 1.toInclusiveBound()
+val end: ExclusiveBound<Int> = 42.toExclusiveBound()
+val range: NotEmptyRange<Int> = start..end
+println(range) // [1;42[
 ```
 
 ### Changed

--- a/changelog.md
+++ b/changelog.md
@@ -62,7 +62,7 @@ Support for
 ### Deprecated
 
 The `min` and the `max` companion's properties of the `StrictlyPositiveInt`, the
-`StrictlyNegativeInt` and the `PositiveInt` types (issue
+`StrictlyNegativeInt`, the `PositiveInt` and the `NegativeInt` types (issue
 [#56](https://github.com/kotools/types/issues/56)).
 
 ```kotlin

--- a/packages.md
+++ b/packages.md
@@ -10,6 +10,11 @@ Contains types such as `NotEmptyList` for manipulating collections.
 
 Contains types such as `NonZeroInt` for manipulating numbers.
 
+# Package kotools.types.range
+
+Contains types such as `NotEmptyRange` for manipulating ranges of comparable
+values.
+
 # Package kotools.types.result
 
 Contains declarations for manipulating the

--- a/src/commonMain/kotlin/kotools/types/number/AnyInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/AnyInt.kt
@@ -9,6 +9,9 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.range.ExclusiveBound
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -85,6 +88,18 @@ public operator fun AnyInt.div(other: NonZeroInt): Int = toInt() / other
  */
 @SinceKotoolsTypes("4.1")
 public operator fun AnyInt.rem(other: NonZeroInt): Int = toInt() % other
+
+internal fun <T : AnyInt> NotEmptyRange<T>.toIntRange(): IntRange {
+    val start: Int = when (start) {
+        is InclusiveBound -> start.value.toInt()
+        is ExclusiveBound -> start.value + 1
+    }
+    val end: Int = when (end) {
+        is InclusiveBound -> end.value.toInt()
+        is ExclusiveBound -> end.value - 1
+    }
+    return start..end
+}
 
 internal sealed interface AnyIntSerializer<I : AnyInt> : KSerializer<I> {
     val serialName: Result<NotBlankString>

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -15,7 +15,7 @@ public sealed interface NegativeInt : AnyInt {
     public companion object {
         /** The minimum value a [NegativeInt] can have. */
         public val min: StrictlyNegativeInt by lazy(
-            StrictlyNegativeInt.Companion::min
+            StrictlyNegativeInt.range.start::value
         )
 
         /** The maximum value a [NegativeInt] can have. */

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -6,6 +6,7 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -4,6 +4,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
+import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -14,21 +18,36 @@ public sealed interface NegativeInt : AnyInt {
     /** Contains declarations for holding or building a [NegativeInt]. */
     public companion object {
         /** The minimum value a [NegativeInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("NegativeInt.range.start.value")
+        )
         public val min: StrictlyNegativeInt by lazy(
             StrictlyNegativeInt.range.start::value
         )
 
         /** The maximum value a [NegativeInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("NegativeInt.range.end.value")
+        )
         public val max: ZeroInt = ZeroInt
+
+        /** The range of values a [NegativeInt] can have. */
+        @SinceKotoolsTypes("4.2")
+        public val range: NotEmptyRange<NegativeInt> by lazy {
+            val start: InclusiveBound<NegativeInt> =
+                StrictlyNegativeInt.range.start.value.toInclusiveBound()
+            val end: InclusiveBound<NegativeInt> = ZeroInt.toInclusiveBound()
+            start..end
+        }
 
         /** Returns a random [NegativeInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): NegativeInt {
-            val range: IntRange = min.toInt()..max.toInt()
-            return range.random()
-                .toNegativeInt()
-                .getOrThrow()
-        }
+        public fun random(): NegativeInt = range.toIntRange()
+            .random()
+            .toNegativeInt()
+            .getOrThrow()
     }
 
     @SinceKotoolsTypes("4.0")

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -6,7 +6,6 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -4,8 +4,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
-import kotools.types.collection.NotEmptySet
-import kotools.types.collection.notEmptySetOf
 import kotools.types.range.NotEmptyRange
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
@@ -48,17 +46,12 @@ public sealed interface NonZeroInt : AnyInt {
 
         /** Returns a random [NonZeroInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): NonZeroInt {
-            val ranges: NotEmptySet<IntRange> = notEmptySetOf(
-                negativeRange.toIntRange(),
-                positiveRange.toIntRange()
-            )
-            return ranges.toSet()
-                .random()
-                .random()
-                .toNonZeroInt()
-                .getOrThrow()
-        }
+        public fun random(): NonZeroInt = setOf(negativeRange, positiveRange)
+            .random()
+            .toIntRange()
+            .random()
+            .toNonZeroInt()
+            .getOrThrow()
     }
 
     @SinceKotoolsTypes("4.0")

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -22,7 +22,7 @@ public sealed interface NonZeroInt : AnyInt {
 
         /** The maximum value a [NonZeroInt] can have. */
         public val max: StrictlyPositiveInt by lazy(
-            StrictlyPositiveInt.Companion::max
+            StrictlyPositiveInt.range.end::value
         )
 
         /** Returns a random [NonZeroInt]. */
@@ -30,7 +30,7 @@ public sealed interface NonZeroInt : AnyInt {
         public fun random(): NonZeroInt {
             val ranges: NotEmptySet<IntRange> = notEmptySetOf(
                 min.toInt()..StrictlyNegativeInt.max.toInt(),
-                StrictlyPositiveInt.min.toInt()..max.toInt()
+                StrictlyPositiveInt.range.start.value.toInt()..max.toInt()
             )
             return ranges.toSet()
                 .random()

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -17,7 +17,7 @@ public sealed interface NonZeroInt : AnyInt {
     public companion object {
         /** The minimum value a [NonZeroInt] can have. */
         public val min: StrictlyNegativeInt by lazy(
-            StrictlyNegativeInt.Companion::min
+            StrictlyNegativeInt.range.start::value
         )
 
         /** The maximum value a [NonZeroInt] can have. */
@@ -29,7 +29,7 @@ public sealed interface NonZeroInt : AnyInt {
         @SinceKotoolsTypes("3.0")
         public fun random(): NonZeroInt {
             val ranges: NotEmptySet<IntRange> = notEmptySetOf(
-                min.toInt()..StrictlyNegativeInt.max.toInt(),
+                min.toInt()..StrictlyNegativeInt.range.end.value.toInt(),
                 StrictlyPositiveInt.range.start.value.toInt()..max.toInt()
             )
             return ranges.toSet()

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -6,6 +6,7 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.collection.NotEmptySet
 import kotools.types.collection.notEmptySetOf
+import kotools.types.range.NotEmptyRange
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -16,21 +17,41 @@ public sealed interface NonZeroInt : AnyInt {
     /** Contains declarations for holding or building a [NonZeroInt]. */
     public companion object {
         /** The minimum value a [NonZeroInt] can have. */
+        @Deprecated(
+            "Use the negativeRange property instead.",
+            ReplaceWith("NonZeroInt.negativeRange.start.value")
+        )
         public val min: StrictlyNegativeInt by lazy(
             StrictlyNegativeInt.range.start::value
         )
 
         /** The maximum value a [NonZeroInt] can have. */
+        @Deprecated(
+            "Use the positiveRange property instead.",
+            ReplaceWith("NonZeroInt.positiveRange.end.value")
+        )
         public val max: StrictlyPositiveInt by lazy(
             StrictlyPositiveInt.range.end::value
+        )
+
+        /** The negative range of values a [NonZeroInt] can have. */
+        @SinceKotoolsTypes("4.2")
+        public val negativeRange: NotEmptyRange<StrictlyNegativeInt> by lazy(
+            StrictlyNegativeInt.Companion::range
+        )
+
+        /** The positive range of values a [NonZeroInt] can have. */
+        @SinceKotoolsTypes("4.2")
+        public val positiveRange: NotEmptyRange<StrictlyPositiveInt> by lazy(
+            StrictlyPositiveInt.Companion::range
         )
 
         /** Returns a random [NonZeroInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): NonZeroInt {
             val ranges: NotEmptySet<IntRange> = notEmptySetOf(
-                min.toInt()..StrictlyNegativeInt.range.end.value.toInt(),
-                StrictlyPositiveInt.range.start.value.toInt()..max.toInt()
+                negativeRange.toIntRange(),
+                positiveRange.toIntRange()
             )
             return ranges.toSet()
                 .random()

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -18,7 +18,7 @@ public sealed interface PositiveInt : AnyInt {
 
         /** The maximum value a [PositiveInt] can have. */
         public val max: StrictlyPositiveInt by lazy(
-            StrictlyPositiveInt.Companion::max
+            StrictlyPositiveInt.range.end::value
         )
 
         /** Returns a random [PositiveInt]. */

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -6,6 +6,7 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -4,6 +4,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
+import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -14,16 +18,34 @@ public sealed interface PositiveInt : AnyInt {
     /** Contains declarations for holding or building a [PositiveInt]. */
     public companion object {
         /** The minimum value a [PositiveInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("PositiveInt.range.start.value")
+        )
         public val min: ZeroInt = ZeroInt
 
         /** The maximum value a [PositiveInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("PositiveInt.range.end.value")
+        )
         public val max: StrictlyPositiveInt by lazy(
             StrictlyPositiveInt.range.end::value
         )
 
+        /** The range of values a [PositiveInt] can have. */
+        @SinceKotoolsTypes("4.2")
+        public val range: NotEmptyRange<PositiveInt> by lazy {
+            val start: InclusiveBound<PositiveInt> = ZeroInt.toInclusiveBound()
+            val end: InclusiveBound<PositiveInt> =
+                StrictlyPositiveInt.range.end.value.toInclusiveBound()
+            start..end
+        }
+
         /** Returns a random [PositiveInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): PositiveInt = (min.toInt()..max.toInt()).random()
+        public fun random(): PositiveInt = range.toIntRange()
+            .random()
             .toPositiveInt()
             .getOrThrow()
     }

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -6,7 +6,6 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -4,6 +4,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
+import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
@@ -19,14 +23,36 @@ private constructor(private val value: Int) : NonZeroInt, NegativeInt {
      */
     public companion object {
         /** The minimum value a [StrictlyNegativeInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("StrictlyNegativeInt.range.start.value")
+        )
         public val min: StrictlyNegativeInt by lazy(
             Int.MIN_VALUE.toStrictlyNegativeInt()::getOrThrow
         )
 
         /** The maximum value a [StrictlyNegativeInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("StrictlyNegativeInt.range.end.value")
+        )
         public val max: StrictlyNegativeInt by lazy(
             (-1).toStrictlyNegativeInt()::getOrThrow
         )
+
+        /** The range of values a [StrictlyNegativeInt] can have. */
+        @SinceKotoolsTypes("4.2")
+        public val range: NotEmptyRange<StrictlyNegativeInt> by lazy {
+            val start: InclusiveBound<StrictlyNegativeInt> = Int.MIN_VALUE
+                .toStrictlyNegativeInt()
+                .getOrThrow()
+                .toInclusiveBound()
+            val end: InclusiveBound<StrictlyNegativeInt> = (-1)
+                .toStrictlyNegativeInt()
+                .getOrThrow()
+                .toInclusiveBound()
+            start..end
+        }
 
         internal infix fun of(value: Int): Result<StrictlyNegativeInt> = value
             .takeIf { it < ZeroInt.toInt() }
@@ -35,7 +61,7 @@ private constructor(private val value: Int) : NonZeroInt, NegativeInt {
 
         /** Returns a random [StrictlyNegativeInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): StrictlyNegativeInt = (min.value..max.value)
+        public fun random(): StrictlyNegativeInt = range.toIntRange()
             .random()
             .toStrictlyNegativeInt()
             .getOrThrow()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -6,6 +6,7 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -6,7 +6,6 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -4,6 +4,10 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
+import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
@@ -19,14 +23,36 @@ private constructor(private val value: Int) : NonZeroInt, PositiveInt {
      */
     public companion object {
         /** The minimum value a [StrictlyPositiveInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("StrictlyPositiveInt.range.start.value")
+        )
         public val min: StrictlyPositiveInt by lazy(
             1.toStrictlyPositiveInt()::getOrThrow
         )
 
         /** The maximum value a [StrictlyPositiveInt] can have. */
+        @Deprecated(
+            "Use the range property instead.",
+            ReplaceWith("StrictlyPositiveInt.range.end.value")
+        )
         public val max: StrictlyPositiveInt by lazy(
             Int.MAX_VALUE.toStrictlyPositiveInt()::getOrThrow
         )
+
+        /** The range of values a [StrictlyPositiveInt] can have. */
+        @SinceKotoolsTypes("4.2")
+        public val range: NotEmptyRange<StrictlyPositiveInt> by lazy {
+            val start: InclusiveBound<StrictlyPositiveInt> = 1
+                .toStrictlyPositiveInt()
+                .getOrThrow()
+                .toInclusiveBound()
+            val end: InclusiveBound<StrictlyPositiveInt> = Int.MAX_VALUE
+                .toStrictlyPositiveInt()
+                .getOrThrow()
+                .toInclusiveBound()
+            start..end
+        }
 
         internal infix fun of(value: Int): Result<StrictlyPositiveInt> = value
             .takeIf { it > ZeroInt.toInt() }
@@ -35,7 +61,7 @@ private constructor(private val value: Int) : NonZeroInt, PositiveInt {
 
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): StrictlyPositiveInt = (min.value..max.value)
+        public fun random(): StrictlyPositiveInt = range.toIntRange()
             .random()
             .toStrictlyPositiveInt()
             .getOrThrow()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -6,6 +6,7 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -6,7 +6,6 @@ import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
 import kotools.types.range.toInclusiveBound
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -8,6 +8,15 @@ public sealed interface Bound<T : Comparable<T>> {
     /** The value of this bound. */
     public val value: T
 
+    /**
+     * Creates a [NotEmptyRange] using this bound and the [other] one.
+     * If the [other] bound is lower than this bound, the resulting range will
+     * [start][NotEmptyRange.start] with the [other] bound.
+     */
+    public infix operator fun rangeTo(other: Bound<T>): NotEmptyRange<T> =
+        if (value <= other.value) NotEmptyRange(start = this, end = other)
+        else NotEmptyRange(start = other, end = this)
+
     /** Returns the string representation of this bound's [value]. */
     override fun toString(): String
 }

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -1,0 +1,37 @@
+package kotools.types.range
+
+import kotools.types.SinceKotoolsTypes
+
+/** Representation of a bound in a [range][NotEmptyRange]. */
+@SinceKotoolsTypes("4.2")
+public sealed interface Bound<T : Comparable<T>> {
+    /** The value of this bound. */
+    public val value: T
+
+    /** Returns the string representation of this bound's [value]. */
+    override fun toString(): String
+}
+
+/** Representation of an inclusive bound in a [range][NotEmptyRange]. */
+@SinceKotoolsTypes("4.2")
+public data class InclusiveBound<T : Comparable<T>>
+internal constructor(override val value: T) : Bound<T> {
+    override fun toString(): String = "$value"
+}
+
+/** Returns this comparable value as an [InclusiveBound]. */
+@SinceKotoolsTypes("4.2")
+public fun <T : Comparable<T>> T.toInclusiveBound(): InclusiveBound<T> =
+    InclusiveBound(this)
+
+/** Representation of an exclusive bound in a [range][NotEmptyRange]. */
+@SinceKotoolsTypes("4.2")
+public data class ExclusiveBound<T : Comparable<T>>
+internal constructor(override val value: T) : Bound<T> {
+    override fun toString(): String = "$value"
+}
+
+/** Returns this comparable value as an [ExclusiveBound]. */
+@SinceKotoolsTypes("4.2")
+public fun <T : Comparable<T>> T.toExclusiveBound(): ExclusiveBound<T> =
+    ExclusiveBound(this)

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -14,15 +14,18 @@ public sealed interface Bound<T : Comparable<T>> {
 
 /** Representation of an inclusive bound in a [range][NotEmptyRange]. */
 @SinceKotoolsTypes("4.2")
-public data class InclusiveBound<T : Comparable<T>>
-internal constructor(override val value: T) : Bound<T> {
+public sealed interface InclusiveBound<T : Comparable<T>> : Bound<T>
+
+private data class InclusiveBoundImplementation<T : Comparable<T>>(
+    override val value: T
+) : InclusiveBound<T> {
     override fun toString(): String = "$value"
 }
 
 /** Returns this comparable value as an [InclusiveBound]. */
 @SinceKotoolsTypes("4.2")
 public fun <T : Comparable<T>> T.toInclusiveBound(): InclusiveBound<T> =
-    InclusiveBound(this)
+    InclusiveBoundImplementation(this)
 
 /** Representation of an exclusive bound in a [range][NotEmptyRange]. */
 @SinceKotoolsTypes("4.2")

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -29,12 +29,15 @@ public fun <T : Comparable<T>> T.toInclusiveBound(): InclusiveBound<T> =
 
 /** Representation of an exclusive bound in a [range][NotEmptyRange]. */
 @SinceKotoolsTypes("4.2")
-public data class ExclusiveBound<T : Comparable<T>>
-internal constructor(override val value: T) : Bound<T> {
+public sealed interface ExclusiveBound<T : Comparable<T>> : Bound<T>
+
+private data class ExclusiveBoundImplementation<T : Comparable<T>>(
+    override val value: T
+) : ExclusiveBound<T> {
     override fun toString(): String = "$value"
 }
 
 /** Returns this comparable value as an [ExclusiveBound]. */
 @SinceKotoolsTypes("4.2")
 public fun <T : Comparable<T>> T.toExclusiveBound(): ExclusiveBound<T> =
-    ExclusiveBound(this)
+    ExclusiveBoundImplementation(this)

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -8,15 +8,6 @@ public sealed interface Bound<T : Comparable<T>> {
     /** The value of this bound. */
     public val value: T
 
-    /**
-     * Creates a [NotEmptyRange] using this bound and the [other] one.
-     * If the [other] bound is lower than this bound, the resulting range will
-     * [start][NotEmptyRange.start] with the [other] bound.
-     */
-    public infix operator fun rangeTo(other: Bound<T>): NotEmptyRange<T> =
-        if (value <= other.value) NotEmptyRange(start = this, end = other)
-        else NotEmptyRange(start = other, end = this)
-
     /** Returns the string representation of this bound's [value]. */
     override fun toString(): String
 }

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -7,13 +7,21 @@ import kotools.types.SinceKotoolsTypes
  * value.
  */
 @SinceKotoolsTypes("4.2")
-public data class NotEmptyRange<T : Comparable<T>> internal constructor(
+public sealed interface NotEmptyRange<T : Comparable<T>> {
     /** The start of this range. */
-    public val start: Bound<T>,
+    public val start: Bound<T>
+
     /** The end of this range. */
     public val end: Bound<T>
-) {
+
     /** Returns the string representation of this range. */
+    override fun toString(): String
+}
+
+private data class NotEmptyRangeImplementation<T : Comparable<T>>(
+    override val start: Bound<T>,
+    override val end: Bound<T>
+) : NotEmptyRange<T> {
     override fun toString(): String {
         val prefix: Char = when (start) {
             is InclusiveBound -> '['
@@ -55,5 +63,8 @@ public infix operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
 public infix operator fun <T : Comparable<T>> Bound<T>.rangeTo(
     other: Bound<T>
 ): NotEmptyRange<T> =
-    if (value <= other.value) NotEmptyRange(start = this, end = other)
-    else NotEmptyRange(start = other, end = this)
+    if (value <= other.value) NotEmptyRangeImplementation(
+        start = this,
+        end = other
+    )
+    else NotEmptyRangeImplementation(start = other, end = this)

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -42,3 +42,15 @@ public data class NotEmptyRange<T : Comparable<T>> internal constructor(
         return "$prefix$start;$end$suffix"
     }
 }
+
+/**
+ * Creates a [NotEmptyRange] using this bound and the [other] one.
+ * If the [other] bound is lower than this bound, the resulting range will
+ * [start][NotEmptyRange.start] with the [other] bound.
+ */
+@SinceKotoolsTypes("4.2")
+public infix operator fun <T : Comparable<T>> Bound<T>.rangeTo(
+    other: Bound<T>
+): NotEmptyRange<T> =
+    if (value <= other.value) NotEmptyRange(start = this, end = other)
+    else NotEmptyRange(start = other, end = this)

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -13,22 +13,6 @@ public data class NotEmptyRange<T : Comparable<T>> internal constructor(
     /** The end of this range. */
     public val end: Bound<T>
 ) {
-    /**
-     * Returns `true` if this range contains the given [value], or returns
-     * `false` otherwise.
-     */
-    public infix operator fun contains(value: T): Boolean {
-        val valueIsGreaterThanStart: Boolean = when (start) {
-            is InclusiveBound -> value >= start.value
-            is ExclusiveBound -> value > start.value
-        }
-        val valueIsLowerThanEnd: Boolean = when (end) {
-            is InclusiveBound -> value <= end.value
-            is ExclusiveBound -> value < end.value
-        }
-        return valueIsGreaterThanStart && valueIsLowerThanEnd
-    }
-
     /** Returns the string representation of this range. */
     override fun toString(): String {
         val prefix: Char = when (start) {
@@ -41,6 +25,25 @@ public data class NotEmptyRange<T : Comparable<T>> internal constructor(
         }
         return "$prefix$start;$end$suffix"
     }
+}
+
+/**
+ * Returns `true` if this range contains the given [value], or returns `false`
+ * otherwise.
+ */
+@SinceKotoolsTypes("4.2")
+public infix operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
+    value: T
+): Boolean {
+    val valueIsGreaterThanStart: Boolean = when (start) {
+        is InclusiveBound -> value >= start.value
+        is ExclusiveBound -> value > start.value
+    }
+    val valueIsLowerThanEnd: Boolean = when (end) {
+        is InclusiveBound -> value <= end.value
+        is ExclusiveBound -> value < end.value
+    }
+    return valueIsGreaterThanStart && valueIsLowerThanEnd
 }
 
 /**

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -40,7 +40,7 @@ private data class NotEmptyRangeImplementation<T : Comparable<T>>(
  * otherwise.
  */
 @SinceKotoolsTypes("4.2")
-public infix operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
+public operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
     value: T
 ): Boolean {
     val valueIsGreaterThanStart: Boolean = when (start) {
@@ -60,11 +60,9 @@ public infix operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
  * [start][NotEmptyRange.start] with the [other] bound.
  */
 @SinceKotoolsTypes("4.2")
-public infix operator fun <T : Comparable<T>> Bound<T>.rangeTo(
+public operator fun <T : Comparable<T>> Bound<T>.rangeTo(
     other: Bound<T>
-): NotEmptyRange<T> =
-    if (value <= other.value) NotEmptyRangeImplementation(
-        start = this,
-        end = other
-    )
-    else NotEmptyRangeImplementation(start = other, end = this)
+): NotEmptyRange<T> = if (value <= other.value) NotEmptyRangeImplementation(
+    start = this,
+    end = other
+) else NotEmptyRangeImplementation(start = other, end = this)

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -42,15 +42,3 @@ public data class NotEmptyRange<T : Comparable<T>> internal constructor(
         return "$prefix$start;$end$suffix"
     }
 }
-
-/**
- * Creates a [NotEmptyRange] using this bound and the [other] one.
- * If the [other] bound is lower than this bound, the resulting range will
- * [start][NotEmptyRange.start] with the [other] bound.
- */
-@SinceKotoolsTypes("4.2")
-public infix operator fun <T : Comparable<T>> Bound<T>.rangeTo(
-    other: Bound<T>
-): NotEmptyRange<T> =
-    if (value <= other.value) NotEmptyRange(start = this, end = other)
-    else NotEmptyRange(start = other, end = this)

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -1,0 +1,56 @@
+package kotools.types.range
+
+import kotools.types.SinceKotoolsTypes
+
+/**
+ * Representation of a range of comparable values that contain at least one
+ * value.
+ */
+@SinceKotoolsTypes("4.2")
+public data class NotEmptyRange<T : Comparable<T>> internal constructor(
+    /** The start of this range. */
+    public val start: Bound<T>,
+    /** The end of this range. */
+    public val end: Bound<T>
+) {
+    /**
+     * Returns `true` if this range contains the given [value], or returns
+     * `false` otherwise.
+     */
+    public infix operator fun contains(value: T): Boolean {
+        val valueIsGreaterThanStart: Boolean = when (start) {
+            is InclusiveBound -> value >= start.value
+            is ExclusiveBound -> value > start.value
+        }
+        val valueIsLowerThanEnd: Boolean = when (end) {
+            is InclusiveBound -> value <= end.value
+            is ExclusiveBound -> value < end.value
+        }
+        return valueIsGreaterThanStart && valueIsLowerThanEnd
+    }
+
+    /** Returns the string representation of this range. */
+    override fun toString(): String {
+        val prefix: Char = when (start) {
+            is InclusiveBound -> '['
+            is ExclusiveBound -> ']'
+        }
+        val suffix: Char = when (end) {
+            is InclusiveBound -> ']'
+            is ExclusiveBound -> '['
+        }
+        return "$prefix$start;$end$suffix"
+    }
+}
+
+/**
+ * Creates a [NotEmptyRange] using this bound and the [other] one.
+ * If the [other] bound is lower than this bound, the resulting range will
+ * [start][NotEmptyRange.start] with the [other] bound.
+ */
+@SinceKotoolsTypes("4.2")
+public infix operator fun <T : Comparable<T>> Bound<T>.rangeTo(
+    other: Bound<T>
+): NotEmptyRange<T> =
+    if (value <= other.value) NotEmptyRange(start = this, end = other)
+    else NotEmptyRange(start = other, end = this)

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -5,23 +5,42 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class NegativeIntCompanionTest {
+    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_the_minimum_value_of_Int() {
         val result: StrictlyNegativeInt = NegativeInt.min
         result.toInt() shouldEqual Int.MIN_VALUE
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_zero() {
         val result: ZeroInt = NegativeInt.max
         result shouldEqual ZeroInt
+    }
+
+    @Test
+    fun range_should_start_with_an_InclusiveBound_that_equals_the_minimum_value_of_Int() {
+        val range: NotEmptyRange<NegativeInt> = NegativeInt.range
+        assertTrue { range.start is InclusiveBound }
+        range.start.value.toInt() shouldEqual Int.MIN_VALUE
+    }
+
+    @Test
+    fun range_should_end_with_an_InclusiveBound_that_equals_zero() {
+        val range: NotEmptyRange<NegativeInt> = NegativeInt.range
+        assertTrue { range.end is InclusiveBound }
+        range.end.value shouldEqual ZeroInt
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
@@ -14,16 +15,30 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class NonZeroIntCompanionTest {
+    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_the_minimum_value_of_Int() {
         val result: StrictlyNegativeInt = NonZeroInt.min
         result.toInt() shouldEqual Int.MIN_VALUE
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_the_maximum_value_of_Int() {
         val result: StrictlyPositiveInt = NonZeroInt.max
         result.toInt() shouldEqual Int.MAX_VALUE
+    }
+
+    @Test
+    fun negativeRange_should_be_the_range_of_StrictlyNegativeInt() {
+        val range: NotEmptyRange<StrictlyNegativeInt> = NonZeroInt.negativeRange
+        range shouldEqual StrictlyNegativeInt.range
+    }
+
+    @Test
+    fun positiveRange_should_be_the_range_of_StrictlyPositiveInt() {
+        val range: NotEmptyRange<StrictlyPositiveInt> = NonZeroInt.positiveRange
+        range shouldEqual StrictlyPositiveInt.range
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -6,23 +6,42 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class PositiveIntCompanionTest {
+    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_zero() {
         val result: ZeroInt = PositiveInt.min
         result shouldEqual ZeroInt
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_the_maximum_value_of_Int() {
         val result: StrictlyPositiveInt = PositiveInt.max
         result.toInt() shouldEqual Int.MAX_VALUE
+    }
+
+    @Test
+    fun range_should_start_with_an_InclusiveBound_that_equals_zero() {
+        val range: NotEmptyRange<PositiveInt> = PositiveInt.range
+        assertTrue { range.start is InclusiveBound }
+        range.start.value shouldEqual ZeroInt
+    }
+
+    @Test
+    fun range_should_end_with_an_InclusiveBound_that_equals_the_maximum_value_of_Int() {
+        val range: NotEmptyRange<PositiveInt> = PositiveInt.range
+        assertTrue { range.end is InclusiveBound }
+        range.end.value.toInt() shouldEqual Int.MAX_VALUE
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -6,23 +6,44 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class StrictlyNegativeIntCompanionTest {
+    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_the_minimum_value_of_Int() {
         val result: StrictlyNegativeInt = StrictlyNegativeInt.min
         result.toInt() shouldEqual Int.MIN_VALUE
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_minus_one() {
         val result: StrictlyNegativeInt = StrictlyNegativeInt.max
         result.toInt() shouldEqual -1
+    }
+
+    @Test
+    fun range_should_start_with_an_InclusiveBound_that_equals_the_minimum_value_of_Int() {
+        val range: NotEmptyRange<StrictlyNegativeInt> =
+            StrictlyNegativeInt.range
+        assertTrue { range.start is InclusiveBound }
+        range.start.value.toInt() shouldEqual Int.MIN_VALUE
+    }
+
+    @Test
+    fun range_should_end_with_an_InclusiveBound_that_equals_minus_one() {
+        val range: NotEmptyRange<StrictlyNegativeInt> =
+            StrictlyNegativeInt.range
+        assertTrue { range.end is InclusiveBound }
+        range.end.value.toInt() shouldEqual -1
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -6,23 +6,44 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.range.InclusiveBound
+import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class StrictlyPositiveIntCompanionTest {
+    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_one() {
         val result: StrictlyPositiveInt = StrictlyPositiveInt.min
         result.toInt() shouldEqual 1
     }
 
+    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_the_maximum_value_of_Int() {
         val result: StrictlyPositiveInt = StrictlyPositiveInt.max
         result.toInt() shouldEqual Int.MAX_VALUE
+    }
+
+    @Test
+    fun range_should_start_with_an_inclusive_bound_that_equals_1() {
+        val range: NotEmptyRange<StrictlyPositiveInt> =
+            StrictlyPositiveInt.range
+        assertTrue { range.start is InclusiveBound }
+        range.start.value.toInt() shouldEqual 1
+    }
+
+    @Test
+    fun range_should_end_with_an_inclusive_bound_that_equals_the_maximum_value_of_Int() {
+        val range: NotEmptyRange<StrictlyPositiveInt> =
+            StrictlyPositiveInt.range
+        assertTrue { range.end is InclusiveBound }
+        range.end.value.toInt() shouldEqual Int.MAX_VALUE
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
@@ -7,30 +7,6 @@ import kotools.types.shouldEqual
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
-class BoundTest {
-    @Test
-    fun rangeTo_should_return_a_NotEmptyRange_ending_with_the_other_one() {
-        val firstBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val otherBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
-        result.start shouldEqual firstBound
-        result.end shouldEqual otherBound
-    }
-
-    @Test
-    fun rangeTo_should_return_a_NotEmptyRange_starting_with_the_other_one() {
-        val firstBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val otherBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
-        result.start shouldEqual otherBound
-        result.end shouldEqual firstBound
-    }
-}
-
 class InclusiveBoundTest {
     @Test
     fun equals_should_pass_with_another_InclusiveBound_having_the_same_value() {

--- a/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
@@ -7,6 +7,30 @@ import kotools.types.shouldEqual
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+class BoundTest {
+    @Test
+    fun rangeTo_should_return_a_NotEmptyRange_ending_with_the_other_one() {
+        val firstBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val otherBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
+        result.start shouldEqual firstBound
+        result.end shouldEqual otherBound
+    }
+
+    @Test
+    fun rangeTo_should_return_a_NotEmptyRange_starting_with_the_other_one() {
+        val firstBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val otherBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
+        result.start shouldEqual otherBound
+        result.end shouldEqual firstBound
+    }
+}
+
 class InclusiveBoundTest {
     @Test
     fun equals_should_pass_with_another_InclusiveBound_having_the_same_value() {

--- a/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
@@ -1,0 +1,98 @@
+package kotools.types.range
+
+import kotools.types.number.NonZeroInt
+import kotools.types.number.StrictlyNegativeInt
+import kotools.types.number.StrictlyPositiveInt
+import kotools.types.shouldEqual
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class InclusiveBoundTest {
+    @Test
+    fun equals_should_pass_with_another_InclusiveBound_having_the_same_value() {
+        val firstBound: InclusiveBound<NonZeroInt> = NonZeroInt.random()
+            .toInclusiveBound()
+        val secondBound: InclusiveBound<NonZeroInt> =
+            firstBound.value.toInclusiveBound()
+        assertTrue { firstBound == secondBound }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_InclusiveBound_having_another_value() {
+        val firstBound: InclusiveBound<NonZeroInt> = StrictlyPositiveInt
+            .random()
+            .toInclusiveBound()
+        val secondBound: InclusiveBound<NonZeroInt> = StrictlyNegativeInt
+            .random()
+            .toInclusiveBound()
+        assertTrue { firstBound != secondBound }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_ExclusiveBound() {
+        val firstBound: InclusiveBound<NonZeroInt> = NonZeroInt.random()
+            .toInclusiveBound()
+        val secondBound: ExclusiveBound<NonZeroInt> =
+            firstBound.value.toExclusiveBound()
+        assertTrue { firstBound != secondBound }
+    }
+
+    @Test
+    fun toString_should_return_the_string_representation_of_its_value() {
+        val bound: InclusiveBound<NonZeroInt> = NonZeroInt.random()
+            .toInclusiveBound()
+        "$bound" shouldEqual "${bound.value}"
+    }
+
+    @Test
+    fun toInclusiveBound_should_return_an_InclusiveBound_of_this_value() {
+        val value: NonZeroInt = NonZeroInt.random()
+        val result: InclusiveBound<NonZeroInt> = value.toInclusiveBound()
+        result.value shouldEqual value
+    }
+}
+
+class ExclusiveBoundTest {
+    @Test
+    fun equals_should_pass_with_another_ExclusiveBound_having_the_same_value() {
+        val firstBound: ExclusiveBound<NonZeroInt> = NonZeroInt.random()
+            .toExclusiveBound()
+        val secondBound: ExclusiveBound<NonZeroInt> =
+            firstBound.value.toExclusiveBound()
+        assertTrue { firstBound == secondBound }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_ExclusiveBound_having_another_value() {
+        val firstBound: ExclusiveBound<NonZeroInt> = StrictlyPositiveInt
+            .random()
+            .toExclusiveBound()
+        val secondBound: ExclusiveBound<NonZeroInt> = StrictlyNegativeInt
+            .random()
+            .toExclusiveBound()
+        assertTrue { firstBound != secondBound }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_InclusiveBound() {
+        val firstBound: ExclusiveBound<NonZeroInt> = NonZeroInt.random()
+            .toExclusiveBound()
+        val secondBound: InclusiveBound<NonZeroInt> =
+            firstBound.value.toInclusiveBound()
+        assertTrue { firstBound != secondBound }
+    }
+
+    @Test
+    fun toString_should_return_the_string_representation_of_its_value() {
+        val bound: ExclusiveBound<NonZeroInt> = NonZeroInt.random()
+            .toExclusiveBound()
+        "$bound" shouldEqual "${bound.value}"
+    }
+
+    @Test
+    fun toExclusiveBound_should_return_an_ExclusiveBound_of_this_value() {
+        val value: NonZeroInt = NonZeroInt.random()
+        val result: ExclusiveBound<NonZeroInt> = value.toExclusiveBound()
+        result.value shouldEqual value
+    }
+}

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -164,26 +164,4 @@ class NotEmptyRangeTest {
         val range: NotEmptyRange<NonZeroInt> = start..end
         "$range" shouldEqual "[$start;$end["
     }
-
-    @Test
-    fun rangeTo_should_return_a_NotEmptyRange_ending_with_the_other_one() {
-        val firstBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val otherBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
-        result.start shouldEqual firstBound
-        result.end shouldEqual otherBound
-    }
-
-    @Test
-    fun rangeTo_should_return_a_NotEmptyRange_starting_with_the_other_one() {
-        val firstBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val otherBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
-        result.start shouldEqual otherBound
-        result.end shouldEqual firstBound
-    }
 }

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -1,0 +1,128 @@
+package kotools.types.range
+
+import kotools.types.number.*
+import kotools.types.shouldEqual
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class NotEmptyRangeTest {
+    @Test
+    fun contains_should_pass_with_a_value_in_inclusive_bounds() {
+        val start: InclusiveBound<NonZeroInt> =
+            NonZeroInt.min.toInclusiveBound()
+        val end: InclusiveBound<NonZeroInt> = NonZeroInt.max.toInclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = NonZeroInt.random()
+        assertTrue { value in range }
+    }
+
+    @Test
+    fun contains_should_pass_with_a_value_in_exclusive_bounds() {
+        val start: ExclusiveBound<NonZeroInt> =
+            NonZeroInt.min.toExclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> = 2.toStrictlyPositiveInt()
+            .getOrThrow()
+            .toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = 1.toStrictlyPositiveInt()
+            .getOrThrow()
+        assertTrue { value in range }
+    }
+
+    @Test
+    fun contains_should_pass_with_a_value_in_inclusive_and_exclusive_bounds() {
+        val start: InclusiveBound<NonZeroInt> =
+            NonZeroInt.min.toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> = NonZeroInt.max.toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = (NonZeroInt.random()
+            .takeIf { it != NonZeroInt.max }
+            ?: NonZeroInt.min)
+        assertTrue { value in range }
+    }
+
+    @Test
+    fun contains_should_fail_with_a_value_that_is_not_in_inclusive_bounds() {
+        val start: InclusiveBound<PositiveInt> = 1.toStrictlyPositiveInt()
+            .getOrThrow()
+            .toInclusiveBound()
+        val end: InclusiveBound<PositiveInt> =
+            PositiveInt.max.toInclusiveBound()
+        val range: NotEmptyRange<PositiveInt> = start..end
+        val value: PositiveInt = ZeroInt
+        assertTrue { value !in range }
+    }
+
+    @Test
+    fun contains_should_fail_with_a_value_that_is_not_in_exclusive_bounds() {
+        val start: ExclusiveBound<PositiveInt> =
+            PositiveInt.min.toExclusiveBound()
+        val end: ExclusiveBound<PositiveInt> =
+            PositiveInt.max.toExclusiveBound()
+        val range: NotEmptyRange<PositiveInt> = start..end
+        val value: PositiveInt = PositiveInt.min
+        assertTrue { value !in range }
+    }
+
+    @Test
+    fun contains_should_fail_with_a_value_that_is_not_in_inclusive_and_exclusive_bounds() {
+        val start: InclusiveBound<NonZeroInt> =
+            NonZeroInt.max.toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> = NonZeroInt.min.toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = NonZeroInt.min
+        assertTrue { value !in range }
+    }
+
+    @Test
+    fun toString_should_pass_with_2_InclusiveBounds() {
+        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toInclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        "$range" shouldEqual "[$start;$end]"
+    }
+
+    @Test
+    fun toString_should_pass_with_2_ExclusiveBounds() {
+        val start: ExclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toExclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        "$range" shouldEqual "]$start;$end["
+    }
+
+    @Test
+    fun toString_should_pass_with_an_InclusiveBound_and_ExclusiveBound() {
+        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        "$range" shouldEqual "[$start;$end["
+    }
+
+    @Test
+    fun rangeTo_should_return_a_NotEmptyRange_ending_with_the_other_one() {
+        val firstBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val otherBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
+        result.start shouldEqual firstBound
+        result.end shouldEqual otherBound
+    }
+
+    @Test
+    fun rangeTo_should_return_a_NotEmptyRange_starting_with_the_other_one() {
+        val firstBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val otherBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
+        result.start shouldEqual otherBound
+        result.end shouldEqual firstBound
+    }
+}

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -8,18 +8,15 @@ import kotlin.test.assertTrue
 class NotEmptyRangeTest {
     @Test
     fun contains_should_pass_with_a_value_in_inclusive_bounds() {
-        val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.min.toInclusiveBound()
-        val end: InclusiveBound<NonZeroInt> = NonZeroInt.max.toInclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = NonZeroInt.random()
+        val range: NotEmptyRange<PositiveInt> = PositiveInt.range
+        val value: PositiveInt = PositiveInt.random()
         assertTrue { value in range }
     }
 
     @Test
     fun contains_should_pass_with_a_value_in_exclusive_bounds() {
         val start: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.min.toExclusiveBound()
+            NonZeroInt.negativeRange.start.value.toExclusiveBound()
         val end: ExclusiveBound<NonZeroInt> = 2.toStrictlyPositiveInt()
             .getOrThrow()
             .toExclusiveBound()
@@ -32,12 +29,13 @@ class NotEmptyRangeTest {
     @Test
     fun contains_should_pass_with_a_value_in_inclusive_and_exclusive_bounds() {
         val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.min.toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> = NonZeroInt.max.toExclusiveBound()
+            NonZeroInt.negativeRange.start.value.toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> =
+            NonZeroInt.positiveRange.end.value.toExclusiveBound()
         val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = (NonZeroInt.random()
-            .takeIf { it != NonZeroInt.max }
-            ?: NonZeroInt.min)
+        val value: NonZeroInt = NonZeroInt.random()
+            .takeIf { it != NonZeroInt.positiveRange.end.value }
+            ?: NonZeroInt.negativeRange.start.value
         assertTrue { value in range }
     }
 
@@ -67,10 +65,11 @@ class NotEmptyRangeTest {
     @Test
     fun contains_should_fail_with_a_value_that_is_not_in_inclusive_and_exclusive_bounds() {
         val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.max.toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> = NonZeroInt.min.toExclusiveBound()
+            NonZeroInt.positiveRange.end.value.toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> =
+            NonZeroInt.negativeRange.start.value.toExclusiveBound()
         val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = NonZeroInt.min
+        val value: NonZeroInt = NonZeroInt.negativeRange.start.value
         assertTrue { value !in range }
     }
 

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -164,4 +164,26 @@ class NotEmptyRangeTest {
         val range: NotEmptyRange<NonZeroInt> = start..end
         "$range" shouldEqual "[$start;$end["
     }
+
+    @Test
+    fun rangeTo_should_return_a_NotEmptyRange_ending_with_the_other_one() {
+        val firstBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val otherBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
+        result.start shouldEqual firstBound
+        result.end shouldEqual otherBound
+    }
+
+    @Test
+    fun rangeTo_should_return_a_NotEmptyRange_starting_with_the_other_one() {
+        val firstBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toExclusiveBound()
+        val otherBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
+        result.start shouldEqual otherBound
+        result.end shouldEqual firstBound
+    }
 }

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -74,6 +74,68 @@ class NotEmptyRangeTest {
     }
 
     @Test
+    fun equals_should_pass_with_another_NotEmptyRange_having_the_same_bounds() {
+        val start: InclusiveBound<AnyInt> = NegativeInt.random()
+            .toInclusiveBound()
+        val end: InclusiveBound<AnyInt> = PositiveInt.random()
+            .toInclusiveBound()
+        val firstRange: NotEmptyRange<AnyInt> = start..end
+        val secondRange: NotEmptyRange<AnyInt> = start..end
+        assertTrue { firstRange == secondRange }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_NotEmptyRange_starting_with_another_type_of_bound_but_with_the_same_value() {
+        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toInclusiveBound()
+        val firstRange: NotEmptyRange<NonZeroInt> = start..end
+        val secondRange: NotEmptyRange<NonZeroInt> =
+            start.value.toExclusiveBound()..end
+        assertTrue { firstRange != secondRange }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_NotEmptyRange_starting_with_the_same_type_of_bound_but_with_another_value() {
+        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toInclusiveBound()
+        val firstRange: NotEmptyRange<NonZeroInt> = start..end
+        val secondRange: NotEmptyRange<NonZeroInt> = StrictlyNegativeInt
+            .random()
+            .toInclusiveBound<NonZeroInt>()
+            .rangeTo(end)
+        assertTrue { firstRange != secondRange }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_NotEmptyRange_ending_with_another_type_of_bound_but_with_the_same_value() {
+        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toInclusiveBound()
+        val firstRange: NotEmptyRange<NonZeroInt> = start..end
+        val secondRange: NotEmptyRange<NonZeroInt> =
+            start..end.value.toExclusiveBound()
+        assertTrue { firstRange != secondRange }
+    }
+
+    @Test
+    fun equals_should_fail_with_another_NotEmptyRange_ending_with_the_same_type_of_bound_but_with_another_value() {
+        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
+            .toInclusiveBound()
+        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
+            .toInclusiveBound()
+        val firstRange: NotEmptyRange<NonZeroInt> = start..end
+        val secondRange: NotEmptyRange<NonZeroInt> = start..StrictlyPositiveInt
+            .random()
+            .toInclusiveBound()
+        assertTrue { firstRange != secondRange }
+    }
+
+    @Test
     fun toString_should_pass_with_2_InclusiveBounds() {
         val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
             .toInclusiveBound()

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -47,7 +47,7 @@ class NotEmptyRangeTest {
             .getOrThrow()
             .toInclusiveBound()
         val end: InclusiveBound<PositiveInt> =
-            PositiveInt.max.toInclusiveBound()
+            PositiveInt.range.end.value.toInclusiveBound()
         val range: NotEmptyRange<PositiveInt> = start..end
         val value: PositiveInt = ZeroInt
         assertTrue { value !in range }
@@ -56,11 +56,11 @@ class NotEmptyRangeTest {
     @Test
     fun contains_should_fail_with_a_value_that_is_not_in_exclusive_bounds() {
         val start: ExclusiveBound<PositiveInt> =
-            PositiveInt.min.toExclusiveBound()
+            PositiveInt.range.start.value.toExclusiveBound()
         val end: ExclusiveBound<PositiveInt> =
-            PositiveInt.max.toExclusiveBound()
+            PositiveInt.range.end.value.toExclusiveBound()
         val range: NotEmptyRange<PositiveInt> = start..end
-        val value: PositiveInt = PositiveInt.min
+        val value: PositiveInt = PositiveInt.range.start.value
         assertTrue { value !in range }
     }
 

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -7,73 +7,6 @@ import kotlin.test.assertTrue
 
 class NotEmptyRangeTest {
     @Test
-    fun contains_should_pass_with_a_value_in_inclusive_bounds() {
-        val range: NotEmptyRange<PositiveInt> = PositiveInt.range
-        val value: PositiveInt = PositiveInt.random()
-        assertTrue { value in range }
-    }
-
-    @Test
-    fun contains_should_pass_with_a_value_in_exclusive_bounds() {
-        val start: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.negativeRange.start.value.toExclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> = 2.toStrictlyPositiveInt()
-            .getOrThrow()
-            .toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = 1.toStrictlyPositiveInt()
-            .getOrThrow()
-        assertTrue { value in range }
-    }
-
-    @Test
-    fun contains_should_pass_with_a_value_in_inclusive_and_exclusive_bounds() {
-        val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.negativeRange.start.value.toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.positiveRange.end.value.toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = NonZeroInt.random()
-            .takeIf { it != NonZeroInt.positiveRange.end.value }
-            ?: NonZeroInt.negativeRange.start.value
-        assertTrue { value in range }
-    }
-
-    @Test
-    fun contains_should_fail_with_a_value_that_is_not_in_inclusive_bounds() {
-        val start: InclusiveBound<PositiveInt> = 1.toStrictlyPositiveInt()
-            .getOrThrow()
-            .toInclusiveBound()
-        val end: InclusiveBound<PositiveInt> =
-            PositiveInt.range.end.value.toInclusiveBound()
-        val range: NotEmptyRange<PositiveInt> = start..end
-        val value: PositiveInt = ZeroInt
-        assertTrue { value !in range }
-    }
-
-    @Test
-    fun contains_should_fail_with_a_value_that_is_not_in_exclusive_bounds() {
-        val start: ExclusiveBound<PositiveInt> =
-            PositiveInt.range.start.value.toExclusiveBound()
-        val end: ExclusiveBound<PositiveInt> =
-            PositiveInt.range.end.value.toExclusiveBound()
-        val range: NotEmptyRange<PositiveInt> = start..end
-        val value: PositiveInt = PositiveInt.range.start.value
-        assertTrue { value !in range }
-    }
-
-    @Test
-    fun contains_should_fail_with_a_value_that_is_not_in_inclusive_and_exclusive_bounds() {
-        val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.positiveRange.end.value.toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.negativeRange.start.value.toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = NonZeroInt.negativeRange.start.value
-        assertTrue { value !in range }
-    }
-
-    @Test
     fun equals_should_pass_with_another_NotEmptyRange_having_the_same_bounds() {
         val start: InclusiveBound<AnyInt> = NegativeInt.random()
             .toInclusiveBound()
@@ -163,6 +96,73 @@ class NotEmptyRangeTest {
             .toExclusiveBound()
         val range: NotEmptyRange<NonZeroInt> = start..end
         "$range" shouldEqual "[$start;$end["
+    }
+
+    @Test
+    fun contains_should_pass_with_a_value_in_inclusive_bounds() {
+        val range: NotEmptyRange<PositiveInt> = PositiveInt.range
+        val value: PositiveInt = PositiveInt.random()
+        assertTrue { value in range }
+    }
+
+    @Test
+    fun contains_should_pass_with_a_value_in_exclusive_bounds() {
+        val start: ExclusiveBound<NonZeroInt> =
+            NonZeroInt.negativeRange.start.value.toExclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> = 2.toStrictlyPositiveInt()
+            .getOrThrow()
+            .toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = 1.toStrictlyPositiveInt()
+            .getOrThrow()
+        assertTrue { value in range }
+    }
+
+    @Test
+    fun contains_should_pass_with_a_value_in_inclusive_and_exclusive_bounds() {
+        val start: InclusiveBound<NonZeroInt> =
+            NonZeroInt.negativeRange.start.value.toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> =
+            NonZeroInt.positiveRange.end.value.toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = NonZeroInt.random()
+            .takeIf { it != NonZeroInt.positiveRange.end.value }
+            ?: NonZeroInt.negativeRange.start.value
+        assertTrue { value in range }
+    }
+
+    @Test
+    fun contains_should_fail_with_a_value_that_is_not_in_inclusive_bounds() {
+        val start: InclusiveBound<PositiveInt> = 1.toStrictlyPositiveInt()
+            .getOrThrow()
+            .toInclusiveBound()
+        val end: InclusiveBound<PositiveInt> =
+            PositiveInt.range.end.value.toInclusiveBound()
+        val range: NotEmptyRange<PositiveInt> = start..end
+        val value: PositiveInt = ZeroInt
+        assertTrue { value !in range }
+    }
+
+    @Test
+    fun contains_should_fail_with_a_value_that_is_not_in_exclusive_bounds() {
+        val start: ExclusiveBound<PositiveInt> =
+            PositiveInt.range.start.value.toExclusiveBound()
+        val end: ExclusiveBound<PositiveInt> =
+            PositiveInt.range.end.value.toExclusiveBound()
+        val range: NotEmptyRange<PositiveInt> = start..end
+        val value: PositiveInt = PositiveInt.range.start.value
+        assertTrue { value !in range }
+    }
+
+    @Test
+    fun contains_should_fail_with_a_value_that_is_not_in_inclusive_and_exclusive_bounds() {
+        val start: InclusiveBound<NonZeroInt> =
+            NonZeroInt.positiveRange.end.value.toInclusiveBound()
+        val end: ExclusiveBound<NonZeroInt> =
+            NonZeroInt.negativeRange.start.value.toExclusiveBound()
+        val range: NotEmptyRange<NonZeroInt> = start..end
+        val value: NonZeroInt = NonZeroInt.negativeRange.start.value
+        assertTrue { value !in range }
     }
 
     @Test


### PR DESCRIPTION
> Close #56.

- Add the `NotEmptyRange` and the `Bound` types.
- Add the `range` property to the following types: [`PositiveInt`][positive-int], [`NegativeInt`][negative-int], [`StrictlyPositiveInt`][strictly-positive-int] and [`StrictlyNegativeInt`][strictly-negative-int].
- Add the `negativeRange` and the `positiveRange` properties to the [`NonZeroInt`][non-zero-int] type.
- Deprecate the `min` and the `max` properties of the following types: [`NonZeroInt`][non-zero-int], [`PositiveInt`][positive-int], [`NegativeInt`][negative-int], [`StrictlyPositiveInt`][strictly-positive-int] and [`StrictlyNegativeInt`][strictly-negative-int].

[non-zero-int]: https://kotools.github.io/types/types/kotools.types.number/-non-zero-int/index.html
[positive-int]: https://kotools.github.io/types/types/kotools.types.number/-positive-int/index.html
[negative-int]: https://kotools.github.io/types/types/kotools.types.number/-negative-int/index.html
[strictly-positive-int]: https://kotools.github.io/types/types/kotools.types.number/-strictly-positive-int/index.html
[strictly-negative-int]: https://kotools.github.io/types/types/kotools.types.number/-strictly-negative-int/index.html