### PR TITLE
Fix version of `ExperimentalCollectionApi` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,12 @@ All notable changes to this project will be documented in this file.
 
 This version introduces an `ExperimentalCollectionApi` annotation in the
 `kotools.types.experimental` package for marking experimental declarations
-of the `kotools.types.collection` package (issue [#177] fixed by PR [#183]).
+of the `kotools.types.collection` package (issue [#177] fixed by PRs [#183] and
+[#201]).
 
 [#177]: https://github.com/kotools/types/issues/177
 [#183]: https://github.com/kotools/types/pull/183
+[#201]: https://github.com/kotools/types/pull/201
 
 #### Builders suffixed by `OrNull` and `OrThrow`
 

--- a/src/commonMain/kotlin/kotools/types/experimental/Annotations.kt
+++ b/src/commonMain/kotlin/kotools/types/experimental/Annotations.kt
@@ -11,7 +11,7 @@ import kotlin.annotation.AnnotationTarget.TYPEALIAS
 @MustBeDocumented
 @RequiresOptIn
 @Retention(BINARY)
-@SinceKotoolsTypes("4.4")
+@SinceKotoolsTypes("4.3.1")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 public annotation class ExperimentalCollectionApi
 


### PR DESCRIPTION
This request fixes #177 by correcting the version specified in the `SinceKotoolsTypes` annotation on the `ExperimentalCollectionApi` one.