### PR TITLE
Extract versions from Gradle build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,23 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#182]: https://github.com/kotools/types/pull/182
 [@o-korpi]: https://github.com/o-korpi
 
+### Changed
+
+#### Centralizing Gradle plugins and dependencies
+
+For reducing the overall complexity of the
+[Gradle build script](build.gradle.kts), we've centralized the plugins and the
+dependencies in a [version catalog](gradle/libs.versions.toml) instead of
+defining them in the build script (PR [#199]).
+
+Read the _[TOML + Gradle + project accessors]_ article by [@FunkyMuse] for
+more information about how to set up a version catalog with a [TOML] file.
+
+[#199]: https://github.com/kotools/types/pull/199
+[@FunkyMuse]: https://github.com/FunkyMuse
+[TOML + Gradle + project accessors]: https://funkymuse.dev/posts/toml-gradle
+[TOML]: https://toml.io
+
 ## 4.3.0
 
 _Release date: 2023-08-14._

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ This project is very light and just ship with one direct dependency:
 Knowing that these types could be used in any type of API, this feature is
 essential for this library.
 
+See the [version catalog](gradle/libs.versions.toml) for more details about the
+tools used for building Kotools Types.
+
 ### Error handling agnostic
 
 Users should be responsible for deciding how to handle errors, not this library.
@@ -124,10 +127,9 @@ about what's happening, please follow us here and say hi!
 - [GitHub Discussions]
 - [#kotools-types on Kotlin Slack]
 
-See the [contributing guidelines] for more details.
+See the [contributing guidelines](CONTRIBUTING.md) for more details.
 
 [#kotools-types on Kotlin Slack]: https://kotlinlang.slack.com/archives/C05H0L1LD25
-[contributing guidelines]: https://github.com/kotools/types/blob/main/CONTRIBUTING.md
 [GitHub Discussions]: https://github.com/kotools/types/discussions
 
 ## Show Your Support
@@ -149,6 +151,4 @@ as bug reports, feature suggestions and so on.
 
 ## License
 
-This project is licensed under the [MIT License].
-
-[MIT License]: https://choosealicense.com/licenses/mit
+This project is licensed under the [MIT License](LICENSE.txt).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 plugins {
-    val kotlinVersion = "1.7.21"
-    kotlin("multiplatform") version kotlinVersion
-    kotlin("plugin.serialization") version kotlinVersion
-    id("org.jetbrains.dokka") version "1.7.20"
-    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.12.1"
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlinx.binary.compatibility.validator)
     `maven-publish`
     signing
 }
@@ -20,14 +19,8 @@ dependencies {
     commonTestImplementation(kotlin("test"))
 
     // Kotlinx Serialization
-    fun kotlinxSerialization(module: String): String {
-        val group = "org.jetbrains.kotlinx"
-        val artifact = "kotlinx-serialization-$module"
-        val version = "1.4.1"
-        return "$group:$artifact:$version"
-    }
-    commonMainImplementation(kotlinxSerialization("core"))
-    commonTestImplementation(kotlinxSerialization("json"))
+    commonMainImplementation(libs.kotlinx.serialization.core)
+    commonTestImplementation(libs.kotlinx.serialization.json)
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlinx.binary.compatibility.validator)
+    alias(libs.plugins.kotlinx.serialization)
     `maven-publish`
     signing
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,35 @@
+[versions]
+dokka = "1.7.20"
+kotlin = "1.7.21"
+kotlinx-binary-compatibility-validator = "0.12.1"
+kotlinx-serialization = "1.4.1"
+
+# Plugins
+
+[plugins.dokka]
+id = "org.jetbrains.dokka"
+version.ref = "dokka"
+
+[plugins.kotlin-multiplatform]
+id = "org.jetbrains.kotlin.multiplatform"
+version.ref = "kotlin"
+
+[plugins.kotlinx-binary-compatibility-validator]
+id = "org.jetbrains.kotlinx.binary-compatibility-validator"
+version.ref = "kotlinx-binary-compatibility-validator"
+
+[plugins.kotlinx-serialization]
+id = "org.jetbrains.kotlin.plugin.serialization"
+version.ref = "kotlin"
+
+# Libraries
+
+[libraries.kotlinx-serialization-core]
+group = "org.jetbrains.kotlinx"
+name = "kotlinx-serialization-core"
+version.ref = "kotlinx-serialization"
+
+[libraries.kotlinx-serialization-json]
+group = "org.jetbrains.kotlinx"
+name = "kotlinx-serialization-json"
+version.ref = "kotlinx-serialization"


### PR DESCRIPTION
This request moves the plugin and dependency declarations in a new `gradle/libs.versions.toml` file for better readability.
See the [TOML](https://toml.io/en/) website for more details about its syntax.