### PR TITLE
Add `DeprecatedSinceKotoolsTypes` annotation

### DIFF
--- a/src/commonMain/kotlin/kotools/types/Annotations.kt
+++ b/src/commonMain/kotlin/kotools/types/Annotations.kt
@@ -31,3 +31,27 @@ internal annotation class ExperimentalSinceKotoolsTypes(val version: String)
 @Retention(BINARY)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class SinceKotoolsTypes(val version: String)
+
+/**
+ * Specifies the first versions of Kotools Types where a declaration has
+ * appeared as a **deprecated** feature.
+ *
+ * The specified [warningSince] should match the version where the declaration
+ * was deprecated with a [warning][DeprecationLevel.WARNING] level.
+ * The specified [errorSince] should match the version where it was deprecated
+ * with an [error][DeprecationLevel.ERROR] level.
+ * The specified [hiddenSince] should match the version where the declaration
+ * was deprecated with a [hidden][DeprecationLevel.HIDDEN] level.
+ *
+ * The versions should be in the following formats: `<major>.<minor>` or
+ * `<major>.<minor>.<patch>`, where _major_, _minor_ and _patch_ are positive
+ * integers without leading zeros.
+ */
+@MustBeDocumented
+@Retention(BINARY)
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+internal annotation class DeprecatedSinceKotoolsTypes(
+    val warningSince: String,
+    val errorSince: String = "",
+    val hiddenSince: String = ""
+)


### PR DESCRIPTION
This request resolves #84 by introducing the `DeprecatedSinceKotoolsTypes` annotation.
