### PR TITLE
Add type converters suffixed by `OrNull` and `OrThrow` for `PositiveInt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ should return `null` if the builder is suffixed by `OrNull` or throw an
 exception if it's suffixed by `OrThrow`.
 This change applies for the following types:
 
-- `PositiveInt` (issue [#155])
+- `PositiveInt` (issue [#155] fixed by PR [#236])
 - `NegativeInt` (issue [#171])
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
@@ -76,6 +76,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#204]: https://github.com/kotools/types/pull/204
 [#233]: https://github.com/kotools/types/pull/233
 [#235]: https://github.com/kotools/types/pull/235
+[#236]: https://github.com/kotools/types/pull/236
 [@o-korpi]: https://github.com/o-korpi
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ should return `null` if the builder is suffixed by `OrNull` or throw an
 exception if it's suffixed by `OrThrow`.
 This change applies for the following types:
 
+- `PositiveInt` (issue [#155])
 - `NegativeInt` (issue [#171])
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
@@ -63,6 +64,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#132]: https://github.com/kotools/types/issues/132
 [#141]: https://github.com/kotools/types/issues/141
 [#149]: https://github.com/kotools/types/issues/149
+[#155]: https://github.com/kotools/types/issues/155
 [#164]: https://github.com/kotools/types/pull/164
 [#167]: https://github.com/kotools/types/pull/167
 [#171]: https://github.com/kotools/types/issues/171

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ should return `null` if the builder is suffixed by `OrNull` or throw an
 exception if it's suffixed by `OrThrow`.
 This change applies for the following types:
 
+- `NegativeInt` (issue [#171])
 - `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
 - `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
   [@o-korpi] in PR [#167])
@@ -64,6 +65,7 @@ Here's an example for the `StrictlyPositiveInt` type:
 [#149]: https://github.com/kotools/types/issues/149
 [#164]: https://github.com/kotools/types/pull/164
 [#167]: https://github.com/kotools/types/pull/167
+[#171]: https://github.com/kotools/types/issues/171
 [#174]: https://github.com/kotools/types/issues/174
 [#181]: https://github.com/kotools/types/pull/181
 [#182]: https://github.com/kotools/types/pull/182

--- a/api/types.api
+++ b/api/types.api
@@ -171,6 +171,8 @@ public final class kotools/types/number/NegativeIntKt {
 	public static final fun div-Vo0Sc0k (Lkotools/types/number/NegativeInt;I)Lkotools/types/number/NegativeInt;
 	public static final fun rem (Lkotools/types/number/NegativeInt;Lkotools/types/number/NonZeroInt;)Lkotools/types/number/NegativeInt;
 	public static final fun toNegativeInt (Ljava/lang/Number;)Ljava/lang/Object;
+	public static final fun toNegativeIntOrNull (Ljava/lang/Number;)Lkotools/types/number/NegativeInt;
+	public static final fun toNegativeIntOrThrow (Ljava/lang/Number;)Lkotools/types/number/NegativeInt;
 	public static final fun unaryMinus (Lkotools/types/number/NegativeInt;)Lkotools/types/number/PositiveInt;
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -225,6 +225,8 @@ public final class kotools/types/number/PositiveIntKt {
 	public static final fun div-Vo0Sc0k (Lkotools/types/number/PositiveInt;I)Lkotools/types/number/PositiveInt;
 	public static final fun rem (Lkotools/types/number/PositiveInt;Lkotools/types/number/NonZeroInt;)Lkotools/types/number/PositiveInt;
 	public static final fun toPositiveInt (Ljava/lang/Number;)Ljava/lang/Object;
+	public static final fun toPositiveIntOrNull (Ljava/lang/Number;)Lkotools/types/number/PositiveInt;
+	public static final fun toPositiveIntOrThrow (Ljava/lang/Number;)Lkotools/types/number/PositiveInt;
 	public static final fun unaryMinus (Lkotools/types/number/PositiveInt;)Lkotools/types/number/NegativeInt;
 }
 

--- a/src/commonMain/kotlin/kotools/types/number/Error.kt
+++ b/src/commonMain/kotlin/kotools/types/number/Error.kt
@@ -8,12 +8,10 @@ internal sealed class NumberErrorDescription(private val value: String) {
 
     object NonZero : NumberErrorDescription("other than zero")
     object Positive : NumberErrorDescription("positive")
-    object Negative : NumberErrorDescription("negative")
 }
 
 internal val otherThanZero = NumberErrorDescription.NonZero
 internal val aPositiveNumber = NumberErrorDescription.Positive
-internal val aNegativeNumber = NumberErrorDescription.Negative
 
 internal infix fun <N : Number> N.shouldBe(
     description: NumberErrorDescription

--- a/src/commonMain/kotlin/kotools/types/number/Error.kt
+++ b/src/commonMain/kotlin/kotools/types/number/Error.kt
@@ -7,11 +7,9 @@ internal sealed class NumberErrorDescription(private val value: String) {
     override fun toString(): String = value
 
     object NonZero : NumberErrorDescription("other than zero")
-    object Positive : NumberErrorDescription("positive")
 }
 
 internal val otherThanZero = NumberErrorDescription.NonZero
-internal val aPositiveNumber = NumberErrorDescription.Positive
 
 internal infix fun <N : Number> N.shouldBe(
     description: NumberErrorDescription

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -56,7 +56,7 @@ public fun Number.toNegativeIntOrNull(): NegativeInt? {
     val value: Int = toInt()
     return when {
         value == 0 -> ZeroInt
-        value < 0 -> StrictlyNegativeInt(value)
+        value.isStrictlyNegative() -> StrictlyNegativeInt(value)
         else -> null
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -27,6 +27,57 @@ public fun Number.toNegativeInt(): Result<NegativeInt> {
     }
 }
 
+/**
+ * Returns this number as a [NegativeInt], which may involve rounding or
+ * truncation, or returns `null` if this number is
+ * [strictly positive][StrictlyPositiveInt].
+ *
+ * ```kotlin
+ * var result: NegativeInt? = (-1).toNegativeIntOrNull()
+ * println(result) // -1
+ *
+ * result = 0.toNegativeIntOrNull()
+ * println(result) // 0
+ *
+ * result = 1.toNegativeIntOrNull()
+ * println(result) // null
+ * ```
+ *
+ * You can use the [toNegativeIntOrThrow] function for throwing an
+ * [IllegalArgumentException] instead of returning `null` when this number is
+ * [strictly positive][StrictlyPositiveInt].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3.1")
+public fun Number.toNegativeIntOrNull(): NegativeInt? {
+    TODO()
+}
+
+/**
+ * Returns this number as a [NegativeInt], which may involve rounding or
+ * truncation, or throws [IllegalArgumentException] if this number is
+ * [strictly positive][StrictlyPositiveInt].
+ *
+ * ```kotlin
+ * var result: NegativeInt = (-1).toNegativeIntOrThrow()
+ * println(result) // -1
+ *
+ * result = 0.toNegativeIntOrThrow()
+ * println(result) // 0
+ *
+ * 1.toNegativeIntOrThrow() // IllegalArgumentException
+ * ```
+ *
+ * You can use the [toNegativeIntOrNull] function for returning `null` instead
+ * of throwing an [IllegalArgumentException] when this number is
+ * [strictly positive][StrictlyPositiveInt].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3.1")
+public fun Number.toNegativeIntOrThrow(): NegativeInt {
+    TODO()
+}
+
 /** Representation of negative integers including [zero][ZeroInt]. */
 @Serializable(NegativeIntSerializer::class)
 @SinceKotoolsTypes("1.1")

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -22,7 +22,7 @@ public fun Number.toNegativeInt(): Result<NegativeInt> {
     val value: Int = toInt()
     return when {
         value == 0 -> Result.success(ZeroInt)
-        value < 0 -> value.toStrictlyNegativeInt()
+        value.isStrictlyNegative() -> value.toStrictlyNegativeInt()
         else -> {
             val exception = NegativeIntConstructionException(value)
             Result.failure(exception)

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -79,9 +79,8 @@ public fun Number.toNegativeIntOrNull(): NegativeInt? {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toNegativeIntOrThrow(): NegativeInt {
-    TODO()
-}
+public fun Number.toNegativeIntOrThrow(): NegativeInt =
+    toNegativeIntOrNull() ?: throw shouldBe(aNegativeNumber)
 
 /** Representation of negative integers including [zero][ZeroInt]. */
 @Serializable(NegativeIntSerializer::class)

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -108,7 +108,8 @@ public sealed interface NegativeInt : AnyInt {
 
         /** Returns a random [NegativeInt]. */
         @SinceKotoolsTypes("3.0")
-        public fun random(): NegativeInt = (min.toInt()..max.toInt()).random()
+        public fun random(): NegativeInt = (min.toInt()..max.toInt())
+            .random()
             .toNegativeInt()
             .getOrThrow()
     }

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -92,9 +92,7 @@ public sealed interface NegativeInt : AnyInt {
     /** Contains declarations for holding or building a [NegativeInt]. */
     public companion object {
         /** The minimum value a [NegativeInt] can have. */
-        public val min: StrictlyNegativeInt by lazy(
-            StrictlyNegativeInt.Companion::min
-        )
+        public val min: StrictlyNegativeInt by lazy { StrictlyNegativeInt.min }
 
         /** The maximum value a [NegativeInt] can have. */
         public val max: ZeroInt = ZeroInt

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -50,7 +50,12 @@ public fun Number.toNegativeInt(): Result<NegativeInt> {
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toNegativeIntOrNull(): NegativeInt? {
-    TODO()
+    val value: Int = toInt()
+    return when {
+        value == 0 -> ZeroInt
+        value < 0 -> StrictlyNegativeInt(value)
+        else -> null
+    }
 }
 
 /**

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -27,6 +27,57 @@ public fun Number.toPositiveInt(): Result<PositiveInt> {
     }
 }
 
+/**
+ * Returns this number as a [PositiveInt], which may involve rounding or
+ * truncation, or returns `null` if this number is
+ * [strictly negative][StrictlyNegativeInt].
+ *
+ * ```kotlin
+ * var result: PositiveInt? = 1.toPositiveIntOrNull()
+ * println(result) // 1
+ *
+ * result = 0.toPositiveIntOrNull()
+ * println(result) // 0
+ *
+ * result = (-1).toPositiveIntOrNull()
+ * println(result) // null
+ * ```
+ *
+ * You can use the [toPositiveIntOrThrow] function for throwing an
+ * [IllegalArgumentException] instead of returning `null` when this number is
+ * [strictly negative][StrictlyNegativeInt].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3.1")
+public fun Number.toPositiveIntOrNull(): PositiveInt? {
+    TODO()
+}
+
+/**
+ * Returns this number as a [PositiveInt], which may involve rounding or
+ * truncation, or throws [IllegalArgumentException] if this number is
+ * [strictly negative][StrictlyNegativeInt].
+ *
+ * ```kotlin
+ * var result: PositiveInt = 1.toPositiveIntOrThrow()
+ * println(result) // 1
+ *
+ * result = 0.toPositiveIntOrThrow()
+ * println(result) // 0
+ *
+ * (-1).toPositiveIntOrThrow() // IllegalArgumentException
+ * ```
+ *
+ * You can use the [toPositiveIntOrNull] function for returning `null` instead
+ * of throwing an [IllegalArgumentException] when this number is
+ * [strictly negative][StrictlyNegativeInt].
+ */
+@ExperimentalNumberApi
+@ExperimentalSinceKotoolsTypes("4.3.1")
+public fun Number.toPositiveIntOrThrow(): PositiveInt {
+    TODO()
+}
+
 /** Representation of positive integers including [zero][ZeroInt]. */
 @Serializable(PositiveIntSerializer::class)
 @SinceKotoolsTypes("1.1")

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -79,9 +79,8 @@ public fun Number.toPositiveIntOrNull(): PositiveInt? {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toPositiveIntOrThrow(): PositiveInt {
-    TODO()
-}
+public fun Number.toPositiveIntOrThrow(): PositiveInt =
+    toStrictlyPositiveIntOrNull() ?: throw shouldBe(aPositiveNumber)
 
 /** Representation of positive integers including [zero][ZeroInt]. */
 @Serializable(PositiveIntSerializer::class)

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -82,9 +82,11 @@ public fun Number.toPositiveIntOrNull(): PositiveInt? {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toPositiveIntOrThrow(): PositiveInt =
-    toStrictlyPositiveIntOrNull()
-        ?: throw PositiveIntConstructionException(this)
+public fun Number.toPositiveIntOrThrow(): PositiveInt {
+    val value: Int = toInt()
+    require(value >= 0) { PositiveIntConstructionException(value).message }
+    return if (value == 0) ZeroInt else StrictlyPositiveInt(value)
+}
 
 /** Representation of positive integers including [zero][ZeroInt]. */
 @Serializable(PositiveIntSerializer::class)

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -98,9 +98,7 @@ public sealed interface PositiveInt : AnyInt {
         public val min: ZeroInt = ZeroInt
 
         /** The maximum value a [PositiveInt] can have. */
-        public val max: StrictlyPositiveInt by lazy(
-            StrictlyPositiveInt.Companion::max
-        )
+        public val max: StrictlyPositiveInt by lazy { StrictlyPositiveInt.max }
 
         /** The range of values a [PositiveInt] can have. */
         @ExperimentalRangeApi

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -21,8 +21,8 @@ import kotools.types.text.toNotBlankString
 public fun Number.toPositiveInt(): Result<PositiveInt> {
     val value: Int = toInt()
     return when {
-        value == ZeroInt.toInt() -> Result.success(ZeroInt)
-        value > ZeroInt.toInt() -> value.toStrictlyPositiveInt()
+        value == 0 -> Result.success(ZeroInt)
+        value.isStrictlyPositive() -> value.toStrictlyPositiveInt()
         else -> {
             val exception = PositiveIntConstructionException(value)
             Result.failure(exception)

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -56,7 +56,7 @@ public fun Number.toPositiveIntOrNull(): PositiveInt? {
     val value: Int = toInt()
     return when {
         value == 0 -> ZeroInt
-        value > 0 -> StrictlyPositiveInt(value)
+        value.isStrictlyPositive() -> StrictlyPositiveInt(value)
         else -> null
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -50,7 +50,12 @@ public fun Number.toPositiveInt(): Result<PositiveInt> {
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toPositiveIntOrNull(): PositiveInt? {
-    TODO()
+    val value: Int = toInt()
+    return when {
+        value == 0 -> ZeroInt
+        value > 0 -> StrictlyPositiveInt(value)
+        else -> null
+    }
 }
 
 /**

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -12,8 +12,10 @@ import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
-private fun Int.isStrictlyNegative(): Boolean = this < 0
+@JvmSynthetic
+internal fun Int.isStrictlyNegative(): Boolean = this < 0
 
 /**
  * Returns this number as an encapsulated [StrictlyNegativeInt], which may

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -12,8 +12,10 @@ import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
-private fun Int.isStrictlyPositive(): Boolean = this > 0
+@JvmSynthetic
+internal fun Int.isStrictlyPositive(): Boolean = this > 0
 
 /**
  * Returns this number as an encapsulated [StrictlyPositiveInt], which may

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -12,8 +12,11 @@ import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
+import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class NegativeIntCompanionTest {
@@ -54,22 +57,24 @@ class NegativeIntCompanionTest {
 
 class NegativeIntTest {
     @Test
-    fun number_toNegativeInt_should_pass_with_a_negative_Int() {
-        val value: Number = NegativeInt.random()
+    fun toNegativeInt_should_pass_with_a_negative_Int() {
+        val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val result: Result<NegativeInt> = number.toNegativeInt()
+        val actual: Int = result.getOrThrow()
             .toInt()
-        val result: Int = value.toNegativeInt()
-            .getOrThrow()
-            .toInt()
-        result shouldEqual value
+        assertEquals(expected = number, actual)
     }
 
     @Test
-    fun number_toNegativeInt_should_fail_with_a_strictly_positive_Int() {
-        val value: Number = StrictlyPositiveInt.random()
-            .toInt()
-        val result: Result<NegativeInt> = value.toNegativeInt()
-        assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
-            .shouldHaveAMessage()
+    fun toNegativeInt_should_fail_with_a_strictly_positive_Int() {
+        val number: Number = Random.nextInt(from = 1, until = Int.MAX_VALUE)
+        val result: Result<NegativeInt> = number.toNegativeInt()
+        val exception: IllegalArgumentException = assertFailsWith {
+            result.getOrThrow()
+        }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String? = number.shouldBe(aNegativeNumber).message
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -74,7 +74,8 @@ class NegativeIntTest {
             result.getOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String? = number.shouldBe(aNegativeNumber).message
+        val expectedMessage: String = NegativeIntConstructionException(number)
+            .message
         assertEquals(expectedMessage, actualMessage)
     }
 
@@ -113,7 +114,8 @@ class NegativeIntTest {
             number.toNegativeIntOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String? = number.shouldBe(aNegativeNumber).message
+        val expectedMessage: String = NegativeIntConstructionException(number)
+            .message
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -98,6 +98,27 @@ class NegativeIntTest {
 
     @ExperimentalNumberApi
     @Test
+    fun toNegativeIntOrThrow_should_pass_with_a_negative_Int() {
+        val expected: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val result: NegativeInt = expected.toNegativeIntOrThrow()
+        val actual: Int = result.toInt()
+        assertEquals(expected, actual)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toNegativeIntOrThrow_should_fail_with_a_strictly_positive_Int() {
+        val number: Number = Random.nextInt(from = 1, until = Int.MAX_VALUE)
+        val exception: IllegalArgumentException = assertFailsWith {
+            number.toNegativeIntOrThrow()
+        }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String? = number.shouldBe(aNegativeNumber).message
+        assertEquals(expectedMessage, actualMessage)
+    }
+
+    @ExperimentalNumberApi
+    @Test
     fun unaryMinus_should_pass() {
         // GIVEN
         val x: NegativeInt = NegativeInt.random()

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class NegativeIntCompanionTest {
@@ -58,11 +59,11 @@ class NegativeIntCompanionTest {
 class NegativeIntTest {
     @Test
     fun toNegativeInt_should_pass_with_a_negative_Int() {
-        val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
-        val result: Result<NegativeInt> = number.toNegativeInt()
+        val expected: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val result: Result<NegativeInt> = expected.toNegativeInt()
         val actual: Int = result.getOrThrow()
             .toInt()
-        assertEquals(expected = number, actual)
+        assertEquals(expected, actual)
     }
 
     @Test
@@ -75,6 +76,24 @@ class NegativeIntTest {
         val actualMessage: String = assertNotNull(exception.message)
         val expectedMessage: String? = number.shouldBe(aNegativeNumber).message
         assertEquals(expectedMessage, actualMessage)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toNegativeIntOrNull_should_pass_with_a_negative_Int() {
+        val expected: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val result: NegativeInt? = expected.toNegativeIntOrNull()
+        val x: NegativeInt = assertNotNull(result)
+        val actual: Int = x.toInt()
+        assertEquals(expected, actual)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toNegativeIntOrNull_should_fail_with_a_strictly_positive_Int() {
+        val number: Number = Random.nextInt(from = 1, until = Int.MAX_VALUE)
+        val result: NegativeInt? = number.toNegativeIntOrNull()
+        assertNull(result)
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -75,7 +75,8 @@ class PositiveIntTest {
             result.getOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String? = number.shouldBe(aPositiveNumber).message
+        val expectedMessage: String = PositiveIntConstructionException(number)
+            .message
         assertEquals(expectedMessage, actualMessage)
     }
 
@@ -114,7 +115,8 @@ class PositiveIntTest {
             number.toPositiveIntOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String? = number.shouldBe(aPositiveNumber).message
+        val expectedMessage: String = PositiveIntConstructionException(number)
+            .message
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -75,7 +75,7 @@ class PositiveIntTest {
             result.getOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage = "Number should be positive (tried with $number)."
+        val expectedMessage: String? = number.shouldBe(aPositiveNumber).message
         assertEquals(expectedMessage, actualMessage)
     }
 
@@ -95,6 +95,27 @@ class PositiveIntTest {
         val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
         val result: PositiveInt? = number.toPositiveIntOrNull()
         assertNull(result)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toPositiveIntOrThrow_should_pass_with_a_positive_Int() {
+        val expected: Number = Random.nextInt(from = 0, until = Int.MAX_VALUE)
+        val result: PositiveInt = expected.toPositiveIntOrThrow()
+        val actual: Int = result.toInt()
+        assertEquals(expected, actual)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toPositiveIntOrThrow_should_fail_with_a_strictly_negative_Int() {
+        val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val exception: IllegalArgumentException = assertFailsWith {
+            number.toPositiveIntOrThrow()
+        }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String? = number.shouldBe(aPositiveNumber).message
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class PositiveIntCompanionTest {
@@ -76,6 +77,24 @@ class PositiveIntTest {
         val actualMessage: String = assertNotNull(exception.message)
         val expectedMessage = "Number should be positive (tried with $number)."
         assertEquals(expectedMessage, actualMessage)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toPositiveIntOrNull_should_pass_with_a_positive_Int() {
+        val expected: Number = Random.nextInt(from = 0, until = Int.MAX_VALUE)
+        val result: PositiveInt? = expected.toPositiveIntOrNull()
+        val x: PositiveInt = assertNotNull(result)
+        val actual: Int = x.toInt()
+        assertEquals(expected, actual)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun toPositiveIntOrNull_should_fail_with_a_strictly_negative_Int() {
+        val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val result: PositiveInt? = number.toPositiveIntOrNull()
+        assertNull(result)
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -13,8 +13,11 @@ import kotools.types.range.NotEmptyRange
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
+import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class PositiveIntCompanionTest {
@@ -55,18 +58,24 @@ class PositiveIntCompanionTest {
 
 class PositiveIntTest {
     @Test
-    fun number_toPositiveInt_should_pass_with_a_positive_Int() {
-        val expected: Number = PositiveInt.random().toInt()
+    fun toPositiveInt_should_pass_with_a_positive_Int() {
+        val expected: Number = Random.nextInt(from = 0, until = Int.MAX_VALUE)
         val result: Result<PositiveInt> = expected.toPositiveInt()
-        result.getOrThrow().toInt() shouldEqual expected
+        val actual: Int = result.getOrThrow()
+            .toInt()
+        assertEquals(expected, actual)
     }
 
     @Test
-    fun number_toPositiveInt_should_fail_with_a_strictly_negative_Int() {
-        val number: Number = StrictlyNegativeInt.random().toInt()
+    fun toPositiveInt_should_fail_with_a_strictly_negative_Int() {
+        val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
         val result: Result<PositiveInt> = number.toPositiveInt()
-        assertFailsWith<IllegalArgumentException>(block = result::getOrThrow)
-            .shouldHaveAMessage()
+        val exception: IllegalArgumentException = assertFailsWith {
+            result.getOrThrow()
+        }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage = "Number should be positive (tried with $number)."
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi


### PR DESCRIPTION
This request closes #155 by adding the `toPositiveIntOrNull` and the `toPositiveIntOrThrow` functions as **experimental** declarations.
Also, it includes some refactoring for the `PositiveInt` type.
