### PR TITLE
Workflow dependencies upgrade

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1.0.5
+        uses: gradle/wrapper-validation-action@v1.0.6
   # ---------- Stage 2 ----------
   deliver-js:
     name: Deliver JS package

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -13,8 +13,8 @@ env:
   GIT_USER: ${{ secrets.GIT_USER }}
   GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
   GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-  JAVA_DISTRIBUTION: adopt
-  JAVA_VERSION: 8
+  JAVA_DISTRIBUTION: temurin
+  JAVA_VERSION: 17
   MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
   MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 permissions: read-all
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -118,7 +118,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1.0.5
   # ---------- Stage 2 ----------
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:
@@ -80,7 +80,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:
@@ -95,7 +95,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1.0.5
+        uses: gradle/wrapper-validation-action@v1.0.6
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -12,7 +12,7 @@ jobs:
       pages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1.0.5
       - name: Setup Java & Gradle

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1.0.6
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
-          distribution: adopt
-          java-version: 8
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Generate documentation with Dokka
         run: ./gradlew dokkaHtml --no-daemon

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1.0.6
       - name: Setup Java & Gradle
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@v3.11.0
         with:
-          distribution: adopt
-          java-version: 8
+          distribution: temurin
+          java-version: 17
           cache: gradle
       - name: Test all platforms
         run: ./gradlew allTests --no-daemon

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1.0.5
+        uses: gradle/wrapper-validation-action@v1.0.6
       - name: Setup Java & Gradle
         uses: actions/setup-java@v3.6.0
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
     permissions: read-all
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3.5.0
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1.0.5
       - name: Setup Java & Gradle


### PR DESCRIPTION
> Close #46.

Workflows are now using:
- [`actions/checkout@v3.5.0`](https://github.com/actions/checkout/releases/tag/v3.5.0)
- [`gradle/wrapper-validation-action@v1.0.6`](https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.6)
- [`actions/setup-java@v3.11.0`](https://github.com/actions/setup-java/releases/tag/v3.11.0) with [Eclipse Temurin JDK 17](https://adoptium.net).