### PR TITLE
Add type converters suffixed by `OrNull` and `OrThrow` for `StrictlyPositiveInt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-**Experimental** builders suffixed by `OrNull` and `OrThrow` for the 
-`StrictlyNegativeInt` type (issue [#149] implemented by [@o-korpi]).
+- **Experimental** builders suffixed by `OrNull` and `OrThrow` for the
+  `StrictlyNegativeInt` type (issue [#149] implemented by [@o-korpi]).
 
 [#149]: https://github.com/kotools/types/issues/149
 [@o-korpi]: https://github.com/o-korpi
@@ -35,6 +35,25 @@ All notable changes to this project will be documented in this file.
 // after
 (-2).toStrictlyNegativeIntOrNull()
 (-3).toStrictlyNegativeIntOrThrow()
+```
+
+- **Experimental** builders suffixed by `OrElse`, `OrNull` and `OrThrow` for the
+  `StrictlyPositiveInt` type (issue [#141]).
+
+[#141]: https://github.com/kotools/types/issues/141
+
+```kotlin
+// before
+1.toStrictlyPositiveInt()
+    .getOrElse { throw it }
+2.toStrictlyPositiveInt()
+    .getOrNull()
+3.toStrictlyPositiveInt()
+    .getOrThrow()
+// after
+1.toStrictlyPositiveIntOrElse { throw it }
+2.toStrictlyPositiveIntOrNull()
+3.toStrictlyPositiveIntOrThrow()
 ```
 
 ## 4.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,38 +22,22 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- **Experimental** builders suffixed by `OrNull` and `OrThrow` for the
-  `StrictlyNegativeInt` type (issue [#149] implemented by [@o-korpi]).
+**Experimental** builders suffixed by `OrNull` and `OrThrow` for the
+`StrictlyPositiveInt` (issue [#141]) and the `StrictlyNegativeInt` types (issue
+[#149] implemented by [@o-korpi]).
+Here's an example for the `StrictlyPositiveInt` type:
 
+[#141]: https://github.com/kotools/types/issues/141
 [#149]: https://github.com/kotools/types/issues/149
 [@o-korpi]: https://github.com/o-korpi
 
 ```kotlin
 // before
-(-2).toStrictlyNegativeInt().getOrNull()
-(-3).toStrictlyNegativeInt().getOrThrow()
+1.toStrictlyPositiveInt().getOrNull()
+2.toStrictlyPositiveInt().getOrThrow()
 // after
-(-2).toStrictlyNegativeIntOrNull()
-(-3).toStrictlyNegativeIntOrThrow()
-```
-
-- **Experimental** builders suffixed by `OrElse`, `OrNull` and `OrThrow` for the
-  `StrictlyPositiveInt` type (issue [#141]).
-
-[#141]: https://github.com/kotools/types/issues/141
-
-```kotlin
-// before
-1.toStrictlyPositiveInt()
-    .getOrElse { throw it }
-2.toStrictlyPositiveInt()
-    .getOrNull()
-3.toStrictlyPositiveInt()
-    .getOrThrow()
-// after
-1.toStrictlyPositiveIntOrElse { throw it }
-2.toStrictlyPositiveIntOrNull()
-3.toStrictlyPositiveIntOrThrow()
+1.toStrictlyPositiveIntOrNull()
+2.toStrictlyPositiveIntOrThrow()
 ```
 
 ## 4.3.0

--- a/api/types.api
+++ b/api/types.api
@@ -309,6 +309,9 @@ public final class kotools/types/number/StrictlyPositiveInt$Companion {
 
 public final class kotools/types/number/StrictlyPositiveIntKt {
 	public static final fun toStrictlyPositiveInt (Ljava/lang/Number;)Ljava/lang/Object;
+	public static final fun toStrictlyPositiveIntOrElse (Ljava/lang/Number;Lkotlin/jvm/functions/Function1;)I
+	public static final fun toStrictlyPositiveIntOrNull (Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveInt;
+	public static final fun toStrictlyPositiveIntOrThrow (Ljava/lang/Number;)I
 	public static final fun unaryMinus-UPGVeGw (I)I
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -309,7 +309,6 @@ public final class kotools/types/number/StrictlyPositiveInt$Companion {
 
 public final class kotools/types/number/StrictlyPositiveIntKt {
 	public static final fun toStrictlyPositiveInt (Ljava/lang/Number;)Ljava/lang/Object;
-	public static final fun toStrictlyPositiveIntOrElse (Ljava/lang/Number;Lkotlin/jvm/functions/Function1;)I
 	public static final fun toStrictlyPositiveIntOrNull (Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveInt;
 	public static final fun toStrictlyPositiveIntOrThrow (Ljava/lang/Number;)I
 	public static final fun unaryMinus-UPGVeGw (I)I

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -103,7 +103,10 @@ public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = TODO()
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3")
-public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt = TODO()
+public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt {
+    val value: Int = toInt()
+    return StrictlyPositiveInt(value)
+}
 
 /** Representation of positive integers excluding [zero][ZeroInt]. */
 @JvmInline

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -22,6 +22,86 @@ import kotlin.jvm.JvmInline
 public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
     StrictlyPositiveInt of toInt()
 
+/**
+ * Returns this number as a [StrictlyPositiveInt], which may involve rounding
+ * or truncation, or returns the result of calling the [onFailure] function if
+ * this number is negative.
+ *
+ * Here's some usage examples:
+ *
+ * ```kotlin
+ * var result: StrictlyPositiveInt = 1.toStrictlyPositiveIntOrElse { throw it }
+ * println(result) // 1
+ *
+ * 0.toStrictlyPositiveIntOrElse { throw it } // IllegalArgumentException
+ *
+ * result = (-1).toStrictlyPositiveIntOrElse {
+ *     3.toStrictlyPositiveIntOrThrow()
+ * }
+ * println(result) // 3
+ * ```
+ *
+ * Instead of returning the result of calling the [onFailure] function when this
+ * number is negative, you can use the [toStrictlyPositiveIntOrNull] for
+ * returning `null`, or the [toStrictlyPositiveIntOrThrow] for throwing an
+ * [IllegalArgumentException].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3")
+public inline fun Number.toStrictlyPositiveIntOrElse(
+    onFailure: (IllegalArgumentException) -> StrictlyPositiveInt
+): StrictlyPositiveInt = TODO()
+
+/**
+ * Returns this number as a [StrictlyPositiveInt], which may involve rounding
+ * or truncation, or returns `null` if this number is negative.
+ *
+ * Here's some usage examples:
+ *
+ * ```kotlin
+ * var result: StrictlyPositiveInt? = 1.toStrictlyPositiveIntOrNull()
+ * println(result) // 1
+ *
+ * result = 0.toStrictlyPositiveIntOrNull()
+ * println(result) // null
+ *
+ * result = (-1).toStrictlyPositiveIntOrNull()
+ * println(result) // null
+ * ```
+ *
+ * Instead of returning `null` when this number is negative, you can use the
+ * [toStrictlyPositiveIntOrElse] for returning the result of calling the
+ * specified callback, or the [toStrictlyPositiveIntOrThrow] for throwing an
+ * [IllegalArgumentException].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3")
+public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = TODO()
+
+/**
+ * Returns this number as a [StrictlyPositiveInt], which may involve rounding
+ * or truncation, or throws [IllegalArgumentException] if this number is
+ * negative.
+ *
+ * Here's some usage examples:
+ *
+ * ```kotlin
+ * val result: StrictlyPositiveInt = 1.toStrictlyPositiveIntOrThrow()
+ * println(result) // 1
+ *
+ * 0.toStrictlyPositiveIntOrThrow() // IllegalArgumentException
+ * (-1).toStrictlyPositiveIntOrThrow() // IllegalArgumentException
+ * ```
+ *
+ * Instead of throwing an [IllegalArgumentException] when this number is
+ * negative, you can use the [toStrictlyPositiveIntOrElse] for returning the
+ * result of calling the specified callback, or the
+ * [toStrictlyPositiveIntOrNull] for returning `null`.
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3")
+public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt = TODO()
+
 /** Representation of positive integers excluding [zero][ZeroInt]. */
 @JvmInline
 @Serializable(StrictlyPositiveIntSerializer::class)

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -18,12 +18,10 @@ import kotlin.jvm.JvmInline
  * involve rounding or truncation, or returns an encapsulated
  * [IllegalArgumentException] if this number is [negative][NegativeInt].
  */
+@OptIn(ExperimentalNumberApi::class)
 @SinceKotoolsTypes("4.1")
 public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
-    runCatching {
-        val value: Int = toInt()
-        StrictlyPositiveInt(value)
-    }
+    runCatching { toStrictlyPositiveIntOrThrow() }
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding
@@ -48,10 +46,11 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.4")
-public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? {
-    val value: Int = toInt()
-    return if (value <= 0) null else StrictlyPositiveInt(value)
-}
+public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = toInt()
+    .takeIf { it.isStrictlyPositive() }
+    ?.toStrictlyPositiveIntOrThrow()
+
+private fun Int.isStrictlyPositive(): Boolean = this > 0
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding
@@ -74,10 +73,11 @@ public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.4")
-public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt {
-    val value: Int = toInt()
-    return StrictlyPositiveInt(value)
-}
+public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt = toInt()
+    .toStrictlyPositiveIntOrThrow()
+
+private fun Int.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt =
+    StrictlyPositiveInt(this)
 
 /** Representation of positive integers excluding [zero][ZeroInt]. */
 @JvmInline
@@ -86,8 +86,8 @@ public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt {
 public value class StrictlyPositiveInt
 internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
     init {
-        require(value > 0) {
-            "Number should be strictly positive (tried with $this)."
+        require(value.isStrictlyPositive()) {
+            "Integer should be strictly positive (tried with $value)."
         }
     }
 

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -86,9 +86,7 @@ private fun Int.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt =
 public value class StrictlyPositiveInt
 internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
     init {
-        require(value.isStrictlyPositive()) {
-            "Integer should be strictly positive (tried with $value)."
-        }
+        require(value.isStrictlyPositive()) { errorMessageFor(value) }
     }
 
     @SinceKotoolsTypes("4.0")
@@ -124,6 +122,11 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
             notEmptyRangeOf { start.inclusive to end.inclusive }
         }
 
+        internal infix fun errorMessageFor(number: Number): NotBlankString =
+            "Number should be strictly positive (tried with $number)."
+                .toNotBlankString()
+                .getOrThrow()
+
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): StrictlyPositiveInt = (min.value..max.value)
@@ -151,5 +154,7 @@ internal object StrictlyPositiveIntSerializer :
     override fun deserialize(value: Int): StrictlyPositiveInt = value
         .toStrictlyPositiveInt()
         .getOrNull()
-        ?: throw SerializationException(value shouldBe aStrictlyPositiveNumber)
+        ?: throw SerializationException(
+            "${StrictlyPositiveInt errorMessageFor value}"
+        )
 }

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -27,41 +27,6 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding
- * or truncation, or returns the result of calling the [onFailure] function if
- * this number is negative.
- *
- * Here's some usage examples:
- *
- * ```kotlin
- * var result: StrictlyPositiveInt = 1.toStrictlyPositiveIntOrElse { throw it }
- * println(result) // 1
- *
- * 0.toStrictlyPositiveIntOrElse { throw it } // IllegalArgumentException
- *
- * result = (-1).toStrictlyPositiveIntOrElse {
- *     3.toStrictlyPositiveIntOrThrow()
- * }
- * println(result) // 3
- * ```
- *
- * Instead of returning the result of calling the [onFailure] function when this
- * number is negative, you can use the [toStrictlyPositiveIntOrNull] for
- * returning `null`, or the [toStrictlyPositiveIntOrThrow] for throwing an
- * [IllegalArgumentException].
- */
-@ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.3")
-public inline fun Number.toStrictlyPositiveIntOrElse(
-    onFailure: (IllegalArgumentException) -> StrictlyPositiveInt
-): StrictlyPositiveInt = toStrictlyPositiveIntOrNull() ?: let {
-    val error = IllegalArgumentException(
-        "Number should be strictly positive (tried with $it)."
-    )
-    onFailure(error)
-}
-
-/**
- * Returns this number as a [StrictlyPositiveInt], which may involve rounding
  * or truncation, or returns `null` if this number is negative.
  *
  * Here's some usage examples:
@@ -77,10 +42,9 @@ public inline fun Number.toStrictlyPositiveIntOrElse(
  * println(result) // null
  * ```
  *
- * Instead of returning `null` when this number is negative, you can use the
- * [toStrictlyPositiveIntOrElse] for returning the result of calling the
- * specified callback, or the [toStrictlyPositiveIntOrThrow] for throwing an
- * [IllegalArgumentException].
+ * You can use the [toStrictlyPositiveIntOrThrow] function for throwing an
+ * [IllegalArgumentException] instead of returning `null` when this number is
+ * negative.
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3")
@@ -104,10 +68,9 @@ public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? {
  * (-1).toStrictlyPositiveIntOrThrow() // IllegalArgumentException
  * ```
  *
- * Instead of throwing an [IllegalArgumentException] when this number is
- * negative, you can use the [toStrictlyPositiveIntOrElse] for returning the
- * result of calling the specified callback, or the
- * [toStrictlyPositiveIntOrNull] for returning `null`.
+ * You can use the [toStrictlyPositiveIntOrNull] function for returning `null`
+ * instead of throwing an [IllegalArgumentException] when this number is
+ * negative.
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3")

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -53,7 +53,12 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
 @ExperimentalSinceKotoolsTypes("4.3")
 public inline fun Number.toStrictlyPositiveIntOrElse(
     onFailure: (IllegalArgumentException) -> StrictlyPositiveInt
-): StrictlyPositiveInt = TODO()
+): StrictlyPositiveInt = toStrictlyPositiveIntOrNull() ?: let {
+    val error = IllegalArgumentException(
+        "Number should be strictly positive (tried with $it)."
+    )
+    onFailure(error)
+}
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -13,6 +13,8 @@ import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
 
+private fun Int.isStrictlyPositive(): Boolean = this > 0
+
 /**
  * Returns this number as an encapsulated [StrictlyPositiveInt], which may
  * involve rounding or truncation, or returns an encapsulated
@@ -49,8 +51,6 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
 public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = toInt()
     .takeIf { it.isStrictlyPositive() }
     ?.toStrictlyPositiveIntOrThrow()
-
-private fun Int.isStrictlyPositive(): Boolean = this > 0
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -47,7 +47,7 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
  * negative.
  */
 @ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.3")
+@ExperimentalSinceKotoolsTypes("4.4")
 public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? {
     val value: Int = toInt()
     return if (value <= 0) null else StrictlyPositiveInt(value)
@@ -73,7 +73,7 @@ public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? {
  * negative.
  */
 @ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.3")
+@ExperimentalSinceKotoolsTypes("4.4")
 public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt {
     val value: Int = toInt()
     return StrictlyPositiveInt(value)

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -79,7 +79,10 @@ public inline fun Number.toStrictlyPositiveIntOrElse(
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3")
-public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = TODO()
+public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? {
+    val value: Int = toInt()
+    return if (value <= 0) null else StrictlyPositiveInt(value)
+}
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -21,6 +21,7 @@ import kotlin.random.nextInt
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 class StrictlyPositiveIntCompanionTest {
     @Test
@@ -74,6 +75,33 @@ class StrictlyPositiveIntTest {
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
             .shouldHaveAMessage()
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toStrictlyPositiveIntOrElse_should_pass_with_a_strictly_positive_Number() {
+        val number: Number = Random.nextInt(1..Int.MAX_VALUE)
+        val onFailure: (IllegalArgumentException) -> StrictlyPositiveInt = {
+            fail("We shouldn't call the 'onFailure' function.")
+        }
+        val result: StrictlyPositiveInt =
+            number.toStrictlyPositiveIntOrElse(onFailure)
+        result.toInt() shouldEqual number
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toStrictlyPositiveIntOrElse_should_fail_with_a_negative_Number() {
+        val number: Number = Random.nextInt(Int.MIN_VALUE..0)
+        val defaultValue: StrictlyPositiveInt = Random.nextInt(1..Int.MAX_VALUE)
+            .toStrictlyPositiveIntOrThrow()
+        val onFailure: (IllegalArgumentException) -> StrictlyPositiveInt = {
+            defaultValue
+        }
+        val result: StrictlyPositiveInt =
+            number.toStrictlyPositiveIntOrElse(onFailure)
+        result.toInt() shouldNotEqual number
+        result shouldEqual defaultValue
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -21,7 +21,6 @@ import kotlin.random.nextInt
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 class StrictlyPositiveIntCompanionTest {
     @Test
@@ -75,33 +74,6 @@ class StrictlyPositiveIntTest {
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
             .shouldHaveAMessage()
-    }
-
-    @ExperimentalNumberApi
-    @Test
-    fun toStrictlyPositiveIntOrElse_should_pass_with_a_strictly_positive_Number() {
-        val number: Number = Random.nextInt(1..Int.MAX_VALUE)
-        val onFailure: (IllegalArgumentException) -> StrictlyPositiveInt = {
-            fail("We shouldn't call the 'onFailure' function.")
-        }
-        val result: StrictlyPositiveInt =
-            number.toStrictlyPositiveIntOrElse(onFailure)
-        result.toInt() shouldEqual number
-    }
-
-    @ExperimentalNumberApi
-    @Test
-    fun toStrictlyPositiveIntOrElse_should_fail_with_a_negative_Number() {
-        val number: Number = Random.nextInt(Int.MIN_VALUE..0)
-        val defaultValue: StrictlyPositiveInt = Random.nextInt(1..Int.MAX_VALUE)
-            .toStrictlyPositiveIntOrThrow()
-        val onFailure: (IllegalArgumentException) -> StrictlyPositiveInt = {
-            defaultValue
-        }
-        val result: StrictlyPositiveInt =
-            number.toStrictlyPositiveIntOrElse(onFailure)
-        result.toInt() shouldNotEqual number
-        result shouldEqual defaultValue
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -10,6 +10,8 @@ import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.shouldBeNotNull
+import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldFailWithIllegalArgumentException
 import kotools.types.shouldHaveAMessage
@@ -60,14 +62,14 @@ class StrictlyPositiveIntCompanionTest {
 
 class StrictlyPositiveIntTest {
     @Test
-    fun number_toStrictlyPositiveInt_should_pass_with_a_strictly_positive_Number() {
+    fun toStrictlyPositiveInt_should_pass_with_a_strictly_positive_Number() {
         val number: Number = StrictlyPositiveInt.random().toInt()
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         result.getOrThrow().toInt() shouldEqual number
     }
 
     @Test
-    fun number_toStrictlyPositiveInt_should_fail_with_a_negative_Number() {
+    fun toStrictlyPositiveInt_should_fail_with_a_negative_Number() {
         val number: Number = NegativeInt.random().toInt()
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
@@ -76,7 +78,24 @@ class StrictlyPositiveIntTest {
 
     @ExperimentalNumberApi
     @Test
-    fun number_toStrictlyPositiveIntOrThrow_should_pass_with_a_strictly_positive_Number() {
+    fun toStrictlyPositiveIntOrNull_should_pass_with_a_strictly_positive_Number() {
+        val number: Number = Random.nextInt(1..Int.MAX_VALUE)
+        val result: StrictlyPositiveInt? = number.toStrictlyPositiveIntOrNull()
+        result.shouldBeNotNull()
+            .toInt() shouldEqual number
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toStrictlyPositiveIntOrNull_should_fail_with_a_negative_Number() {
+        val number: Number = Random.nextInt(Int.MIN_VALUE..0)
+        val result: StrictlyPositiveInt? = number.toStrictlyPositiveIntOrNull()
+        result.shouldBeNull()
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toStrictlyPositiveIntOrThrow_should_pass_with_a_strictly_positive_Number() {
         val number: Number = Random.nextInt(1..Int.MAX_VALUE)
         val result: StrictlyPositiveInt = number.toStrictlyPositiveIntOrThrow()
         result.toInt() shouldEqual number
@@ -84,7 +103,7 @@ class StrictlyPositiveIntTest {
 
     @ExperimentalNumberApi
     @Test
-    fun number_toStrictlyPositiveIntOrThrow_should_fail_with_a_negative_Number() {
+    fun toStrictlyPositiveIntOrThrow_should_fail_with_a_negative_Number() {
         val number: Number = Random.nextInt(Int.MIN_VALUE..0)
         val error: IllegalArgumentException =
             number.shouldFailWithIllegalArgumentException {

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -11,8 +11,11 @@ import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
+import kotools.types.shouldFailWithIllegalArgumentException
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
+import kotlin.random.Random
+import kotlin.random.nextInt
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -69,6 +72,25 @@ class StrictlyPositiveIntTest {
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
             .shouldHaveAMessage()
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun number_toStrictlyPositiveIntOrThrow_should_pass_with_a_strictly_positive_Number() {
+        val number: Number = Random.nextInt(1..Int.MAX_VALUE)
+        val result: StrictlyPositiveInt = number.toStrictlyPositiveIntOrThrow()
+        result.toInt() shouldEqual number
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun number_toStrictlyPositiveIntOrThrow_should_fail_with_a_negative_Number() {
+        val number: Number = Random.nextInt(Int.MIN_VALUE..0)
+        val error: IllegalArgumentException =
+            number.shouldFailWithIllegalArgumentException {
+                toStrictlyPositiveIntOrThrow()
+            }
+        error.shouldHaveAMessage()
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -63,14 +63,14 @@ class StrictlyPositiveIntCompanionTest {
 class StrictlyPositiveIntTest {
     @Test
     fun toStrictlyPositiveInt_should_pass_with_a_strictly_positive_Number() {
-        val number: Number = StrictlyPositiveInt.random().toInt()
+        val number: Number = Random.nextInt(1..Int.MAX_VALUE)
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         result.getOrThrow().toInt() shouldEqual number
     }
 
     @Test
     fun toStrictlyPositiveInt_should_fail_with_a_negative_Number() {
-        val number: Number = NegativeInt.random().toInt()
+        val number: Number = Random.nextInt(Int.MIN_VALUE..0)
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
         result.shouldFailWithIllegalArgumentException { getOrThrow() }
             .message


### PR DESCRIPTION
This request closes #141 by introducing the `toStrictlyPositiveIntOrNull` and the `toStrictlyPositiveIntOrThrow` **experimental** functions.
