### PR TITLE
New experimental API for `NotEmptyRange`

### DIFF
--- a/api/types.api
+++ b/api/types.api
@@ -94,6 +94,9 @@ public final class kotools/types/collection/NotEmptySetKt {
 public abstract interface annotation class kotools/types/experimental/ExperimentalNumberApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class kotools/types/experimental/ExperimentalRangeApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class kotools/types/experimental/ExperimentalResultApi : java/lang/annotation/Annotation {
 }
 
@@ -303,26 +306,30 @@ public abstract interface class kotools/types/range/Bound {
 	public abstract fun toString ()Ljava/lang/String;
 }
 
-public final class kotools/types/range/BoundKt {
-	public static final fun toExclusiveBound (Ljava/lang/Comparable;)Lkotools/types/range/ExclusiveBound;
-	public static final fun toInclusiveBound (Ljava/lang/Comparable;)Lkotools/types/range/InclusiveBound;
+public final class kotools/types/range/ExclusiveBound : kotools/types/range/Bound {
+	public fun getValue ()Ljava/lang/Comparable;
+	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class kotools/types/range/ExclusiveBound : kotools/types/range/Bound {
+public final class kotools/types/range/InclusiveBound : kotools/types/range/Bound {
+	public fun getValue ()Ljava/lang/Comparable;
+	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class kotools/types/range/InclusiveBound : kotools/types/range/Bound {
+public final class kotools/types/range/NotEmptyRange {
+	public final fun getEnd ()Lkotools/types/range/Bound;
+	public final fun getStart ()Lkotools/types/range/Bound;
+	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class kotools/types/range/NotEmptyRange {
-	public abstract fun getEnd ()Lkotools/types/range/Bound;
-	public abstract fun getStart ()Lkotools/types/range/Bound;
-	public abstract fun toString ()Ljava/lang/String;
+public final class kotools/types/range/NotEmptyRange$BuilderScope {
+	public final fun getExclusive (Ljava/lang/Comparable;)Lkotools/types/range/ExclusiveBound;
+	public final fun getInclusive (Ljava/lang/Comparable;)Lkotools/types/range/InclusiveBound;
 }
 
 public final class kotools/types/range/NotEmptyRangeKt {
 	public static final fun contains (Lkotools/types/range/NotEmptyRange;Ljava/lang/Comparable;)Z
-	public static final fun rangeTo (Lkotools/types/range/Bound;Lkotools/types/range/Bound;)Lkotools/types/range/NotEmptyRange;
+	public static final fun notEmptyRangeOf (Lkotlin/jvm/functions/Function1;)Lkotools/types/range/NotEmptyRange;
 }
 
 public final class kotools/types/result/ContextKt {

--- a/changelog.md
+++ b/changelog.md
@@ -22,15 +22,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- The `NotEmptyRange` and the `Bound` types representing a range of comparable
-  values that contain at least one value (issue
+- The `NotEmptyRange` and the `Bound` **experimental** types representing a
+  range of comparable values that contain at least one value (issue
   [#56](https://github.com/kotools/types/issues/56)).
 
 ```kotlin
-val start: InclusiveBound<Int> = 1.toInclusiveBound()
-val end: ExclusiveBound<Int> = 42.toExclusiveBound()
-val range: NotEmptyRange<Int> = start..end // or end..start
+val range = notEmptyRangeOf<Int> { 1.inclusive to 42.exclusive }
 println(range) // [1;42[
+println(3 in range) // true
+println(42 in range) // false
 ```
 
 - The `StrictlyPositiveDouble` **experimental** type representing strictly
@@ -89,22 +89,6 @@ result = 3.toNonZeroInt()
 implementation("io.github.kotools:types:$version")
 // after
 implementation("org.kotools:types:$version")
-```
-
-### Deprecated
-
-The `min` and the `max` companion's properties of the `StrictlyPositiveInt`, the
-`StrictlyNegativeInt`, the `PositiveInt`, the `NegativeInt` and the `NonZeroInt`
-types (issue [#56](https://github.com/kotools/types/issues/56)).
-
-```kotlin
-var result: StrictlyPositiveInt
-// before
-result = StrictlyPositiveInt.min
-result = StrictlyPositiveInt.max
-// after
-result = StrictlyPositiveInt.range.start.value
-result = StrictlyPositiveInt.range.end.value
 ```
 
 ## 4.1.0

--- a/src/commonMain/kotlin/kotools/types/Package.kt
+++ b/src/commonMain/kotlin/kotools/types/Package.kt
@@ -3,6 +3,7 @@ package kotools.types
 internal object Package {
     private const val root: String = "kotools.types"
     const val collection: String = "$root.collection"
+    const val experimental: String = "$root.experimental"
     const val number: String = "$root.number"
     const val text: String = "$root.text"
 }

--- a/src/commonMain/kotlin/kotools/types/experimental/Annotations.kt
+++ b/src/commonMain/kotlin/kotools/types/experimental/Annotations.kt
@@ -12,6 +12,14 @@ import kotlin.annotation.AnnotationTarget.*
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 public annotation class ExperimentalNumberApi
 
+/** Marks declarations that are still **experimental** in the range API. */
+@MustBeDocumented
+@RequiresOptIn
+@Retention(BINARY)
+@SinceKotoolsTypes("4.2")
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+public annotation class ExperimentalRangeApi
+
 /** Marks declarations that are still **experimental** in the result API. */
 @MustBeDocumented
 @RequiresOptIn

--- a/src/commonMain/kotlin/kotools/types/number/AnyInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/AnyInt.kt
@@ -9,9 +9,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
-import kotools.types.range.ExclusiveBound
-import kotools.types.range.InclusiveBound
-import kotools.types.range.NotEmptyRange
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -88,18 +85,6 @@ public operator fun AnyInt.div(other: NonZeroInt): Int = toInt() / other
  */
 @SinceKotoolsTypes("4.1")
 public operator fun AnyInt.rem(other: NonZeroInt): Int = toInt() % other
-
-internal fun <T : AnyInt> NotEmptyRange<T>.toIntRange(): IntRange {
-    val start: Int = when (start) {
-        is InclusiveBound -> start.value.toInt()
-        is ExclusiveBound -> start.value + 1
-    }
-    val end: Int = when (end) {
-        is InclusiveBound -> end.value.toInt()
-        is ExclusiveBound -> end.value - 1
-    }
-    return start..end
-}
 
 internal sealed interface AnyIntSerializer<I : AnyInt> : KSerializer<I> {
     val serialName: Result<NotBlankString>

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -4,10 +4,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
-import kotools.types.range.InclusiveBound
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
-import kotools.types.range.toInclusiveBound
+import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -18,34 +17,25 @@ public sealed interface NegativeInt : AnyInt {
     /** Contains declarations for holding or building a [NegativeInt]. */
     public companion object {
         /** The minimum value a [NegativeInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("NegativeInt.range.start.value")
-        )
         public val min: StrictlyNegativeInt by lazy(
-            StrictlyNegativeInt.range.start::value
+            StrictlyNegativeInt.Companion::min
         )
 
         /** The maximum value a [NegativeInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("NegativeInt.range.end.value")
-        )
         public val max: ZeroInt = ZeroInt
 
         /** The range of values a [NegativeInt] can have. */
+        @ExperimentalRangeApi
         @SinceKotoolsTypes("4.2")
         public val range: NotEmptyRange<NegativeInt> by lazy {
-            val start: InclusiveBound<NegativeInt> =
-                StrictlyNegativeInt.range.start.value.toInclusiveBound()
-            val end: InclusiveBound<NegativeInt> = ZeroInt.toInclusiveBound()
-            start..end
+            val start: StrictlyNegativeInt =
+                StrictlyNegativeInt.range.start.value
+            notEmptyRangeOf { start.inclusive to ZeroInt.inclusive }
         }
 
         /** Returns a random [NegativeInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): NegativeInt = range.toIntRange()
-            .random()
+        public fun random(): NegativeInt = (min.toInt()..max.toInt()).random()
             .toNegativeInt()
             .getOrThrow()
     }

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -4,6 +4,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.collection.NotEmptySet
+import kotools.types.collection.notEmptySetOf
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
@@ -15,30 +18,24 @@ public sealed interface NonZeroInt : AnyInt {
     /** Contains declarations for holding or building a [NonZeroInt]. */
     public companion object {
         /** The minimum value a [NonZeroInt] can have. */
-        @Deprecated(
-            "Use the negativeRange property instead.",
-            ReplaceWith("NonZeroInt.negativeRange.start.value")
-        )
         public val min: StrictlyNegativeInt by lazy(
-            StrictlyNegativeInt.range.start::value
+            StrictlyNegativeInt.Companion::min
         )
 
         /** The maximum value a [NonZeroInt] can have. */
-        @Deprecated(
-            "Use the positiveRange property instead.",
-            ReplaceWith("NonZeroInt.positiveRange.end.value")
-        )
         public val max: StrictlyPositiveInt by lazy(
-            StrictlyPositiveInt.range.end::value
+            StrictlyPositiveInt.Companion::max
         )
 
         /** The negative range of values a [NonZeroInt] can have. */
+        @ExperimentalRangeApi
         @SinceKotoolsTypes("4.2")
         public val negativeRange: NotEmptyRange<StrictlyNegativeInt> by lazy(
             StrictlyNegativeInt.Companion::range
         )
 
         /** The positive range of values a [NonZeroInt] can have. */
+        @ExperimentalRangeApi
         @SinceKotoolsTypes("4.2")
         public val positiveRange: NotEmptyRange<StrictlyPositiveInt> by lazy(
             StrictlyPositiveInt.Companion::range
@@ -46,12 +43,17 @@ public sealed interface NonZeroInt : AnyInt {
 
         /** Returns a random [NonZeroInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): NonZeroInt = setOf(negativeRange, positiveRange)
-            .random()
-            .toIntRange()
-            .random()
-            .toNonZeroInt()
-            .getOrThrow()
+        public fun random(): NonZeroInt {
+            val ranges: NotEmptySet<IntRange> = notEmptySetOf(
+                min.toInt()..StrictlyNegativeInt.max.toInt(),
+                StrictlyPositiveInt.min.toInt()..max.toInt()
+            )
+            return ranges.toSet()
+                .random()
+                .random()
+                .toNonZeroInt()
+                .getOrThrow()
+        }
     }
 
     @SinceKotoolsTypes("4.0")

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -4,10 +4,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
-import kotools.types.range.InclusiveBound
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
-import kotools.types.range.toInclusiveBound
+import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 
@@ -18,33 +17,24 @@ public sealed interface PositiveInt : AnyInt {
     /** Contains declarations for holding or building a [PositiveInt]. */
     public companion object {
         /** The minimum value a [PositiveInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("PositiveInt.range.start.value")
-        )
         public val min: ZeroInt = ZeroInt
 
         /** The maximum value a [PositiveInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("PositiveInt.range.end.value")
-        )
         public val max: StrictlyPositiveInt by lazy(
-            StrictlyPositiveInt.range.end::value
+            StrictlyPositiveInt.Companion::max
         )
 
         /** The range of values a [PositiveInt] can have. */
+        @ExperimentalRangeApi
         @SinceKotoolsTypes("4.2")
         public val range: NotEmptyRange<PositiveInt> by lazy {
-            val start: InclusiveBound<PositiveInt> = ZeroInt.toInclusiveBound()
-            val end: InclusiveBound<PositiveInt> =
-                StrictlyPositiveInt.range.end.value.toInclusiveBound()
-            start..end
+            val end: StrictlyPositiveInt = StrictlyPositiveInt.range.end.value
+            notEmptyRangeOf { ZeroInt.inclusive to end.inclusive }
         }
 
         /** Returns a random [PositiveInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): PositiveInt = range.toIntRange()
+        public fun random(): PositiveInt = (min.toInt()..max.toInt())
             .random()
             .toPositiveInt()
             .getOrThrow()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -4,10 +4,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
-import kotools.types.range.InclusiveBound
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
-import kotools.types.range.toInclusiveBound
+import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
@@ -23,35 +22,25 @@ private constructor(private val value: Int) : NonZeroInt, NegativeInt {
      */
     public companion object {
         /** The minimum value a [StrictlyNegativeInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("StrictlyNegativeInt.range.start.value")
-        )
         public val min: StrictlyNegativeInt by lazy(
             Int.MIN_VALUE.toStrictlyNegativeInt()::getOrThrow
         )
 
         /** The maximum value a [StrictlyNegativeInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("StrictlyNegativeInt.range.end.value")
-        )
         public val max: StrictlyNegativeInt by lazy(
             (-1).toStrictlyNegativeInt()::getOrThrow
         )
 
         /** The range of values a [StrictlyNegativeInt] can have. */
+        @ExperimentalRangeApi
         @SinceKotoolsTypes("4.2")
         public val range: NotEmptyRange<StrictlyNegativeInt> by lazy {
-            val start: InclusiveBound<StrictlyNegativeInt> = Int.MIN_VALUE
+            val start: StrictlyNegativeInt = Int.MIN_VALUE
                 .toStrictlyNegativeInt()
                 .getOrThrow()
-                .toInclusiveBound()
-            val end: InclusiveBound<StrictlyNegativeInt> = (-1)
-                .toStrictlyNegativeInt()
+            val end: StrictlyNegativeInt = (-1).toStrictlyNegativeInt()
                 .getOrThrow()
-                .toInclusiveBound()
-            start..end
+            notEmptyRangeOf { start.inclusive to end.inclusive }
         }
 
         internal infix fun of(value: Int): Result<StrictlyNegativeInt> = value
@@ -61,7 +50,7 @@ private constructor(private val value: Int) : NonZeroInt, NegativeInt {
 
         /** Returns a random [StrictlyNegativeInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): StrictlyNegativeInt = range.toIntRange()
+        public fun random(): StrictlyNegativeInt = (min.value..max.value)
             .random()
             .toStrictlyNegativeInt()
             .getOrThrow()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -4,10 +4,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
-import kotools.types.range.InclusiveBound
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
-import kotools.types.range.rangeTo
-import kotools.types.range.toInclusiveBound
+import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
@@ -23,35 +22,26 @@ private constructor(private val value: Int) : NonZeroInt, PositiveInt {
      */
     public companion object {
         /** The minimum value a [StrictlyPositiveInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("StrictlyPositiveInt.range.start.value")
-        )
         public val min: StrictlyPositiveInt by lazy(
             1.toStrictlyPositiveInt()::getOrThrow
         )
 
         /** The maximum value a [StrictlyPositiveInt] can have. */
-        @Deprecated(
-            "Use the range property instead.",
-            ReplaceWith("StrictlyPositiveInt.range.end.value")
-        )
         public val max: StrictlyPositiveInt by lazy(
             Int.MAX_VALUE.toStrictlyPositiveInt()::getOrThrow
         )
 
         /** The range of values a [StrictlyPositiveInt] can have. */
+        @ExperimentalRangeApi
         @SinceKotoolsTypes("4.2")
         public val range: NotEmptyRange<StrictlyPositiveInt> by lazy {
-            val start: InclusiveBound<StrictlyPositiveInt> = 1
+            val start: StrictlyPositiveInt = 1
                 .toStrictlyPositiveInt()
                 .getOrThrow()
-                .toInclusiveBound()
-            val end: InclusiveBound<StrictlyPositiveInt> = Int.MAX_VALUE
+            val end: StrictlyPositiveInt = Int.MAX_VALUE
                 .toStrictlyPositiveInt()
                 .getOrThrow()
-                .toInclusiveBound()
-            start..end
+            notEmptyRangeOf { start.inclusive to end.inclusive }
         }
 
         internal infix fun of(value: Int): Result<StrictlyPositiveInt> = value
@@ -61,7 +51,7 @@ private constructor(private val value: Int) : NonZeroInt, PositiveInt {
 
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): StrictlyPositiveInt = range.toIntRange()
+        public fun random(): StrictlyPositiveInt = (min.value..max.value)
             .random()
             .toStrictlyPositiveInt()
             .getOrThrow()

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -1,10 +1,15 @@
 package kotools.types.range
 
 import kotools.types.SinceKotoolsTypes
+import kotools.types.experimental.ExperimentalRangeApi
 
-/** Representation of a bound in a [range][NotEmptyRange]. */
+/**
+ * Represents a bound in a [range][NotEmptyRange].
+ * @param T the **covariant** type of this bound's value.
+ */
+@ExperimentalRangeApi
 @SinceKotoolsTypes("4.2")
-public sealed interface Bound<T : Comparable<T>> {
+public sealed interface Bound<out T : Comparable<@UnsafeVariance T>> {
     /** The value of this bound. */
     public val value: T
 
@@ -12,32 +17,24 @@ public sealed interface Bound<T : Comparable<T>> {
     override fun toString(): String
 }
 
-/** Representation of an inclusive bound in a [range][NotEmptyRange]. */
+/**
+ * Represents an inclusive bound in a [range][NotEmptyRange].
+ * @param T the **covariant** type of this bound's value.
+ */
+@ExperimentalRangeApi
 @SinceKotoolsTypes("4.2")
-public sealed interface InclusiveBound<T : Comparable<T>> : Bound<T>
-
-private data class InclusiveBoundImplementation<T : Comparable<T>>(
-    override val value: T
-) : InclusiveBound<T> {
+public class InclusiveBound<out T : Comparable<@UnsafeVariance T>>
+internal constructor(override val value: T) : Bound<T> {
     override fun toString(): String = "$value"
 }
 
-/** Returns this comparable value as an [InclusiveBound]. */
+/**
+ * Represents an exclusive bound in a [range][NotEmptyRange].
+ * @param T the **covariant** type of this bound's value.
+ */
+@ExperimentalRangeApi
 @SinceKotoolsTypes("4.2")
-public fun <T : Comparable<T>> T.toInclusiveBound(): InclusiveBound<T> =
-    InclusiveBoundImplementation(this)
-
-/** Representation of an exclusive bound in a [range][NotEmptyRange]. */
-@SinceKotoolsTypes("4.2")
-public sealed interface ExclusiveBound<T : Comparable<T>> : Bound<T>
-
-private data class ExclusiveBoundImplementation<T : Comparable<T>>(
-    override val value: T
-) : ExclusiveBound<T> {
+public class ExclusiveBound<out T : Comparable<@UnsafeVariance T>>
+internal constructor(override val value: T) : Bound<T> {
     override fun toString(): String = "$value"
 }
-
-/** Returns this comparable value as an [ExclusiveBound]. */
-@SinceKotoolsTypes("4.2")
-public fun <T : Comparable<T>> T.toExclusiveBound(): ExclusiveBound<T> =
-    ExclusiveBoundImplementation(this)

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -1,27 +1,41 @@
 package kotools.types.range
 
 import kotools.types.SinceKotoolsTypes
+import kotools.types.experimental.ExperimentalRangeApi
 
 /**
- * Representation of a range of comparable values that contain at least one
- * value.
+ * Returns a not empty range with the given pair of [bounds].
+ * The resulting range will [start][NotEmptyRange.start] with the lower value
+ * between the given [bounds].
  */
+@ExperimentalRangeApi
 @SinceKotoolsTypes("4.2")
-public sealed interface NotEmptyRange<T : Comparable<T>> {
-    /** The start of this range. */
-    public val start: Bound<T>
+public fun <T : Comparable<T>> notEmptyRangeOf(
+    bounds: NotEmptyRange.BuilderScope<T>.() -> Pair<Bound<T>, Bound<T>>
+): NotEmptyRange<T> = NotEmptyRange.BuilderScope<T>()
+    .bounds()
+    .run {
+        if (first.value < second.value) NotEmptyRange(
+            start = first,
+            end = second
+        )
+        else NotEmptyRange(start = second, end = first)
+    }
 
+/**
+ * Represents a range of comparable values that contain at least one value.
+ * @param T the **covariant** type of values in this range.
+ */
+@ExperimentalRangeApi
+@SinceKotoolsTypes("4.2")
+public class NotEmptyRange<out T : Comparable<@UnsafeVariance T>>
+internal constructor(
+    /** The start of this range. */
+    public val start: Bound<T>,
     /** The end of this range. */
     public val end: Bound<T>
-
+) {
     /** Returns the string representation of this range. */
-    override fun toString(): String
-}
-
-private data class NotEmptyRangeImplementation<T : Comparable<T>>(
-    override val start: Bound<T>,
-    override val end: Bound<T>
-) : NotEmptyRange<T> {
     override fun toString(): String {
         val prefix: Char = when (start) {
             is InclusiveBound -> '['
@@ -33,12 +47,22 @@ private data class NotEmptyRangeImplementation<T : Comparable<T>>(
         }
         return "$prefix$start;$end$suffix"
     }
+
+    /** Class responsible for configuring an instance of [NotEmptyRange]. */
+    public class BuilderScope<T : Comparable<T>> internal constructor() {
+        /** Returns this value as an inclusive bound. */
+        public val T.inclusive: InclusiveBound<T> get() = InclusiveBound(this)
+
+        /** Returns this value as an exclusive bound. */
+        public val T.exclusive: ExclusiveBound<T> get() = ExclusiveBound(this)
+    }
 }
 
 /**
  * Returns `true` if this range contains the given [value], or returns `false`
  * otherwise.
  */
+@ExperimentalRangeApi
 @SinceKotoolsTypes("4.2")
 public operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
     value: T
@@ -53,16 +77,3 @@ public operator fun <T : Comparable<T>> NotEmptyRange<T>.contains(
     }
     return valueIsGreaterThanStart && valueIsLowerThanEnd
 }
-
-/**
- * Creates a [NotEmptyRange] using this bound and the [other] one.
- * If the [other] bound is lower than this bound, the resulting range will
- * [start][NotEmptyRange.start] with the [other] bound.
- */
-@SinceKotoolsTypes("4.2")
-public operator fun <T : Comparable<T>> Bound<T>.rangeTo(
-    other: Bound<T>
-): NotEmptyRange<T> = if (value <= other.value) NotEmptyRangeImplementation(
-    start = this,
-    end = other
-) else NotEmptyRangeImplementation(start = other, end = this)

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
@@ -15,20 +16,19 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class NegativeIntCompanionTest {
-    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_the_minimum_value_of_Int() {
         val result: StrictlyNegativeInt = NegativeInt.min
         result.toInt() shouldEqual Int.MIN_VALUE
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_zero() {
         val result: ZeroInt = NegativeInt.max
         result shouldEqual ZeroInt
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_start_with_an_InclusiveBound_that_equals_the_minimum_value_of_Int() {
         val range: NotEmptyRange<NegativeInt> = NegativeInt.range
@@ -36,6 +36,7 @@ class NegativeIntCompanionTest {
         range.start.value.toInt() shouldEqual Int.MIN_VALUE
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_end_with_an_InclusiveBound_that_equals_zero() {
         val range: NotEmptyRange<NegativeInt> = NegativeInt.range

--- a/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
@@ -15,26 +16,26 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 class NonZeroIntCompanionTest {
-    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_the_minimum_value_of_Int() {
         val result: StrictlyNegativeInt = NonZeroInt.min
         result.toInt() shouldEqual Int.MIN_VALUE
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_the_maximum_value_of_Int() {
         val result: StrictlyPositiveInt = NonZeroInt.max
         result.toInt() shouldEqual Int.MAX_VALUE
     }
 
+    @ExperimentalRangeApi
     @Test
     fun negativeRange_should_be_the_range_of_StrictlyNegativeInt() {
         val range: NotEmptyRange<StrictlyNegativeInt> = NonZeroInt.negativeRange
         range shouldEqual StrictlyNegativeInt.range
     }
 
+    @ExperimentalRangeApi
     @Test
     fun positiveRange_should_be_the_range_of_StrictlyPositiveInt() {
         val range: NotEmptyRange<StrictlyPositiveInt> = NonZeroInt.positiveRange

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
@@ -16,20 +17,19 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class PositiveIntCompanionTest {
-    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_zero() {
         val result: ZeroInt = PositiveInt.min
         result shouldEqual ZeroInt
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_the_maximum_value_of_Int() {
         val result: StrictlyPositiveInt = PositiveInt.max
         result.toInt() shouldEqual Int.MAX_VALUE
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_start_with_an_InclusiveBound_that_equals_zero() {
         val range: NotEmptyRange<PositiveInt> = PositiveInt.range
@@ -37,6 +37,7 @@ class PositiveIntCompanionTest {
         range.start.value shouldEqual ZeroInt
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_end_with_an_InclusiveBound_that_equals_the_maximum_value_of_Int() {
         val range: NotEmptyRange<PositiveInt> = PositiveInt.range

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
@@ -16,20 +17,19 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class StrictlyNegativeIntCompanionTest {
-    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_the_minimum_value_of_Int() {
         val result: StrictlyNegativeInt = StrictlyNegativeInt.min
         result.toInt() shouldEqual Int.MIN_VALUE
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_minus_one() {
         val result: StrictlyNegativeInt = StrictlyNegativeInt.max
         result.toInt() shouldEqual -1
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_start_with_an_InclusiveBound_that_equals_the_minimum_value_of_Int() {
         val range: NotEmptyRange<StrictlyNegativeInt> =
@@ -38,6 +38,7 @@ class StrictlyNegativeIntCompanionTest {
         range.start.value.toInt() shouldEqual Int.MIN_VALUE
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_end_with_an_InclusiveBound_that_equals_minus_one() {
         val range: NotEmptyRange<StrictlyNegativeInt> =

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
+import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
@@ -16,20 +17,19 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class StrictlyPositiveIntCompanionTest {
-    @Suppress("DEPRECATION")
     @Test
     fun min_should_equal_one() {
         val result: StrictlyPositiveInt = StrictlyPositiveInt.min
         result.toInt() shouldEqual 1
     }
 
-    @Suppress("DEPRECATION")
     @Test
     fun max_should_equal_the_maximum_value_of_Int() {
         val result: StrictlyPositiveInt = StrictlyPositiveInt.max
         result.toInt() shouldEqual Int.MAX_VALUE
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_start_with_an_inclusive_bound_that_equals_1() {
         val range: NotEmptyRange<StrictlyPositiveInt> =
@@ -38,6 +38,7 @@ class StrictlyPositiveIntCompanionTest {
         range.start.value.toInt() shouldEqual 1
     }
 
+    @ExperimentalRangeApi
     @Test
     fun range_should_end_with_an_inclusive_bound_that_equals_the_maximum_value_of_Int() {
         val range: NotEmptyRange<StrictlyPositiveInt> =

--- a/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
@@ -1,98 +1,114 @@
 package kotools.types.range
 
-import kotools.types.number.NonZeroInt
-import kotools.types.number.StrictlyNegativeInt
-import kotools.types.number.StrictlyPositiveInt
-import kotools.types.shouldEqual
+import kotools.types.experimental.ExperimentalRangeApi
+import kotlin.random.Random
+import kotlin.test.Ignore
 import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
+@ExperimentalRangeApi
 class InclusiveBoundTest {
+    // Implementing the equals function introduces a KotlinFrontEndException.
+    @Ignore
     @Test
-    fun equals_should_pass_with_another_InclusiveBound_having_the_same_value() {
-        val firstBound: InclusiveBound<NonZeroInt> = NonZeroInt.random()
-            .toInclusiveBound()
-        val secondBound: InclusiveBound<NonZeroInt> =
-            firstBound.value.toInclusiveBound()
-        assertTrue { firstBound == secondBound }
+    fun equals_should_pass_with_an_inclusive_bound_having_the_same_value() {
+        // GIVEN
+        val x: InclusiveBound<Int> = InclusiveBound(Random.nextInt())
+        val y: InclusiveBound<Int> = InclusiveBound(x.value)
+        // WHEN & THEN
+        "The equals operation should be reflexive.".let {
+            assertEquals(expected = x, actual = x, message = it)
+            assertEquals(expected = y, actual = y, message = it)
+        }
+        "The equals operation should be symmetric.".let {
+            assertEquals(expected = x, actual = y, message = it)
+            assertEquals(expected = y, actual = x, message = it)
+        }
+        "The equals operation should be transitive.".let {
+            val z: InclusiveBound<Int> = InclusiveBound(y.value)
+            assertEquals(expected = x, actual = y, message = it)
+            assertEquals(expected = y, actual = z, message = it)
+            assertEquals(expected = x, actual = z, message = it)
+        }
+        "The equals operation should never equal to null.".let {
+            val z: InclusiveBound<Int>? = null
+            assertNotEquals(illegal = z, actual = x, message = it)
+        }
     }
 
+    // Implementing the equals function introduces a KotlinFrontEndException.
+    @Ignore
     @Test
-    fun equals_should_fail_with_another_InclusiveBound_having_another_value() {
-        val firstBound: InclusiveBound<NonZeroInt> = StrictlyPositiveInt
-            .random()
-            .toInclusiveBound()
-        val secondBound: InclusiveBound<NonZeroInt> = StrictlyNegativeInt
-            .random()
-            .toInclusiveBound()
-        assertTrue { firstBound != secondBound }
-    }
-
-    @Test
-    fun equals_should_fail_with_another_ExclusiveBound() {
-        val firstBound: InclusiveBound<NonZeroInt> = NonZeroInt.random()
-            .toInclusiveBound()
-        val secondBound: ExclusiveBound<NonZeroInt> =
-            firstBound.value.toExclusiveBound()
-        assertTrue { firstBound != secondBound }
+    fun equals_should_fail_with_an_inclusive_bound_having_another_value() {
+        // GIVEN
+        val x: InclusiveBound<Int> = InclusiveBound(Random.nextInt())
+        val y: InclusiveBound<Int> = InclusiveBound(Random.nextInt())
+        // WHEN & THEN
+        assertNotEquals(illegal = x, actual = y)
     }
 
     @Test
     fun toString_should_return_the_string_representation_of_its_value() {
-        val bound: InclusiveBound<NonZeroInt> = NonZeroInt.random()
-            .toInclusiveBound()
-        "$bound" shouldEqual "${bound.value}"
-    }
-
-    @Test
-    fun toInclusiveBound_should_return_an_InclusiveBound_of_this_value() {
-        val value: NonZeroInt = NonZeroInt.random()
-        val result: InclusiveBound<NonZeroInt> = value.toInclusiveBound()
-        result.value shouldEqual value
+        // GIVEN
+        val value: Int = Random.nextInt()
+        val bound: InclusiveBound<Int> = InclusiveBound(value)
+        // WHEN
+        val result = "$bound"
+        // THEN
+        assertEquals(expected = "$value", actual = result)
     }
 }
 
+@ExperimentalRangeApi
 class ExclusiveBoundTest {
+    // Implementing the equals function introduces a KotlinFrontEndException.
+    @Ignore
     @Test
-    fun equals_should_pass_with_another_ExclusiveBound_having_the_same_value() {
-        val firstBound: ExclusiveBound<NonZeroInt> = NonZeroInt.random()
-            .toExclusiveBound()
-        val secondBound: ExclusiveBound<NonZeroInt> =
-            firstBound.value.toExclusiveBound()
-        assertTrue { firstBound == secondBound }
+    fun equals_should_pass_with_an_exclusive_bound_having_the_same_value() {
+        // GIVEN
+        val x: ExclusiveBound<Int> = ExclusiveBound(Random.nextInt())
+        val y: ExclusiveBound<Int> = ExclusiveBound(x.value)
+        // WHEN & THEN
+        "The equals operation should be reflexive.".let {
+            assertEquals(expected = x, actual = x, message = it)
+            assertEquals(expected = y, actual = y, message = it)
+        }
+        "The equals operation should be symmetric.".let {
+            assertEquals(expected = x, actual = y, message = it)
+            assertEquals(expected = y, actual = x, message = it)
+        }
+        "The equals operation should be transitive.".let {
+            val z: ExclusiveBound<Int> = ExclusiveBound(y.value)
+            assertEquals(expected = x, actual = y, message = it)
+            assertEquals(expected = y, actual = z, message = it)
+            assertEquals(expected = x, actual = z, message = it)
+        }
+        "The equals operation should never equal to null.".let {
+            val z: ExclusiveBound<Int>? = null
+            assertNotEquals(illegal = z, actual = x, message = it)
+        }
     }
 
+    // Implementing the equals function introduces a KotlinFrontEndException.
+    @Ignore
     @Test
-    fun equals_should_fail_with_another_ExclusiveBound_having_another_value() {
-        val firstBound: ExclusiveBound<NonZeroInt> = StrictlyPositiveInt
-            .random()
-            .toExclusiveBound()
-        val secondBound: ExclusiveBound<NonZeroInt> = StrictlyNegativeInt
-            .random()
-            .toExclusiveBound()
-        assertTrue { firstBound != secondBound }
-    }
-
-    @Test
-    fun equals_should_fail_with_another_InclusiveBound() {
-        val firstBound: ExclusiveBound<NonZeroInt> = NonZeroInt.random()
-            .toExclusiveBound()
-        val secondBound: InclusiveBound<NonZeroInt> =
-            firstBound.value.toInclusiveBound()
-        assertTrue { firstBound != secondBound }
+    fun equals_should_fail_with_an_exclusive_bound_having_another_value() {
+        // GIVEN
+        val x: ExclusiveBound<Int> = ExclusiveBound(Random.nextInt())
+        val y: ExclusiveBound<Int> = ExclusiveBound(Random.nextInt())
+        // WHEN & THEN
+        assertNotEquals(illegal = x, actual = y)
     }
 
     @Test
     fun toString_should_return_the_string_representation_of_its_value() {
-        val bound: ExclusiveBound<NonZeroInt> = NonZeroInt.random()
-            .toExclusiveBound()
-        "$bound" shouldEqual "${bound.value}"
-    }
-
-    @Test
-    fun toExclusiveBound_should_return_an_ExclusiveBound_of_this_value() {
-        val value: NonZeroInt = NonZeroInt.random()
-        val result: ExclusiveBound<NonZeroInt> = value.toExclusiveBound()
-        result.value shouldEqual value
+        // GIVEN
+        val value: Int = Random.nextInt()
+        val bound: ExclusiveBound<Int> = ExclusiveBound(value)
+        // WHEN
+        val result = "$bound"
+        // THEN
+        assertEquals(expected = "$value", actual = result)
     }
 }

--- a/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/NotEmptyRangeTest.kt
@@ -1,189 +1,169 @@
 package kotools.types.range
 
-import kotools.types.number.*
-import kotools.types.shouldEqual
-import kotlin.test.Test
-import kotlin.test.assertTrue
+import kotools.types.experimental.ExperimentalRangeApi
+import kotlin.random.Random
+import kotlin.test.*
 
+@ExperimentalRangeApi
 class NotEmptyRangeTest {
     @Test
-    fun equals_should_pass_with_another_NotEmptyRange_having_the_same_bounds() {
-        val start: InclusiveBound<AnyInt> = NegativeInt.random()
-            .toInclusiveBound()
-        val end: InclusiveBound<AnyInt> = PositiveInt.random()
-            .toInclusiveBound()
-        val firstRange: NotEmptyRange<AnyInt> = start..end
-        val secondRange: NotEmptyRange<AnyInt> = start..end
-        assertTrue { firstRange == secondRange }
+    fun notEmptyRangeOf_should_return_a_range_starting_with_the_first_bound() {
+        // GIVEN
+        val first: Int = (Int.MIN_VALUE..0).random()
+        val second: Int = (1..Int.MAX_VALUE).random()
+        // WHEN
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.exclusive }
+        // THEN
+        range.start.run {
+            assertTrue("The range's start should be inclusive.") {
+                this is InclusiveBound
+            }
+            assertEquals(expected = first, actual = value)
+        }
+        range.end.run {
+            assertTrue("The range's end should be exclusive.") {
+                this is ExclusiveBound
+            }
+            assertEquals(expected = second, actual = value)
+        }
     }
 
     @Test
-    fun equals_should_fail_with_another_NotEmptyRange_starting_with_another_type_of_bound_but_with_the_same_value() {
-        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toInclusiveBound()
-        val firstRange: NotEmptyRange<NonZeroInt> = start..end
-        val secondRange: NotEmptyRange<NonZeroInt> =
-            start.value.toExclusiveBound()..end
-        assertTrue { firstRange != secondRange }
+    fun notEmptyRangeOf_should_return_a_range_starting_with_the_second_bound() {
+        // GIVEN
+        val first: Int = (1..Int.MAX_VALUE).random()
+        val second: Int = (Int.MIN_VALUE..0).random()
+        // WHEN
+        val range = notEmptyRangeOf<Int> { first.exclusive to second.inclusive }
+        // THEN
+        range.start.run {
+            assertTrue("The range's start should be inclusive.") {
+                this is InclusiveBound
+            }
+            assertEquals(expected = second, actual = value)
+        }
+        range.end.run {
+            assertTrue("The range's end should be exclusive.") {
+                this is ExclusiveBound
+            }
+            assertEquals(expected = first, actual = value)
+        }
     }
 
     @Test
-    fun equals_should_fail_with_another_NotEmptyRange_starting_with_the_same_type_of_bound_but_with_another_value() {
-        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toInclusiveBound()
-        val firstRange: NotEmptyRange<NonZeroInt> = start..end
-        val secondRange: NotEmptyRange<NonZeroInt> = StrictlyNegativeInt
-            .random()
-            .toInclusiveBound<NonZeroInt>()
-            .rangeTo(end)
-        assertTrue { firstRange != secondRange }
+    fun toString_should_pass_with_2_inclusive_bounds() {
+        // GIVEN
+        val first: Int = (Int.MIN_VALUE..0).random()
+        val second: Int = (1..Int.MAX_VALUE).random()
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.inclusive }
+        // WHEN
+        val result = "$range"
+        // THEN
+        assertEquals(expected = "[$first;$second]", actual = result)
     }
 
     @Test
-    fun equals_should_fail_with_another_NotEmptyRange_ending_with_another_type_of_bound_but_with_the_same_value() {
-        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toInclusiveBound()
-        val firstRange: NotEmptyRange<NonZeroInt> = start..end
-        val secondRange: NotEmptyRange<NonZeroInt> =
-            start..end.value.toExclusiveBound()
-        assertTrue { firstRange != secondRange }
+    fun toString_should_pass_with_2_exclusive_bounds() {
+        // GIVEN
+        val first: Int = (Int.MIN_VALUE..0).random()
+        val second: Int = (1..Int.MAX_VALUE).random()
+        val range = notEmptyRangeOf<Int> { first.exclusive to second.exclusive }
+        // WHEN
+        val result = "$range"
+        // THEN
+        assertEquals(expected = "]$first;$second[", actual = result)
     }
 
     @Test
-    fun equals_should_fail_with_another_NotEmptyRange_ending_with_the_same_type_of_bound_but_with_another_value() {
-        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toInclusiveBound()
-        val firstRange: NotEmptyRange<NonZeroInt> = start..end
-        val secondRange: NotEmptyRange<NonZeroInt> = start..StrictlyPositiveInt
-            .random()
-            .toInclusiveBound()
-        assertTrue { firstRange != secondRange }
-    }
-
-    @Test
-    fun toString_should_pass_with_2_InclusiveBounds() {
-        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val end: InclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toInclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        "$range" shouldEqual "[$start;$end]"
-    }
-
-    @Test
-    fun toString_should_pass_with_2_ExclusiveBounds() {
-        val start: ExclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toExclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        "$range" shouldEqual "]$start;$end["
-    }
-
-    @Test
-    fun toString_should_pass_with_an_InclusiveBound_and_ExclusiveBound() {
-        val start: InclusiveBound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        "$range" shouldEqual "[$start;$end["
+    fun toString_should_pass_with_an_inclusive_and_an_exclusive_bounds() {
+        // GIVEN
+        val first: Int = (Int.MIN_VALUE..0).random()
+        val second: Int = (1..Int.MAX_VALUE).random()
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.exclusive }
+        // WHEN
+        val result = "$range"
+        // THEN
+        assertEquals(expected = "[$first;$second[", actual = result)
     }
 
     @Test
     fun contains_should_pass_with_a_value_in_inclusive_bounds() {
-        val range: NotEmptyRange<PositiveInt> = PositiveInt.range
-        val value: PositiveInt = PositiveInt.random()
-        assertTrue { value in range }
+        // GIVEN
+        val first: Int = Random.nextInt()
+        val second: Int = Random.nextInt()
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.inclusive }
+        val value: Int = (range.start.value..range.end.value).random()
+        // WHEN & THEN
+        assertTrue("The value should be included in the range.") {
+            value in range
+        }
     }
 
     @Test
     fun contains_should_pass_with_a_value_in_exclusive_bounds() {
-        val start: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.negativeRange.start.value.toExclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> = 2.toStrictlyPositiveInt()
-            .getOrThrow()
-            .toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = 1.toStrictlyPositiveInt()
-            .getOrThrow()
-        assertTrue { value in range }
+        // GIVEN
+        val first: Int = Random.nextInt()
+        val second: Int = Random.nextInt()
+        val range = notEmptyRangeOf<Int> { first.exclusive to second.exclusive }
+        val value: Int = ((range.start.value + 1) until range.end.value)
+            .random()
+        // WHEN & THEN
+        assertTrue("The value should be included in the range.") {
+            value in range
+        }
     }
 
     @Test
     fun contains_should_pass_with_a_value_in_inclusive_and_exclusive_bounds() {
-        val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.negativeRange.start.value.toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.positiveRange.end.value.toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = NonZeroInt.random()
-            .takeIf { it != NonZeroInt.positiveRange.end.value }
-            ?: NonZeroInt.negativeRange.start.value
-        assertTrue { value in range }
+        // GIVEN
+        val first: Int = Random.nextInt()
+        val second: Int = Random.nextInt()
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.exclusive }
+        val value: Int = (range.start.value until range.end.value).random()
+        // WHEN & THEN
+        assertTrue("The value should be included in the range.") {
+            value in range
+        }
     }
 
     @Test
     fun contains_should_fail_with_a_value_that_is_not_in_inclusive_bounds() {
-        val start: InclusiveBound<PositiveInt> = 1.toStrictlyPositiveInt()
-            .getOrThrow()
-            .toInclusiveBound()
-        val end: InclusiveBound<PositiveInt> =
-            PositiveInt.range.end.value.toInclusiveBound()
-        val range: NotEmptyRange<PositiveInt> = start..end
-        val value: PositiveInt = ZeroInt
-        assertTrue { value !in range }
+        // GIVEN
+        val first: Int = Random.nextInt()
+        val second: Int = Random.nextInt()
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.inclusive }
+        val value: Int = range.end.value + 1
+        // WHEN & THEN
+        assertFalse("The value shouldn't be included in the range.") {
+            value in range
+        }
     }
 
     @Test
     fun contains_should_fail_with_a_value_that_is_not_in_exclusive_bounds() {
-        val start: ExclusiveBound<PositiveInt> =
-            PositiveInt.range.start.value.toExclusiveBound()
-        val end: ExclusiveBound<PositiveInt> =
-            PositiveInt.range.end.value.toExclusiveBound()
-        val range: NotEmptyRange<PositiveInt> = start..end
-        val value: PositiveInt = PositiveInt.range.start.value
-        assertTrue { value !in range }
+        // GIVEN
+        val first: Int = Random.nextInt()
+        val second: Int = Random.nextInt()
+        val range = notEmptyRangeOf<Int> { first.exclusive to second.exclusive }
+        val value: Int = range.end.value
+        // WHEN & THEN
+        assertFalse("The value shouldn't be included in the range.") {
+            value in range
+        }
     }
 
     @Test
     fun contains_should_fail_with_a_value_that_is_not_in_inclusive_and_exclusive_bounds() {
-        val start: InclusiveBound<NonZeroInt> =
-            NonZeroInt.positiveRange.end.value.toInclusiveBound()
-        val end: ExclusiveBound<NonZeroInt> =
-            NonZeroInt.negativeRange.start.value.toExclusiveBound()
-        val range: NotEmptyRange<NonZeroInt> = start..end
-        val value: NonZeroInt = NonZeroInt.negativeRange.start.value
-        assertTrue { value !in range }
-    }
-
-    @Test
-    fun rangeTo_should_return_a_NotEmptyRange_ending_with_the_other_one() {
-        val firstBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val otherBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
-        result.start shouldEqual firstBound
-        result.end shouldEqual otherBound
-    }
-
-    @Test
-    fun rangeTo_should_return_a_NotEmptyRange_starting_with_the_other_one() {
-        val firstBound: Bound<NonZeroInt> = StrictlyPositiveInt.random()
-            .toExclusiveBound()
-        val otherBound: Bound<NonZeroInt> = StrictlyNegativeInt.random()
-            .toInclusiveBound()
-        val result: NotEmptyRange<NonZeroInt> = firstBound..otherBound
-        result.start shouldEqual otherBound
-        result.end shouldEqual firstBound
+        // GIVEN
+        val first: Int = Random.nextInt()
+        val second: Int = Random.nextInt()
+        val range = notEmptyRangeOf<Int> { first.inclusive to second.exclusive }
+        val value: Int = range.end.let {
+            if (it is InclusiveBound) it.value + 1 else it.value
+        }
+        // WHEN & THEN
+        assertFalse("The value shouldn't be included in the range.") {
+            value in range
+        }
     }
 }


### PR DESCRIPTION
> Close #56.

- Add the `ExperimentalRangeApi` annotation in the `kotools.types.experimental` package.
- Mark the `NotEmptyRange` API as experimental.
- Reimplement the `NotEmptyRange` and the `Bound` APIs.
