### PR TITLE
Fix version of type converters suffixed by `OrNull` and `OrThrow` for `StrictlyPositiveInt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ should return `null` if the builder is suffixed by `OrNull` or throw an
 exception if it's suffixed by `OrThrow`.
 This change applies for the following types:
 
-- `StrictlyPositiveInt` (issue [#141] fixed by PR [#164])
+- `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PR [#181] and by [@o-korpi] in PR
   [#167])
 - `NotBlankString` (issue [#174] fixed by PR [#182]).
@@ -65,6 +65,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#174]: https://github.com/kotools/types/issues/174
 [#181]: https://github.com/kotools/types/pull/181
 [#182]: https://github.com/kotools/types/pull/182
+[#202]: https://github.com/kotools/types/pull/202
 [@o-korpi]: https://github.com/o-korpi
 
 ### Changed

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -46,7 +46,7 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
  * [negative][NegativeInt].
  */
 @ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.4")
+@ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = toInt()
     .takeIf { it.isStrictlyPositive() }
     ?.toStrictlyPositiveIntOrThrow()
@@ -71,7 +71,7 @@ public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = toInt()
  * [negative][NegativeInt].
  */
 @ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.4")
+@ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt = toInt()
     .toStrictlyPositiveIntOrThrow()
 


### PR DESCRIPTION
This request fixes #141 by correcting the version specified in the `SinceKotoolsTypes` annotation on the `toStrictlyPositiveIntOrNull` and `toStrictlyPositiveIntOrThrow` functions.