### PR TITLE
Fix version of type converters suffixed by `OrNull` and `OrThrow` for `NotBlankString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This change applies for the following types:
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
   [@o-korpi] in PR [#167])
-- `NotBlankString` (issue [#174] fixed by PR [#182]).
+- `NotBlankString` (issue [#174] fixed by PRs [#182] and [#204]).
 
 Here's an example for the `StrictlyPositiveInt` type:
 
@@ -67,6 +67,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#182]: https://github.com/kotools/types/pull/182
 [#202]: https://github.com/kotools/types/pull/202
 [#203]: https://github.com/kotools/types/pull/203
+[#204]: https://github.com/kotools/types/pull/204
 [@o-korpi]: https://github.com/o-korpi
 
 ### Changed

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -43,7 +43,7 @@ public fun String.toNotBlankString(): Result<NotBlankString> =
  * [IllegalArgumentException] instead of returning `null` when this string is
  * [blank][String.isBlank].
  */
-@ExperimentalSinceKotoolsTypes("4.4")
+@ExperimentalSinceKotoolsTypes("4.3.1")
 @ExperimentalTextApi
 public fun String.toNotBlankStringOrNull(): NotBlankString? =
     takeIf { it.isNotBlank() }
@@ -66,7 +66,7 @@ public fun String.toNotBlankStringOrNull(): NotBlankString? =
  * instead of throwing an [IllegalArgumentException] when this string is
  * [blank][String.isBlank].
  */
-@ExperimentalSinceKotoolsTypes("4.4")
+@ExperimentalSinceKotoolsTypes("4.3.1")
 @ExperimentalTextApi
 public fun String.toNotBlankStringOrThrow(): NotBlankString =
     NotBlankString(this)


### PR DESCRIPTION
This request fixes #174 by correcting the version specified in the `ExperimentalSinceKotoolsTypes` annotation of the `toNotBlankStringOrNull` and `toNotBlankStringOrThrow` functions.