### PR TITLE
Fix documentation of type converters suffixed by `OrNull` and `OrThrow` for `StrictlyPositiveDouble`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This change applies for the following types:
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
   [@o-korpi] in PR [#167])
-- `StrictlyPositiveDouble` (issue [#132] fixed by PR [#233])
+- `StrictlyPositiveDouble` (issue [#132] fixed by PRs [#233] and [#235])
 - `NotBlankString` (issue [#174] fixed by PRs [#182] and [#204]).
 
 Here's an example for the `StrictlyPositiveInt` type:
@@ -71,6 +71,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#203]: https://github.com/kotools/types/pull/203
 [#204]: https://github.com/kotools/types/pull/204
 [#233]: https://github.com/kotools/types/pull/233
+[#235]: https://github.com/kotools/types/pull/235
 [@o-korpi]: https://github.com/o-korpi
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ This change applies for the following types:
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
   [@o-korpi] in PR [#167])
-- `StrictlyPositiveDouble` (issue [#132]).
+- `StrictlyPositiveDouble` (issue [#132] fixed by PR [#233])
 - `NotBlankString` (issue [#174] fixed by PRs [#182] and [#204]).
 
 Here's an example for the `StrictlyPositiveInt` type:
@@ -70,6 +70,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#202]: https://github.com/kotools/types/pull/202
 [#203]: https://github.com/kotools/types/pull/203
 [#204]: https://github.com/kotools/types/pull/204
+[#233]: https://github.com/kotools/types/pull/233
 [@o-korpi]: https://github.com/o-korpi
 
 ### Changed

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -33,22 +33,18 @@ public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
  * or truncation, or returns `null` if this number is negative.
  *
  * ```kotlin
- * val value = 1.0
- * var result: StrictlyPositiveDouble? = value.toStrictlyPositiveDoubleOrNull()
- * assertEquals(value, result?.toDouble())
+ * var result: StrictlyPositiveDouble? = 1.toStrictlyPositiveDoubleOrNull()
+ * println(result) // 1.0
  *
  * result = 0.toStrictlyPositiveDoubleOrNull()
- * assertNull(result)
+ * println(result) // null
  *
  * result = (-1).toStrictlyPositiveDoubleOrNull()
- * assertNull(result)
+ * println(result) // null
  * ```
  *
  * You can use the [toStrictlyPositiveDoubleOrThrow] function for throwing an
  * [IllegalArgumentException] instead of returning `null`.
- *
- * See the [StrictlyPositiveDouble.toDouble] function for more details on
- * converting a [StrictlyPositiveDouble] to a [Double].
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -60,24 +60,16 @@ public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
  * negative.
  *
  * ```kotlin
- * val value = 1.0
- * val result: StrictlyPositiveDouble = value.toStrictlyPositiveDoubleOrThrow()
- * assertEquals(value, result.toDouble())
+ * val result: StrictlyPositiveDouble = 1.toStrictlyPositiveDoubleOrThrow()
+ * println(result) // 1.0
  *
- * assertFailsWith<IllegalArgumentException> {
- *     0.toStrictlyPositiveDoubleOrThrow()
- * }
- * assertFailsWith<IllegalArgumentException> {
- *     (-1).toStrictlyPositiveDoubleOrThrow()
- * }
+ * 0.toStrictlyPositiveDoubleOrThrow() // IllegalArgumentException
+ * (-1).toStrictlyPositiveDoubleOrThrow() // IllegalArgumentException
  * ```
  *
  * You can use the [toStrictlyPositiveDoubleOrNull] function for returning
  * `null` instead of throwing an [IllegalArgumentException] when this number is
  * negative.
- *
- * See the [StrictlyPositiveDouble.toDouble] function for more details on
- * converting a [StrictlyPositiveDouble] to a [Double].
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")


### PR DESCRIPTION
This request closes #132 by fixing the documentation of the `toStrictlyPositiveDoubleOrNull` and the `toStrictlyPositiveDoubleOrThrow` functions.