### PR TITLE
Add type converters suffixed by `OrNull` and `OrThrow` for `NotBlankString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ All notable changes to this project will be documented in this file.
 **Experimental** builders suffixed by `OrNull` and `OrThrow` for the following
 types:
 - `StrictlyPositiveInt` (issue [#141])
-- `StrictlyNegativeInt` (issue [#149] implemented by [@o-korpi]).
+- `StrictlyNegativeInt` (issue [#149] implemented by [@o-korpi])
+- `NotBlankString` (issue [#174]).
 
 [#141]: https://github.com/kotools/types/issues/141
 [#149]: https://github.com/kotools/types/issues/149
+[#174]: https://github.com/kotools/types/issues/174
 [@o-korpi]: https://github.com/o-korpi
 
 Here's an example for the `StrictlyPositiveInt` type:

--- a/api/types.api
+++ b/api/types.api
@@ -410,5 +410,7 @@ public final class kotools/types/text/NotBlankStringKt {
 	public static final fun plus-_fD6_zU (Ljava/lang/String;C)Ljava/lang/String;
 	public static final fun plus-_fD6_zU (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun toNotBlankString (Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun toNotBlankStringOrNull (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun toNotBlankStringOrThrow (Ljava/lang/String;)Ljava/lang/String;
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -389,6 +389,7 @@ public final class kotools/types/result/ResultContext$DefaultImpls {
 }
 
 public final class kotools/types/text/NotBlankString : java/lang/Comparable {
+	public static final field Companion Lkotools/types/text/NotBlankString$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lkotools/types/text/NotBlankString;
 	public synthetic fun compareTo (Ljava/lang/Object;)I
 	public fun compareTo-Adxdz-0 (Ljava/lang/String;)I
@@ -402,6 +403,10 @@ public final class kotools/types/text/NotBlankString : java/lang/Comparable {
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class kotools/types/text/NotBlankString$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class kotools/types/text/NotBlankStringKt {

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -45,9 +45,9 @@ public fun String.toNotBlankString(): Result<NotBlankString> =
  */
 @ExperimentalTextApi
 @ExperimentalSinceKotoolsTypes("4.4")
-public fun String.toNotBlankStringOrNull(): NotBlankString? {
-    TODO()
-}
+public fun String.toNotBlankStringOrNull(): NotBlankString? =
+    takeIf { it.isNotBlank() }
+        ?.toNotBlankStringOrThrow()
 
 /**
  * Returns this string as a [NotBlankString], or throws an

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -26,6 +26,53 @@ public fun String.toNotBlankString(): Result<NotBlankString> =
     NotBlankString of this
 
 /**
+ * Returns this string as a [NotBlankString], or returns `null` if this string
+ * is [blank][String.isBlank].
+ *
+ * Here's some usage examples:
+ *
+ * ```kotlin
+ * var result: NotBlankString? = "hello world".toNotBlankStringOrNull()
+ * println(result) // hello world
+ *
+ * result = "  ".toNotBlankStringOrNull()
+ * println(null) // null
+ * ```
+ *
+ * You can use the [toNotBlankStringOrThrow] function for throwing an
+ * [IllegalArgumentException] instead of returning `null` when this string is
+ * [blank][String.isBlank].
+ */
+@ExperimentalTextApi
+@ExperimentalSinceKotoolsTypes("4.4")
+public fun String.toNotBlankStringOrNull(): NotBlankString? {
+    TODO()
+}
+
+/**
+ * Returns this string as a [NotBlankString], or throws an
+ * [IllegalArgumentException] if this string is [blank][String.isBlank].
+ *
+ * Here's some usage examples:
+ *
+ * ```kotlin
+ * var result: NotBlankString = "hello world".toNotBlankStringOrThrow()
+ * println(result) // hello world
+ *
+ * "  ".toNotBlankStringOrThrow() // IllegalArgumentException
+ * ```
+ *
+ * You can use the [toNotBlankStringOrNull] function for returning `null`
+ * instead of throwing an [IllegalArgumentException] when this string is
+ * [blank][String.isBlank].
+ */
+@ExperimentalTextApi
+@ExperimentalSinceKotoolsTypes("4.4")
+public fun String.toNotBlankStringOrThrow(): NotBlankString {
+    TODO()
+}
+
+/**
  * Representation of strings that have at least one character, excluding
  * whitespaces.
  */

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -10,6 +10,7 @@ import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.ZeroInt
 import kotools.types.shouldBeNotNull
+import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldFailWithIllegalArgumentException
 import kotools.types.shouldHaveAMessage
@@ -38,6 +39,22 @@ class NotBlankStringTest {
             .message
             .shouldBeNotNull()
             .shouldEqual(NotBlankStringException.message)
+    }
+
+    @ExperimentalTextApi
+    @Test
+    fun toNotBlankStringOrNull_should_pass_with_a_not_blank_String() {
+        val string: String = StringExample.NOT_BLANK
+        val result: NotBlankString? = string.toNotBlankStringOrNull()
+        "${result.shouldBeNotNull()}" shouldEqual string
+    }
+
+    @ExperimentalTextApi
+    @Test
+    fun toNotBlankStringOrNull_should_fail_with_a_blank_String() {
+        val string: String = StringExample.BLANK
+        val result: NotBlankString? = string.toNotBlankStringOrNull()
+        result.shouldBeNull()
     }
 
     @ExperimentalTextApi

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -9,7 +9,9 @@ import kotools.types.Package
 import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.ZeroInt
+import kotools.types.shouldBeNotNull
 import kotools.types.shouldEqual
+import kotools.types.shouldFailWithIllegalArgumentException
 import kotools.types.shouldHaveAMessage
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -22,18 +24,40 @@ private object StringExample {
 
 class NotBlankStringTest {
     @Test
-    fun string_toNotBlankString_should_pass_with_a_not_blank_String() {
+    fun toNotBlankString_should_pass_with_a_not_blank_String() {
         val result: Result<NotBlankString> =
             StringExample.NOT_BLANK.toNotBlankString()
         "${result.getOrThrow()}" shouldEqual StringExample.NOT_BLANK
     }
 
     @Test
-    fun string_toNotBlankString_should_fail_with_a_blank_String() {
+    fun toNotBlankString_should_fail_with_a_blank_String() {
         val result: Result<NotBlankString> =
             StringExample.BLANK.toNotBlankString()
-        assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
-            .shouldHaveAMessage()
+        result.shouldFailWithIllegalArgumentException { getOrThrow() }
+            .message
+            .shouldBeNotNull()
+            .shouldEqual(NotBlankStringException.message)
+    }
+
+    @ExperimentalTextApi
+    @Test
+    fun toNotBlankStringOrThrow_should_pass_with_a_not_blank_String() {
+        val string: String = StringExample.NOT_BLANK
+        val result: NotBlankString = string.toNotBlankStringOrThrow()
+        "$result" shouldEqual string
+    }
+
+    @ExperimentalTextApi
+    @Test
+    fun toNotBlankStringOrThrow_should_fail_with_a_blank_String() {
+        val string: String = StringExample.BLANK
+        val error: IllegalArgumentException =
+            string.shouldFailWithIllegalArgumentException {
+                toNotBlankStringOrThrow()
+            }
+        error.message.shouldBeNotNull()
+            .shouldEqual(NotBlankStringException.message)
     }
 
     @Test


### PR DESCRIPTION
This request closes #174 by introducing the `toNotBlankStringOrNull` and the `toNotBlankStringOrThrow` **experimental** functions.
