### PR TITLE
Fix version of type converters suffixed by `OrNull` and `OrThrow` for `StrictlyNegativeInt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ exception if it's suffixed by `OrThrow`.
 This change applies for the following types:
 
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
-- `StrictlyNegativeInt` (issue [#149] fixed by PR [#181] and by [@o-korpi] in PR
-  [#167])
+- `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
+  [@o-korpi] in PR [#167])
 - `NotBlankString` (issue [#174] fixed by PR [#182]).
 
 Here's an example for the `StrictlyPositiveInt` type:
@@ -66,6 +66,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#181]: https://github.com/kotools/types/pull/181
 [#182]: https://github.com/kotools/types/pull/182
 [#202]: https://github.com/kotools/types/pull/202
+[#203]: https://github.com/kotools/types/pull/203
 [@o-korpi]: https://github.com/o-korpi
 
 ### Changed

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -46,7 +46,7 @@ public fun Number.toStrictlyNegativeInt(): Result<StrictlyNegativeInt> =
  * [positive][PositiveInt].
  */
 @ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.4")
+@ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyNegativeIntOrNull(): StrictlyNegativeInt? = toInt()
     .takeIf { it.isStrictlyNegative() }
     ?.toStrictlyNegativeIntOrThrow()
@@ -71,7 +71,7 @@ public fun Number.toStrictlyNegativeIntOrNull(): StrictlyNegativeInt? = toInt()
  * [positive][PositiveInt].
  */
 @ExperimentalNumberApi
-@ExperimentalSinceKotoolsTypes("4.4")
+@ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyNegativeIntOrThrow(): StrictlyNegativeInt = toInt()
     .toStrictlyNegativeIntOrThrow()
 


### PR DESCRIPTION
This request fixes #149 by correcting the version specified in the `ExperimentalSinceKotoolsTypes` of the `toStrictlyNegativeIntOrNull` and `toStrictlyNegativeIntOrThrow` functions.