### PR TITLE
Add type converters suffixed by `OrNull` and `OrThrow` for `StrictlyPositiveDouble`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This change applies for the following types:
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
   [@o-korpi] in PR [#167])
+- `StrictlyPositiveDouble` (issue [#132]).
 - `NotBlankString` (issue [#174] fixed by PRs [#182] and [#204]).
 
 Here's an example for the `StrictlyPositiveInt` type:
@@ -58,6 +59,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 ```
 
 [#104]: https://github.com/kotools/types/discussions/104
+[#132]: https://github.com/kotools/types/issues/132
 [#141]: https://github.com/kotools/types/issues/141
 [#149]: https://github.com/kotools/types/issues/149
 [#164]: https://github.com/kotools/types/pull/164

--- a/api/types.api
+++ b/api/types.api
@@ -282,6 +282,8 @@ public final class kotools/types/number/StrictlyPositiveDouble$Companion {
 
 public final class kotools/types/number/StrictlyPositiveDoubleKt {
 	public static final fun toStrictlyPositiveDouble (Ljava/lang/Number;)Ljava/lang/Object;
+	public static final fun toStrictlyPositiveDoubleOrNull (Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveDouble;
+	public static final fun toStrictlyPositiveDoubleOrThrow (Ljava/lang/Number;)D
 }
 
 public final class kotools/types/number/StrictlyPositiveInt : kotools/types/number/NonZeroInt, kotools/types/number/PositiveInt {

--- a/src/commonMain/kotlin/kotools/types/number/Error.kt
+++ b/src/commonMain/kotlin/kotools/types/number/Error.kt
@@ -1,23 +1,30 @@
 package kotools.types.number
 
+import kotools.types.text.NotBlankString
+import kotools.types.text.toNotBlankString
+
 internal sealed class NumberErrorDescription(private val value: String) {
     override fun toString(): String = value
 
     object NonZero : NumberErrorDescription("other than zero")
     object Positive : NumberErrorDescription("positive")
     object Negative : NumberErrorDescription("negative")
-    object StrictlyPositive : NumberErrorDescription("strictly positive")
-    object StrictlyNegative : NumberErrorDescription("strictly negative")
 }
 
 internal val otherThanZero = NumberErrorDescription.NonZero
 internal val aPositiveNumber = NumberErrorDescription.Positive
 internal val aNegativeNumber = NumberErrorDescription.Negative
-internal val aStrictlyPositiveNumber = NumberErrorDescription.StrictlyPositive
-internal val aStrictlyNegativeNumber = NumberErrorDescription.StrictlyNegative
 
 internal infix fun <N : Number> N.shouldBe(
     description: NumberErrorDescription
 ): IllegalArgumentException = IllegalArgumentException(
     "Number should be $description (tried with $this)."
 )
+
+internal class IllegalStrictlyPositiveNumberError(number: Number) {
+    val message: NotBlankString by lazy {
+        "Number should be strictly positive (tried with $number)."
+            .toNotBlankString()
+            .getOrThrow()
+    }
+}

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -52,7 +52,8 @@ public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
-    TODO("Not implemented yet")
+    val value: Double = toDouble()
+    return if (value > 0.0) StrictlyPositiveDouble(value) else null
 }
 
 /**

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -28,6 +28,65 @@ public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
     }
 
 /**
+ * Returns this number as a [StrictlyPositiveDouble], which may involve rounding
+ * or truncation, or returns `null` if this number is negative.
+ *
+ * ```kotlin
+ * val value = 1.0
+ * var result: StrictlyPositiveDouble? = value.toStrictlyPositiveDoubleOrNull()
+ * assertEquals(value, result?.toDouble())
+ *
+ * result = 0.toStrictlyPositiveDoubleOrNull()
+ * assertNull(result)
+ *
+ * result = (-1).toStrictlyPositiveDoubleOrNull()
+ * assertNull(result)
+ * ```
+ *
+ * You can use the [toStrictlyPositiveDoubleOrThrow] function for throwing an
+ * [IllegalArgumentException] instead of returning `null`.
+ *
+ * See the [StrictlyPositiveDouble.toDouble] function for more details on
+ * converting a [StrictlyPositiveDouble] to a [Double].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3.1")
+public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
+    TODO("Not implemented yet")
+}
+
+/**
+ * Returns this number as a [StrictlyPositiveDouble], which may involve rounding
+ * or truncation, or throws [IllegalArgumentException] if this number is
+ * negative.
+ *
+ * ```kotlin
+ * val value = 1.0
+ * val result: StrictlyPositiveDouble = value.toStrictlyPositiveDoubleOrThrow()
+ * assertEquals(value, result.toDouble())
+ *
+ * assertFailsWith<IllegalArgumentException> {
+ *     0.toStrictlyPositiveDoubleOrThrow()
+ * }
+ * assertFailsWith<IllegalArgumentException> {
+ *     (-1).toStrictlyPositiveDoubleOrThrow()
+ * }
+ * ```
+ *
+ * You can use the [toStrictlyPositiveDoubleOrNull] function for returning
+ * `null` instead of throwing an [IllegalArgumentException] when this number is
+ * negative.
+ *
+ * See the [StrictlyPositiveDouble.toDouble] function for more details on
+ * converting a [StrictlyPositiveDouble] to a [Double].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3.1")
+public fun Number.toStrictlyPositiveDoubleOrThrow(): StrictlyPositiveDouble {
+    TODO("Not implemented yet")
+}
+
+/**
  * Represents strictly positive floating-point numbers represented by the
  * [Double] type.
  */

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -142,8 +142,8 @@ internal object StrictlyPositiveDoubleSerializer :
 
     override fun deserialize(decoder: Decoder): StrictlyPositiveDouble {
         val value: Double = decoder.decodeDouble()
-        return value.toStrictlyPositiveDoubleOrNull() ?: value.let {
-            val error = IllegalStrictlyPositiveNumberError(it)
+        return value.toStrictlyPositiveDoubleOrNull() ?: Unit.let {
+            val error = IllegalStrictlyPositiveNumberError(value)
             throw SerializationException("${error.message}")
         }
     }

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -84,7 +84,9 @@ public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyPositiveDoubleOrThrow(): StrictlyPositiveDouble {
-    TODO("Not implemented yet")
+    val value: Double = toDouble()
+    require(value > 0.0) { value shouldBe aStrictlyPositiveNumber }
+    return StrictlyPositiveDouble(value)
 }
 
 /**

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -9,6 +9,8 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotools.types.Package
 import kotools.types.experimental.ExperimentalNumberApi
+import kotools.types.shouldBeNotNull
+import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotlin.random.Random
@@ -38,6 +40,23 @@ class StrictlyPositiveDoubleTest {
         assertFailsWith<IllegalArgumentException> { result.getOrThrow() }
             .shouldHaveAMessage()
     }
+
+    @Test
+    fun toStrictlyPositiveDoubleOrNull_should_pass_with_a_strictly_positive_Double() {
+        val value: Number =
+            Random.nextDouble(from = 0.1, until = Double.MAX_VALUE)
+        value.toStrictlyPositiveDoubleOrNull()
+            .shouldBeNotNull()
+            .toDouble()
+            .shouldEqual(value)
+    }
+
+    @Test
+    fun toStrictlyPositiveDoubleOrNull_should_fail_with_a_negative_Double(): Unit =
+        Random.nextDouble(from = 0.1, until = Double.MAX_VALUE)
+            .unaryMinus()
+            .toStrictlyPositiveDoubleOrNull()
+            .shouldBeNull()
 
     @Test
     fun compareTo_should_return_zero_with_the_same_StrictlyPositiveDouble() {

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -20,6 +20,26 @@ import kotlin.test.assertTrue
 @ExperimentalNumberApi
 class StrictlyPositiveDoubleTest {
     @Test
+    fun toStrictlyPositiveDouble_should_pass_with_a_strictly_positive_Number() {
+        val value: Number =
+            Random.nextDouble(from = 0.1, until = Double.MAX_VALUE)
+        val result: Result<StrictlyPositiveDouble> =
+            value.toStrictlyPositiveDouble()
+        result.getOrThrow().toDouble() shouldEqual value
+    }
+
+    @Test
+    fun toStrictlyPositiveDouble_should_fail_with_a_negative_Number() {
+        val value: Number = Random
+            .nextDouble(from = 0.1, until = Double.MAX_VALUE)
+            .unaryMinus()
+        val result: Result<StrictlyPositiveDouble> =
+            value.toStrictlyPositiveDouble()
+        assertFailsWith<IllegalArgumentException> { result.getOrThrow() }
+            .shouldHaveAMessage()
+    }
+
+    @Test
     fun compareTo_should_return_zero_with_the_same_StrictlyPositiveDouble() {
         val x: StrictlyPositiveDouble = Random.nextDouble()
             .toStrictlyPositiveDouble()
@@ -65,27 +85,6 @@ class StrictlyPositiveDoubleTest {
             .toString()
             .shouldEqual("$value")
     }
-
-    @Test
-    fun number_toStrictlyPositiveDouble_should_pass_with_a_strictly_positive_Number() {
-        val value: Number =
-            Random.nextDouble(from = 0.1, until = Double.MAX_VALUE)
-        val result: Result<StrictlyPositiveDouble> =
-            value.toStrictlyPositiveDouble()
-        result.getOrThrow()
-            .toDouble()
-            .shouldEqual(value)
-    }
-
-    @Test
-    fun number_toStrictlyPositiveDouble_should_fail_with_a_negative_Number(): Unit =
-        Random.nextDouble(from = 0.1, until = Double.MAX_VALUE)
-            .unaryMinus()
-            .toStrictlyPositiveDouble()
-            .run {
-                assertFailsWith<IllegalArgumentException>(block = ::getOrThrow)
-            }
-            .shouldHaveAMessage()
 }
 
 @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -59,6 +59,25 @@ class StrictlyPositiveDoubleTest {
             .shouldBeNull()
 
     @Test
+    fun toStrictlyPositiveDoubleOrThrow_should_pass_with_a_strictly_positive_Double() {
+        val value: Number =
+            Random.nextDouble(from = 0.1, until = Double.MAX_VALUE)
+        value.toStrictlyPositiveDoubleOrThrow()
+            .toDouble()
+            .shouldEqual(value)
+    }
+
+    @Test
+    fun toStrictlyPositiveDoubleOrThrow_should_fail_with_a_negative_Double() {
+        val value: Number = Random
+            .nextDouble(from = 0.1, until = Double.MAX_VALUE)
+            .unaryMinus()
+        assertFailsWith<IllegalArgumentException> {
+            value.toStrictlyPositiveDoubleOrThrow()
+        }.shouldHaveAMessage()
+    }
+
+    @Test
     fun compareTo_should_return_zero_with_the_same_StrictlyPositiveDouble() {
         val x: StrictlyPositiveDouble = Random.nextDouble()
             .toStrictlyPositiveDouble()

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -72,9 +72,13 @@ class StrictlyPositiveDoubleTest {
         val value: Number = Random
             .nextDouble(from = 0.1, until = Double.MAX_VALUE)
             .unaryMinus()
-        assertFailsWith<IllegalArgumentException> {
+        val exception: IllegalArgumentException = assertFailsWith {
             value.toStrictlyPositiveDoubleOrThrow()
-        }.shouldHaveAMessage()
+        }
+        val expectedMessage: String = IllegalStrictlyPositiveNumberError(value)
+            .message
+            .toString()
+        exception.message shouldEqual expectedMessage
     }
 
     @Test


### PR DESCRIPTION
This request fixes #132 by adding the `toStrictlyPositiveDoubleOrNull` and the `toStrictlyPositiveDoubleOrThrow` functions as **experimental** features.