### PR TITLE
`StrictlyPositiveDouble` experimental API

### DIFF
--- a/api/types.api
+++ b/api/types.api
@@ -228,19 +228,25 @@ public final class kotools/types/number/StrictlyNegativeIntKt {
 	public static final fun toStrictlyNegativeInt (Ljava/lang/Number;)Ljava/lang/Object;
 }
 
-public abstract interface class kotools/types/number/StrictlyPositiveDouble : java/lang/Comparable {
+public final class kotools/types/number/StrictlyPositiveDouble : java/lang/Comparable {
 	public static final field Companion Lkotools/types/number/StrictlyPositiveDouble$Companion;
-	public abstract fun compareTo (Lkotools/types/number/StrictlyPositiveDouble;)I
-	public abstract fun toDouble ()D
-	public abstract fun toString ()Ljava/lang/String;
+	public static final synthetic fun box-impl (D)Lkotools/types/number/StrictlyPositiveDouble;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo-dhNCs2s (D)I
+	public static fun compareTo-dhNCs2s (DD)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (DLjava/lang/Object;)Z
+	public static final fun equals-impl0 (DD)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (D)I
+	public static final fun toDouble-impl (D)D
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (D)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()D
 }
 
 public final class kotools/types/number/StrictlyPositiveDouble$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class kotools/types/number/StrictlyPositiveDouble$DefaultImpls {
-	public static fun compareTo (Lkotools/types/number/StrictlyPositiveDouble;Lkotools/types/number/StrictlyPositiveDouble;)I
 }
 
 public final class kotools/types/number/StrictlyPositiveDoubleKt {
@@ -330,7 +336,7 @@ public abstract interface class kotools/types/result/ResultContext {
 	public abstract fun toNotEmptySet (Ljava/util/Collection;)Lkotools/types/collection/NotEmptySet;
 	public abstract fun toPositiveInt (Ljava/lang/Number;)Lkotools/types/number/PositiveInt;
 	public abstract fun toStrictlyNegativeInt-C9D9PS4 (Ljava/lang/Number;)I
-	public abstract fun toStrictlyPositiveDouble (Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveDouble;
+	public abstract fun toStrictlyPositiveDouble-7dDooEQ (Ljava/lang/Number;)D
 	public abstract fun toStrictlyPositiveInt-4PgMdn8 (Ljava/lang/Number;)I
 }
 
@@ -343,7 +349,7 @@ public final class kotools/types/result/ResultContext$DefaultImpls {
 	public static fun toNotEmptySet (Lkotools/types/result/ResultContext;Ljava/util/Collection;)Lkotools/types/collection/NotEmptySet;
 	public static fun toPositiveInt (Lkotools/types/result/ResultContext;Ljava/lang/Number;)Lkotools/types/number/PositiveInt;
 	public static fun toStrictlyNegativeInt-C9D9PS4 (Lkotools/types/result/ResultContext;Ljava/lang/Number;)I
-	public static fun toStrictlyPositiveDouble (Lkotools/types/result/ResultContext;Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveDouble;
+	public static fun toStrictlyPositiveDouble-7dDooEQ (Lkotools/types/result/ResultContext;Ljava/lang/Number;)D
 	public static fun toStrictlyPositiveInt-4PgMdn8 (Lkotools/types/result/ResultContext;Ljava/lang/Number;)I
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -91,6 +91,9 @@ public final class kotools/types/collection/NotEmptySetKt {
 	public static final fun toNotEmptySet (Ljava/util/Collection;)Ljava/lang/Object;
 }
 
+public abstract interface annotation class kotools/types/experimental/ExperimentalNumberApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface class kotools/types/number/AnyInt : java/lang/Comparable {
 	public static final field Companion Lkotools/types/number/AnyInt$Companion;
 	public abstract fun compareTo (Lkotools/types/number/AnyInt;)I

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
         languageSettings.optIn(
             "kotlinx.serialization.ExperimentalSerializationApi"
         )
+        languageSettings.optIn("kotlin.RequiresOptIn")
     }
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -33,8 +33,8 @@ val range: NotEmptyRange<Int> = start..end // or end..start
 println(range) // [1;42[
 ```
 
-- The `StrictlyPositiveDouble` type representing strictly positive
-  floating-point numbers represented by the `Double` type (issue
+- The `StrictlyPositiveDouble` **experimental** type representing strictly
+  positive floating-point numbers represented by the `Double` type (issue
   [#66](https://github.com/kotools/types/issues/66)).
 
 ```kotlin

--- a/packages.md
+++ b/packages.md
@@ -6,6 +6,10 @@ Multiplatform library providing explicit types for Kotlin.
 
 Contains types such as `NotEmptyList` for manipulating collections.
 
+# Package kotools.types.experimental
+
+Experimental APIs, subject to change in future versions.
+
 # Package kotools.types.number
 
 Contains types such as `NonZeroInt` for manipulating numbers.

--- a/src/commonMain/kotlin/kotools/types/experimental/NumberApi.kt
+++ b/src/commonMain/kotlin/kotools/types/experimental/NumberApi.kt
@@ -1,0 +1,16 @@
+package kotools.types.experimental
+
+import kotools.types.SinceKotoolsTypes
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.*
+
+/**
+ * Declarations marked with this annotation are still **experimental** in the
+ * number API.
+ */
+@MustBeDocumented
+@RequiresOptIn
+@Retention(BINARY)
+@SinceKotoolsTypes("4.2")
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+public annotation class ExperimentalNumberApi

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -10,13 +10,31 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.experimental.ExperimentalNumberApi
 import kotlin.jvm.JvmInline
 
+/**
+ * Returns this number as an encapsulated [StrictlyPositiveDouble],
+ * which may involve rounding or truncation, or returns an encapsulated
+ * [IllegalArgumentException] if this number is negative.
+ */
+@ExperimentalNumberApi
+@SinceKotoolsTypes("4.2")
+public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
+    runCatching {
+        val value: Double = toDouble()
+        require(value > 0.0) { value shouldBe aStrictlyPositiveNumber }
+        StrictlyPositiveDouble(value)
+    }
+
 /** Represents strictly positive floating-point numbers represented by the [Double] type. */
+@ExperimentalNumberApi
+@JvmInline
 @Serializable(StrictlyPositiveDoubleSerializer::class)
 @SinceKotoolsTypes("4.2")
-public sealed interface StrictlyPositiveDouble :
-    Comparable<StrictlyPositiveDouble> {
+public value class StrictlyPositiveDouble internal constructor(
+    private val value: Double
+) : Comparable<StrictlyPositiveDouble> {
     /**
      * Compares this floating-point number with the other one for order.
      * Returns zero if this floating-point number equals the other one,
@@ -30,32 +48,13 @@ public sealed interface StrictlyPositiveDouble :
     }
 
     /** Returns this floating-point number as a [Double]. */
-    public fun toDouble(): Double
+    public fun toDouble(): Double = value
 
     /** Returns the string representation of this floating-point number. */
-    override fun toString(): String
-}
-
-@JvmInline
-private value class StrictlyPositiveDoubleImplementation(
-    private val value: Double
-) : StrictlyPositiveDouble {
-    override fun toDouble(): Double = value
     override fun toString(): String = "$value"
 }
 
-/**
- * Returns this number as an encapsulated [StrictlyPositiveDouble], which may involve rounding or truncation,
- * or returns an encapsulated [IllegalArgumentException] if this number is negative.
- */
-@SinceKotoolsTypes("4.2")
-public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
-    runCatching {
-        val value: Double = toDouble()
-        require(value > 0.0) { value shouldBe aStrictlyPositiveNumber }
-        StrictlyPositiveDoubleImplementation(value)
-    }
-
+@ExperimentalNumberApi
 internal object StrictlyPositiveDoubleSerializer :
     KSerializer<StrictlyPositiveDouble> {
     override val descriptor: SerialDescriptor by lazy {

--- a/src/commonMain/kotlin/kotools/types/result/Context.kt
+++ b/src/commonMain/kotlin/kotools/types/result/Context.kt
@@ -4,6 +4,7 @@ import kotools.types.SinceKotoolsTypes
 import kotools.types.collection.NotEmptyList
 import kotools.types.collection.NotEmptyMap
 import kotools.types.collection.NotEmptySet
+import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.number.*
 import kotools.types.text.NotBlankString
 import kotools.types.collection.toNotEmptyList as delegateToNotEmptyList
@@ -72,6 +73,7 @@ public sealed interface ResultContext {
      * rounding or truncation, or throws an [IllegalArgumentException] if this
      * number is negative.
      */
+    @ExperimentalNumberApi
     @SinceKotoolsTypes("4.2")
     @Throws(IllegalArgumentException::class)
     public fun Number.toStrictlyPositiveDouble(): StrictlyPositiveDouble =

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotlin.random.Random
@@ -13,6 +14,7 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+@ExperimentalNumberApi
 class StrictlyPositiveDoubleTest {
     @Test
     fun compareTo_should_return_zero_with_the_same_StrictlyPositiveDouble() {
@@ -83,6 +85,7 @@ class StrictlyPositiveDoubleTest {
             .shouldHaveAMessage()
 }
 
+@ExperimentalNumberApi
 class StrictlyPositiveDoubleSerializerTest {
     private val serializer: KSerializer<StrictlyPositiveDouble> =
         StrictlyPositiveDoubleSerializer

--- a/src/commonTest/kotlin/kotools/types/result/ContextTest.kt
+++ b/src/commonTest/kotlin/kotools/types/result/ContextTest.kt
@@ -4,6 +4,7 @@ import kotools.types.collection.NotEmptyList
 import kotools.types.collection.NotEmptyMap
 import kotools.types.collection.NotEmptySet
 import kotools.types.contentShouldEqual
+import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.number.*
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
@@ -101,6 +102,7 @@ class ResultContextTest {
             .shouldHaveAMessage()
     }
 
+    @ExperimentalNumberApi
     @Test
     fun number_toStrictlyPositiveDouble_should_pass_with_a_strictly_positive_Number() {
         val value: Number =
@@ -112,6 +114,7 @@ class ResultContextTest {
             .shouldEqual(value)
     }
 
+    @ExperimentalNumberApi
     @Test
     fun number_toStrictlyPositiveDouble_should_fail_with_a_negative_Number() {
         val value: Number =


### PR DESCRIPTION
> Close #66.

- Add an `ExperimentalNumberApi` annotation.
- Mark the `StrictlyPositiveDouble` type as experimental with this new annotation.
- Convert the `StrictlyPositiveDouble` type from `sealed interface` to `value class`.
