### PR TITLE
Enable API reference deployments with SSH key

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -33,6 +33,8 @@ jobs:
           rm -r versions/
       - name: Generate latest API reference
         run: ./gradlew dokkaHtml --no-daemon
+      - name: Set Git user and email
+        uses: fregante/setup-git-user@v2.0.1
       - name: Archive latest API reference
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy API reference
     runs-on: ubuntu-latest
     env:
-      BRANCH_TARGET: deploy-test
+      BRANCH_TARGET: api-reference
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get project version
         run: |
           ./gradlew projectVersion -q --dry-run
-          echo "project_version=$(./gradlew projectVersion -q)" >> "$GITHUB_ENV"
+          echo "PROJECT_VERSION=$(./gradlew projectVersion -q)" >> "$GITHUB_ENV"
       - name: Get archived API references
         run: |
           git checkout "origin/$BRANCH_TARGET" -- versions && \
@@ -43,7 +43,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
-          commit-message: "Archive API reference of v${{ env.project_version }}"
+          commit-message: "Archive API reference of v${{ env.PROJECT_VERSION }}"
           folder: api/references
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: versions
@@ -51,7 +51,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
-          commit-message: "Deploy API reference of v${{ env.project_version }}"
+          commit-message: "Deploy API reference of v${{ env.PROJECT_VERSION }}"
           folder: build/dokka
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: docs

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,7 +32,7 @@ jobs:
           git mv -f versions/* api/references/ && \
           rm -r versions/
       - name: Generate latest API reference
-        run: ./gradlew dokkaHtml --no-daemon
+        run: ./gradlew dokkaHtml -q --no-daemon
       - name: Set Git user and email
         uses: fregante/setup-git-user@v2.0.1
       - name: Archive latest API reference

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -29,7 +29,7 @@ jobs:
         uses: fregante/setup-git-user@v2.0.1
       - name: Get project version
         run: |
-          echo "PROJECT_VERSION=$(./gradlew projectVersion -q)" >> "$GITHUB_ENV"
+          echo "project_version=$(./gradlew projectVersion -q)" >> "$GITHUB_ENV"
       - name: Get archived API references
         run: |
           git checkout "origin/$BRANCH_TARGET" -- versions && \
@@ -38,19 +38,19 @@ jobs:
           rm -r versions/
       - name: Generate latest API reference
         run: ./gradlew dokkaHtml -q
-      - name: Archive API reference of v${{ env.PROJECT_VERSION }}
+      - name: Archive API reference
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
-          commit-message: Archive API reference of v${{ env.PROJECT_VERSION }}
+          commit-message: Archive API reference of v$project_version
           folder: api/references
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: versions
-      - name: Deploy API reference of v${{ env.PROJECT_VERSION }}
+      - name: Deploy API reference
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
-          commit-message: Deploy API reference of v${{ env.PROJECT_VERSION }}
+          commit-message: Deploy API reference of v$project_version
           folder: build/dokka
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: docs

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BRANCH_TARGET: deploy-test
-      DEPLOY_ACTION: JamesIves/github-pages-deploy-action@v4.4.1
     permissions:
       contents: write
       pages: write
@@ -35,14 +34,14 @@ jobs:
       - name: Generate latest API reference
         run: ./gradlew dokkaHtml --no-daemon
       - name: Archive latest API reference
-        uses: ${{ env.DEPLOY_ACTION }}
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
           folder: api/references
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: versions
       - name: Deploy latest API reference
-        uses: ${{ env.DEPLOY_ACTION }}
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
           folder: build/dokka

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -39,16 +39,14 @@ jobs:
         with:
           branch: ${{ env.BRANCH_TARGET }}
           folder: api/references
-          git-config-email: ${{ secrets.GIT_EMAIL }}
-          git-config-name: ${{ secrets.GIT_USER }}
+          ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: versions
       - name: Deploy latest API reference
         uses: ${{ env.DEPLOY_ACTION }}
         with:
           branch: ${{ env.BRANCH_TARGET }}
           folder: build/dokka
-          git-config-email: ${{ secrets.GIT_EMAIL }}
-          git-config-name: ${{ secrets.GIT_USER }}
+          ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: docs
       - name: Remove archived API references
         run: git rm -rf api/references/

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -37,8 +37,6 @@ jobs:
           rm -r versions/
       - name: Generate latest API reference
         run: ./gradlew dokkaHtml -q
-      - name: Set Git user and email
-        uses: fregante/setup-git-user@v2.0.1
       - name: Archive API reference
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -43,7 +43,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
-          commit-message: Archive API reference of v$project_version
+          commit-message: "Archive API reference of v${{ env.project_version }}"
           folder: api/references
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: versions
@@ -51,7 +51,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
-          commit-message: Deploy API reference of v$project_version
+          commit-message: "Deploy API reference of v${{ env.project_version }}"
           folder: build/dokka
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: docs

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -25,10 +25,9 @@ jobs:
           cache: gradle
           distribution: temurin
           java-version: 17
-      - name: Set Git user and email
-        uses: fregante/setup-git-user@v2.0.1
       - name: Get project version
         run: |
+          ./gradlew projectVersion -q --dry-run
           echo "project_version=$(./gradlew projectVersion -q)" >> "$GITHUB_ENV"
       - name: Get archived API references
         run: |
@@ -38,6 +37,8 @@ jobs:
           rm -r versions/
       - name: Generate latest API reference
         run: ./gradlew dokkaHtml -q
+      - name: Set Git user and email
+        uses: fregante/setup-git-user@v2.0.1
       - name: Archive API reference
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -7,6 +7,9 @@ jobs:
   deploy:
     name: Deploy API reference
     runs-on: ubuntu-latest
+    env:
+      BRANCH_TARGET: api-reference
+      DEPLOY_ACTION: JamesIves/github-pages-deploy-action@v4.4.1
     permissions:
       contents: write
       pages: write
@@ -25,24 +28,24 @@ jobs:
           java-version: 17
       - name: Get archived API references
         run: |
-          git checkout origin/api-reference -- versions && \
+          git checkout "origin/$BRANCH_TARGET" -- versions && \
           mkdir api/references && \
           git mv -f versions/* api/references/ && \
           rm -r versions/
       - name: Generate latest API reference
         run: ./gradlew dokkaHtml --no-daemon
       - name: Archive latest API reference
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: ${{ env.DEPLOY_ACTION }}
         with:
-          branch: api-reference
+          branch: ${{ env.BRANCH_TARGET }}
           folder: api/references
           git-config-email: ${{ secrets.GIT_EMAIL }}
           git-config-name: ${{ secrets.GIT_USER }}
           target-folder: versions
       - name: Deploy latest API reference
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: ${{ env.DEPLOY_ACTION }}
         with:
-          branch: api-reference
+          branch: ${{ env.BRANCH_TARGET }}
           folder: build/dokka
           git-config-email: ${{ secrets.GIT_EMAIL }}
           git-config-name: ${{ secrets.GIT_USER }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,7 +8,7 @@ jobs:
     name: Deploy API reference
     runs-on: ubuntu-latest
     env:
-      BRANCH_TARGET: api-reference
+      BRANCH_TARGET: deploy-test
       DEPLOY_ACTION: JamesIves/github-pages-deploy-action@v4.4.1
     permissions:
       contents: write

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -25,6 +25,11 @@ jobs:
           cache: gradle
           distribution: temurin
           java-version: 17
+      - name: Set Git user and email
+        uses: fregante/setup-git-user@v2.0.1
+      - name: Get project version
+        run: |
+          echo "PROJECT_VERSION=$(./gradlew projectVersion -q)" >> "$GITHUB_ENV"
       - name: Get archived API references
         run: |
           git checkout "origin/$BRANCH_TARGET" -- versions && \
@@ -32,20 +37,20 @@ jobs:
           git mv -f versions/* api/references/ && \
           rm -r versions/
       - name: Generate latest API reference
-        run: ./gradlew dokkaHtml -q --no-daemon
-      - name: Set Git user and email
-        uses: fregante/setup-git-user@v2.0.1
-      - name: Archive latest API reference
+        run: ./gradlew dokkaHtml -q
+      - name: Archive API reference of v${{ env.PROJECT_VERSION }}
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
+          commit-message: Archive API reference of v${{ env.PROJECT_VERSION }}
           folder: api/references
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: versions
-      - name: Deploy latest API reference
+      - name: Deploy API reference of v${{ env.PROJECT_VERSION }}
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: ${{ env.BRANCH_TARGET }}
+          commit-message: Deploy API reference of v${{ env.PROJECT_VERSION }}
           folder: build/dokka
           ssh-key: ${{ secrets.ADMIN_DEPLOY_KEY }}
           target-folder: docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,10 +80,16 @@ fixed by PR [#206]).
 We recommend you to only use the versions documented in the API reference for a
 better experience while working with Kotools Types.
 
+The [API reference] is also securely deployed using an [SSH deploy key] when a
+release is published (issue [#207] fixed by PR [#208]).
+
 [#198]: https://github.com/kotools/types/pull/198
 [#205]: https://github.com/kotools/types/issues/205
 [#206]: https://github.com/kotools/types/pull/206
+[#207]: https://github.com/kotools/types/issues/207
+[#208]: https://github.com/kotools/types/pull/208
 [API reference]: https://types.kotools.org
+[SSH deploy key]: https://docs.github.com/fr/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys
 
 #### Centralizing Gradle plugins and dependencies
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,11 @@ group = "org.kotools"
 version = "4.3.1-SNAPSHOT"
 val projectName = "Kotools Types"
 
+tasks.register("projectVersion") {
+    this.description = "Shows the version of this project."
+    doLast { println(version) }
+}
+
 repositories { mavenCentral() }
 
 dependencies {


### PR DESCRIPTION
This request fixes #207 by updating the [deployment] workflow for deploying the API reference with an [SSH deploy key](https://docs.github.com/fr/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys).
It also adds a `projectVersion` task in the Gradle build script for aligning the commit messages in the [deployment] workflow with the project version.

[deployment]: https://github.com/kotools/types/actions/workflows/deployment.yml