### PR TITLE
Experimental concatenations of `NotBlankString`

### DIFF
--- a/api/types.api
+++ b/api/types.api
@@ -94,6 +94,9 @@ public final class kotools/types/collection/NotEmptySetKt {
 public abstract interface annotation class kotools/types/experimental/ExperimentalNumberApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class kotools/types/experimental/ExperimentalTextApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface class kotools/types/number/AnyInt : java/lang/Comparable {
 	public static final field Companion Lkotools/types/number/AnyInt$Companion;
 	public abstract fun compareTo (Lkotools/types/number/AnyInt;)I

--- a/changelog.md
+++ b/changelog.md
@@ -43,23 +43,22 @@ val x: StrictlyPositiveDouble = 0.5.toStrictlyPositiveDouble()
 println(x) // 0.5
 ```
 
-- The `plus` operations for concatenating a `NotBlankString` with a `String` or
-  a `Char` (issue [#53](https://github.com/kotools/types/issues/53)).
+- The `plus` **experimental** operations for concatenating a `NotBlankString`
+  with a `String` or a `Char` (issue
+  [#53](https://github.com/kotools/types/issues/53)).
 
 ```kotlin
-resultOf {
-    val firstString: NotBlankString = "hello".toNotBlankString()
-    val secondString: NotBlankString = "world".toNotBlankString()
-    var result: NotBlankString
-    // before
-    result = ("$firstString" + 'a').toNotBlankString()
-    result = ("$firstString" + "everyone").toNotBlankString()
-    result = ("$firstString" + "$secondString").toNotBlankString()
-    // after
-    result = firstString + 'a'
-    result = firstString + "everyone"
-    result = firstString + secondString
-}
+val firstString: NotBlankString = "hello".toNotBlankString().getOrThrow()
+val secondString: NotBlankString = "world".toNotBlankString().getOrThrow()
+var result: NotBlankString
+// before
+result = ('a' + "$firstString" + 'b').toNotBlankString().getOrThrow()
+result = ("$firstString" + "everyone").toNotBlankString().getOrThrow()
+result = ("$firstString" + "$secondString").toNotBlankString().getOrThrow()
+// after
+result = 'a' + "$firstString" + 'b'
+result = firstString + "everyone"
+result = firstString + secondString
 ```
 
 - The `Result.flatMap` operation for transforming its encapsulated value (issue

--- a/src/commonMain/kotlin/kotools/types/experimental/Annotations.kt
+++ b/src/commonMain/kotlin/kotools/types/experimental/Annotations.kt
@@ -11,3 +11,11 @@ import kotlin.annotation.AnnotationTarget.*
 @SinceKotoolsTypes("4.2")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 public annotation class ExperimentalNumberApi
+
+/** Marks declarations that are still **experimental** in the text API. */
+@MustBeDocumented
+@RequiresOptIn
+@Retention(BINARY)
+@SinceKotoolsTypes("4.2")
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+public annotation class ExperimentalTextApi

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.toStrictlyPositiveInt
 import kotlin.jvm.JvmInline
@@ -51,6 +52,7 @@ public value class NotBlankString private constructor(
 }
 
 /** Concatenates this string with the [other] one. */
+@ExperimentalTextApi
 @SinceKotoolsTypes("4.2")
 public operator fun NotBlankString.plus(other: String): NotBlankString = "$this"
     .plus(other)
@@ -58,16 +60,19 @@ public operator fun NotBlankString.plus(other: String): NotBlankString = "$this"
     .getOrThrow()
 
 /** Concatenates this string with the [other] one. */
+@ExperimentalTextApi
 @SinceKotoolsTypes("4.2")
 public operator fun NotBlankString.plus(other: NotBlankString): NotBlankString =
     plus("$other")
 
 /** Concatenates this string with the [other] character. */
+@ExperimentalTextApi
 @SinceKotoolsTypes("4.2")
 public operator fun NotBlankString.plus(other: Char): NotBlankString =
     plus("$other")
 
 /** Concatenates this character with the [other] string. */
+@ExperimentalTextApi
 @SinceKotoolsTypes("4.2")
 public operator fun Char.plus(other: NotBlankString): NotBlankString =
     plus("$other")

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.ZeroInt
 import kotools.types.shouldEqual
@@ -59,6 +60,7 @@ class NotBlankStringTest {
         assertTrue { result > ZeroInt.toInt() }
     }
 
+    @ExperimentalTextApi
     @Test
     fun plus_should_pass_with_a_String() {
         val first: NotBlankString = "hell".toNotBlankString()
@@ -68,6 +70,7 @@ class NotBlankStringTest {
         "$result" shouldEqual "$first$second"
     }
 
+    @ExperimentalTextApi
     @Test
     fun plus_should_pass_with_a_NotBlankString() {
         val first: NotBlankString = "hell".toNotBlankString()
@@ -78,6 +81,7 @@ class NotBlankStringTest {
         "$result" shouldEqual "$first$second"
     }
 
+    @ExperimentalTextApi
     @Test
     fun plus_should_pass_with_a_Char() {
         val first: NotBlankString = "hell".toNotBlankString()
@@ -87,6 +91,7 @@ class NotBlankStringTest {
         "$result" shouldEqual "$first$second"
     }
 
+    @ExperimentalTextApi
     @Test
     fun char_plus_should_pass_with_a_NotBlankString() {
         val first = 'a'


### PR DESCRIPTION
> Close #53.

- Add the `ExperimentalTextApi` annotation.
- Mark the `NotBlankString`'s concatenations as **experimental** within the text API.