### PR TITLE
Remove versioning annotations from binary output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,17 @@ All notable changes to this project will be documented in this file.
 
 [#250]: https://github.com/kotools/types/issues/250
 
+### Changed
+
+- Retention of the `ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and
+  the `DeprecatedSinceKotoolsTypes` annotations from
+  [BINARY][kotlin.AnnotationRetention.BINARY] to
+  [SOURCE][kotlin.AnnotationRetention.SOURCE] (PR [#214]).
+
+[#214]: https://github.com/kotools/types/pull/214
+[kotlin.AnnotationRetention.BINARY]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-b-i-n-a-r-y.html
+[kotlin.AnnotationRetention.SOURCE]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html
+
 ### Fixed
 
 - The usage examples in the documentation of the `toStrictlyNegativeIntOrThrow`
@@ -125,16 +136,6 @@ Please note that since [Kotools Types 4.3.0], this project is compiled with
 
 [#213]: https://github.com/kotools/types/pull/213
 [Kotools Types 4.3.0]: https://github.com/kotools/types/releases/tag/4.3.0
-
-#### Binary output optimization
-
-For avoiding unnecessary declarations in the binary output, we've removed the
-`ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and the
-`DeprecatedSinceKotoolsTypes` annotations from it by setting their retention to
-[`SOURCE`][kotlin.AnnotationRetention.SOURCE] (PR [#214]).
-
-[#214]: https://github.com/kotools/types/pull/214
-[kotlin.AnnotationRetention.SOURCE]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html
 
 #### Multiple versions in API reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,16 @@ Please note that since [Kotools Types 4.3.0], this project is compiled with
 [#213]: https://github.com/kotools/types/pull/213
 [Kotools Types 4.3.0]: https://github.com/kotools/types/releases/tag/4.3.0
 
+#### Binary output optimization
+
+For avoiding unnecessary declarations in the binary output, we've removed the
+`ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and the
+`DeprecatedSinceKotoolsTypes` annotations from it by setting their retention to
+[`SOURCE`][kotlin.AnnotationRetention.SOURCE] (PR [#214]).
+
+[#214]: https://github.com/kotools/types/pull/214
+[kotlin.AnnotationRetention.SOURCE]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html
+
 #### Multiple versions in API reference
 
 The configuration of the [API reference] was improved for supporting multiple

--- a/src/commonMain/kotlin/kotools/types/Annotations.kt
+++ b/src/commonMain/kotlin/kotools/types/Annotations.kt
@@ -5,7 +5,7 @@
 
 package kotools.types
 
-import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationRetention.SOURCE
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
@@ -20,7 +20,7 @@ import kotlin.annotation.AnnotationTarget.TYPEALIAS
  * integers without leading zeros.
  */
 @MustBeDocumented
-@Retention(BINARY)
+@Retention(SOURCE)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class ExperimentalSinceKotoolsTypes(val version: String)
 
@@ -33,7 +33,7 @@ internal annotation class ExperimentalSinceKotoolsTypes(val version: String)
  * integers without leading zeros.
  */
 @MustBeDocumented
-@Retention(BINARY)
+@Retention(SOURCE)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class SinceKotoolsTypes(val version: String)
 
@@ -53,7 +53,7 @@ internal annotation class SinceKotoolsTypes(val version: String)
  * integers without leading zeros.
  */
 @MustBeDocumented
-@Retention(BINARY)
+@Retention(SOURCE)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class DeprecatedSinceKotoolsTypes(
     val warningSince: String,

--- a/src/commonMain/kotlin/kotools/types/Annotations.kt
+++ b/src/commonMain/kotlin/kotools/types/Annotations.kt
@@ -54,6 +54,7 @@ internal annotation class SinceKotoolsTypes(val version: String)
  */
 @MustBeDocumented
 @Retention(SOURCE)
+@Suppress("unused")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class DeprecatedSinceKotoolsTypes(
     val warningSince: String,


### PR DESCRIPTION
This request removes the `ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and the `DeprecatedSinceKotoolsTypes` annotations from the binary output by setting their retention to [SOURCE](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html).