### PR TITLE
Fix documentation of `notEmptyRangeOf` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ more information about how to set up a version catalog with a [TOML] file.
 [TOML + Gradle + project accessors]: https://funkymuse.dev/posts/toml-gradle
 [TOML]: https://toml.io
 
+### Fixed
+
+#### Documentation typo
+
+We've fixed a little typo in the documentation of the `notEmptyRangeOf`
+function (PR [#222]).
+
+[#222]: https://github.com/kotools/types/pull/222
+
 ## 4.3.0
 
 _Release date: 2023-08-14._

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -5,7 +5,7 @@ import kotools.types.experimental.ExperimentalRangeApi
 
 /**
  * Returns a not empty range with the given pair of [bounds].
- * The resulting range will [start][NotEmptyRange.start] with the lower value
+ * The resulting range will [start][NotEmptyRange.start] with the lowest value
  * between the given [bounds].
  */
 @ExperimentalRangeApi


### PR DESCRIPTION
This request fixes a typo in the documentation of the `notEmptyRangeOf` function.