### PR TITLE
Hide internal declarations from Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,9 @@ All notable changes to this project will be documented in this file.
 
 Because the Kotlin compiler transforms the `internal` keyword to `public` for 
 the JVM platform, we've hidden some internal declarations from Java by marking 
-them with the [JvmSynthetic] annotation (PR [#246]).
+them with the [JvmSynthetic] annotation (issue [#234] fixed by PR [#246]).
 
+[#234]: https://github.com/kotools/types/issues/234
 [#246]: https://github.com/kotools/types/pull/246
 [JvmSynthetic]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-synthetic
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@ the JVM platform, we've hidden some internal declarations from Java by marking
 them with the [JvmSynthetic] annotation.
 Currently, only internal packages constants were updated with this issue in 
 mind: the [JvmSynthetic] annotation can be used on very specific targets, like
-functions or properties.
+functions or properties (PR [#246]).
 
+[#246]: https://github.com/kotools/types/pull/246
 [JvmSynthetic]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-synthetic
 
 ## 4.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Security
+
+#### Hiding some internal declarations from Java
+
+Because the Kotlin compiler transforms the `internal` keyword to `public` for 
+the JVM platform, we've hidden some internal declarations from Java by marking 
+them with the [JvmSynthetic] annotation.
+Currently, only internal packages constants were updated with this issue in 
+mind: the [JvmSynthetic] annotation can be used on very specific targets, like
+functions or properties.
+
+[JvmSynthetic]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-synthetic
+
 ## 4.3.1
 
 _Release date: 2023-09-25._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,7 @@ All notable changes to this project will be documented in this file.
 
 Because the Kotlin compiler transforms the `internal` keyword to `public` for 
 the JVM platform, we've hidden some internal declarations from Java by marking 
-them with the [JvmSynthetic] annotation.
-Currently, only internal packages constants were updated with this issue in 
-mind: the [JvmSynthetic] annotation can be used on very specific targets, like
-functions or properties (PR [#246]).
+them with the [JvmSynthetic] annotation (PR [#246]).
 
 [#246]: https://github.com/kotools/types/pull/246
 [JvmSynthetic]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-synthetic

--- a/api/types.api
+++ b/api/types.api
@@ -351,6 +351,7 @@ public final class kotools/types/range/ExclusiveBound : kotools/types/range/Boun
 }
 
 public final class kotools/types/range/InclusiveBound : kotools/types/range/Bound {
+	public synthetic fun <init> (Ljava/lang/Comparable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getValue ()Ljava/lang/Comparable;
 	public fun toString ()Ljava/lang/String;
 }

--- a/api/types.api
+++ b/api/types.api
@@ -358,6 +358,7 @@ public final class kotools/types/range/InclusiveBound : kotools/types/range/Boun
 }
 
 public final class kotools/types/range/NotEmptyRange {
+	public synthetic fun <init> (Lkotools/types/range/Bound;Lkotools/types/range/Bound;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEnd ()Lkotools/types/range/Bound;
 	public final fun getStart ()Lkotools/types/range/Bound;
 	public fun toString ()Ljava/lang/String;

--- a/api/types.api
+++ b/api/types.api
@@ -346,6 +346,7 @@ public abstract interface class kotools/types/range/Bound {
 }
 
 public final class kotools/types/range/ExclusiveBound : kotools/types/range/Bound {
+	public synthetic fun <init> (Ljava/lang/Comparable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getValue ()Ljava/lang/Comparable;
 	public fun toString ()Ljava/lang/String;
 }

--- a/src/commonMain/kotlin/kotools/types/Package.kt
+++ b/src/commonMain/kotlin/kotools/types/Package.kt
@@ -1,9 +1,11 @@
 package kotools.types
 
-internal object Package {
-    private const val root: String = "kotools.types"
-    const val collection: String = "$root.collection"
-    const val experimental: String = "$root.experimental"
-    const val number: String = "$root.number"
-    const val text: String = "$root.text"
-}
+import kotlin.jvm.JvmSynthetic
+
+private const val ROOT_PACKAGE: String = "kotools.types"
+
+@JvmSynthetic
+internal const val NUMBER_PACKAGE: String = "$ROOT_PACKAGE.number"
+
+@JvmSynthetic
+internal const val TEXT_PACKAGE: String = "$ROOT_PACKAGE.text"

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyCollection.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyCollection.kt
@@ -6,6 +6,11 @@ import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.ZeroInt
 import kotools.types.number.plus
 import kotools.types.number.toStrictlyPositiveInt
+import kotlin.jvm.JvmSynthetic
+
+@JvmSynthetic
+internal const val EMPTY_COLLECTION_ERROR_MESSAGE: String =
+    "Given collection shouldn't be empty."
 
 /**
  * Representation of collections containing at least one element of type [E].
@@ -74,7 +79,3 @@ public sealed interface NotEmptyCollection<out E> {
 @SinceKotoolsTypes("4.1")
 public val NotEmptyCollection<*>?.sizeOrZero: PositiveInt
     get() = this?.size ?: ZeroInt
-
-internal object EmptyCollectionException : IllegalArgumentException() {
-    override val message: String = "Given collection shouldn't be empty."
-}

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -169,7 +169,7 @@ public value class NotEmptyList<out E> private constructor(
 
     init {
         val isValid: Boolean = elements.isNotEmpty()
-        require(isValid) { EmptyCollectionException.message }
+        require(isValid) { EMPTY_COLLECTION_ERROR_MESSAGE }
     }
 
     /**
@@ -213,5 +213,5 @@ internal class NotEmptyListSerializer<E>(elementSerializer: KSerializer<E>) :
         .decodeSerializableValue(delegate)
         .toNotEmptyList()
         .getOrNull()
-        ?: throw SerializationException(EmptyCollectionException)
+        ?: throw SerializationException(EMPTY_COLLECTION_ERROR_MESSAGE)
 }

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -11,6 +11,7 @@ import kotools.types.ExperimentalSinceKotoolsTypes
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalCollectionApi
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Creates a [NotEmptyList] starting with a [head] and containing all the
@@ -26,7 +27,7 @@ import kotlin.jvm.JvmInline
 @SinceKotoolsTypes("4.0")
 public fun <E> notEmptyListOf(head: E, vararg tail: E): NotEmptyList<E> {
     val elements: List<E> = listOf(head) + tail
-    return NotEmptyList(elements)
+    return NotEmptyList.of(elements)
 }
 
 /**
@@ -65,7 +66,7 @@ public fun <E> notEmptyListOf(head: E, vararg tail: E): NotEmptyList<E> {
 public fun <E> Collection<E>.toNotEmptyList(): Result<NotEmptyList<E>> =
     runCatching {
         val elements: List<E> = toList()
-        NotEmptyList(elements)
+        NotEmptyList.of(elements)
     }
 
 /**
@@ -105,7 +106,7 @@ public fun <E> Collection<E>.toNotEmptyList(): Result<NotEmptyList<E>> =
 public fun <E> Collection<E>.toNotEmptyListOrNull(): NotEmptyList<E>? {
     if (isEmpty()) return null
     val elements: List<E> = toList()
-    return NotEmptyList(elements)
+    return NotEmptyList.of(elements)
 }
 
 /**
@@ -144,7 +145,7 @@ public fun <E> Collection<E>.toNotEmptyListOrNull(): NotEmptyList<E>? {
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun <E> Collection<E>.toNotEmptyListOrThrow(): NotEmptyList<E> {
     val elements: List<E> = toList()
-    return NotEmptyList(elements)
+    return NotEmptyList.of(elements)
 }
 
 /**
@@ -156,7 +157,7 @@ public fun <E> Collection<E>.toNotEmptyListOrThrow(): NotEmptyList<E> {
 @JvmInline
 @Serializable(NotEmptyListSerializer::class)
 @SinceKotoolsTypes("4.0")
-public value class NotEmptyList<out E> internal constructor(
+public value class NotEmptyList<out E> private constructor(
     private val elements: List<E>
 ) : NotEmptyCollection<E> {
     override val head: E get() = elements.first()
@@ -185,6 +186,14 @@ public value class NotEmptyList<out E> internal constructor(
     public fun toList(): List<E> = elements
 
     override fun toString(): String = "$elements"
+
+    /** Contains static declarations for the [NotEmptyList] type. */
+    @SinceKotoolsTypes("4.3.2")
+    public companion object {
+        @JvmSynthetic
+        internal fun <E> of(elements: List<E>): NotEmptyList<E> =
+            NotEmptyList(elements)
+    }
 }
 
 internal class NotEmptyListSerializer<E>(elementSerializer: KSerializer<E>) :

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -13,6 +13,7 @@ import kotools.types.experimental.ExperimentalCollectionApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.toStrictlyPositiveInt
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Creates a [NotEmptyMap] starting with a [head] and containing all the entries
@@ -69,7 +70,7 @@ public fun <K, V> notEmptyMapOf(
  */
 @SinceKotoolsTypes("4.0")
 public fun <K, V> Map<K, V>.toNotEmptyMap(): Result<NotEmptyMap<K, V>> =
-    runCatching { NotEmptyMap(entries) }
+    runCatching { NotEmptyMap.of(entries) }
 
 /**
  * Returns a [NotEmptyMap] containing all the entries of this map, or returns
@@ -105,8 +106,10 @@ public fun <K, V> Map<K, V>.toNotEmptyMap(): Result<NotEmptyMap<K, V>> =
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <K, V> Map<K, V>.toNotEmptyMapOrNull(): NotEmptyMap<K, V>? =
-    if (isEmpty()) null else NotEmptyMap(entries)
+public fun <K, V> Map<K, V>.toNotEmptyMapOrNull(): NotEmptyMap<K, V>? {
+    val isValid: Boolean = isNotEmpty()
+    return if (isValid) NotEmptyMap.of(entries) else null
+}
 
 /**
  * Returns a [NotEmptyMap] containing all the entries of this map, or throws an
@@ -142,7 +145,7 @@ public fun <K, V> Map<K, V>.toNotEmptyMapOrNull(): NotEmptyMap<K, V>? =
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun <K, V> Map<K, V>.toNotEmptyMapOrThrow(): NotEmptyMap<K, V> =
-    NotEmptyMap(entries)
+    NotEmptyMap.of(entries)
 
 /**
  * Represents a map with at least one entry with a key of type [K] and a value
@@ -257,10 +260,6 @@ public value class NotEmptyMap<K, out V> private constructor(
         require(isValid) { EmptyMapException.message }
     }
 
-    internal constructor(entries: Set<Map.Entry<K, V>>) : this(
-        entries.associate { it.toPair() }
-    )
-
     /**
      * Returns all entries of this map as a [Map] with keys of type [K] and
      * values of type [V].
@@ -300,6 +299,18 @@ public value class NotEmptyMap<K, out V> private constructor(
      * ```
      */
     override fun toString(): String = "$delegate"
+
+    /** Contains static declarations for the [NotEmptyMap] type. */
+    @SinceKotoolsTypes("4.3.2")
+    public companion object {
+        @JvmSynthetic
+        internal fun <K, V> of(
+            entries: Set<Map.Entry<K, V>>
+        ): NotEmptyMap<K, V> {
+            val map: Map<K, V> = entries.associate { it.toPair() }
+            return NotEmptyMap(map)
+        }
+    }
 }
 
 internal class NotEmptyMapSerializer<K, V>(

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -15,6 +15,10 @@ import kotools.types.number.toStrictlyPositiveInt
 import kotlin.jvm.JvmInline
 import kotlin.jvm.JvmSynthetic
 
+@JvmSynthetic
+internal const val EMPTY_MAP_ERROR_MESSAGE: String =
+    "Given map shouldn't be empty."
+
 /**
  * Creates a [NotEmptyMap] starting with a [head] and containing all the entries
  * of the optional [tail].
@@ -257,7 +261,7 @@ public value class NotEmptyMap<K, out V> private constructor(
 
     init {
         val isValid: Boolean = delegate.isNotEmpty()
-        require(isValid) { EmptyMapException.message }
+        require(isValid) { EMPTY_MAP_ERROR_MESSAGE }
     }
 
     /**
@@ -332,9 +336,5 @@ internal class NotEmptyMapSerializer<K, V>(
         .decodeSerializableValue(delegate)
         .toNotEmptyMap()
         .getOrNull()
-        ?: throw SerializationException(EmptyMapException)
-}
-
-internal object EmptyMapException : IllegalArgumentException() {
-    override val message: String = "Given map shouldn't be empty."
+        ?: throw SerializationException(EMPTY_MAP_ERROR_MESSAGE)
 }

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -11,6 +11,7 @@ import kotools.types.ExperimentalSinceKotoolsTypes
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalCollectionApi
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Creates a [NotEmptySet] starting with a [head] and containing all the
@@ -26,7 +27,7 @@ import kotlin.jvm.JvmInline
 @SinceKotoolsTypes("4.0")
 public fun <E> notEmptySetOf(head: E, vararg tail: E): NotEmptySet<E> {
     val elements: Set<E> = setOf(head) + tail
-    return NotEmptySet(elements)
+    return NotEmptySet.of(elements)
 }
 
 /**
@@ -65,7 +66,7 @@ public fun <E> notEmptySetOf(head: E, vararg tail: E): NotEmptySet<E> {
 public fun <E> Collection<E>.toNotEmptySet(): Result<NotEmptySet<E>> =
     runCatching {
         val elements: Set<E> = toSet()
-        NotEmptySet(elements)
+        NotEmptySet.of(elements)
     }
 
 /**
@@ -105,7 +106,7 @@ public fun <E> Collection<E>.toNotEmptySet(): Result<NotEmptySet<E>> =
 public fun <E> Collection<E>.toNotEmptySetOrNull(): NotEmptySet<E>? {
     if (isEmpty()) return null
     val elements: Set<E> = toSet()
-    return NotEmptySet(elements)
+    return NotEmptySet.of(elements)
 }
 
 /**
@@ -144,7 +145,7 @@ public fun <E> Collection<E>.toNotEmptySetOrNull(): NotEmptySet<E>? {
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun <E> Collection<E>.toNotEmptySetOrThrow(): NotEmptySet<E> {
     val elements: Set<E> = toSet()
-    return NotEmptySet(elements)
+    return NotEmptySet.of(elements)
 }
 
 /**
@@ -156,7 +157,7 @@ public fun <E> Collection<E>.toNotEmptySetOrThrow(): NotEmptySet<E> {
 @JvmInline
 @Serializable(NotEmptySetSerializer::class)
 @SinceKotoolsTypes("4.0")
-public value class NotEmptySet<out E> internal constructor(
+public value class NotEmptySet<out E> private constructor(
     private val elements: Set<E>
 ) : NotEmptyCollection<E> {
     override val head: E get() = elements.first()
@@ -185,6 +186,14 @@ public value class NotEmptySet<out E> internal constructor(
     public fun toSet(): Set<E> = elements
 
     override fun toString(): String = "$elements"
+
+    /** Contains static declarations for the [NotEmptyList] type. */
+    @SinceKotoolsTypes("4.3.2")
+    public companion object {
+        @JvmSynthetic
+        internal fun <E> of(elements: Set<E>): NotEmptySet<E> =
+            NotEmptySet(elements)
+    }
 }
 
 internal class NotEmptySetSerializer<E>(elementSerializer: KSerializer<E>) :

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -169,7 +169,7 @@ public value class NotEmptySet<out E> private constructor(
 
     init {
         val isValid: Boolean = elements.isNotEmpty()
-        require(isValid) { EmptyCollectionException.message }
+        require(isValid) { EMPTY_COLLECTION_ERROR_MESSAGE }
     }
 
     /**
@@ -213,5 +213,5 @@ internal class NotEmptySetSerializer<E>(elementSerializer: KSerializer<E>) :
         .decodeSerializableValue(delegate)
         .toNotEmptySet()
         .getOrNull()
-        ?: throw SerializationException(EmptyCollectionException)
+        ?: throw SerializationException(EMPTY_COLLECTION_ERROR_MESSAGE)
 }

--- a/src/commonMain/kotlin/kotools/types/number/AnyInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/AnyInt.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.text.NotBlankString
@@ -111,9 +111,9 @@ internal sealed interface AnyIntSerializer<I : AnyInt> : KSerializer<I> {
 }
 
 internal object AnyIntSerializerImplementation : AnyIntSerializer<AnyInt> {
-    override val serialName: Result<NotBlankString> by lazy(
-        "${Package.number}.AnyInt"::toNotBlankString
-    )
+    override val serialName: Result<NotBlankString> by lazy {
+        "$NUMBER_PACKAGE.AnyInt".toNotBlankString()
+    }
 
     override fun deserialize(value: Int): AnyInt = when {
         value == ZeroInt.toInt() -> Result.success(ZeroInt)

--- a/src/commonMain/kotlin/kotools/types/number/Errors.kt
+++ b/src/commonMain/kotlin/kotools/types/number/Errors.kt
@@ -1,0 +1,23 @@
+package kotools.types.number
+
+import kotlin.jvm.JvmSynthetic
+
+@JvmSynthetic
+internal const val ZERO_ERROR_MESSAGE: String =
+    "Number should be other than zero."
+
+@JvmSynthetic
+internal fun Number.shouldBePositiveMessage(): String =
+    "Number should be positive (tried with $this)."
+
+@JvmSynthetic
+internal fun Number.shouldBeNegativeMessage(): String =
+    "Number should be negative (tried with $this)."
+
+@JvmSynthetic
+internal fun Number.shouldBeStrictlyPositiveMessage(): String =
+    "Number should be strictly positive (tried with $this)."
+
+@JvmSynthetic
+internal fun Number.shouldBeStrictlyNegativeMessage(): String =
+    "Number should be strictly negative (tried with $this)."

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -50,7 +50,7 @@ public fun Number.toNegativeIntOrNull(): NegativeInt? {
     val value: Int = toInt()
     return when {
         value == 0 -> ZeroInt
-        value.isStrictlyNegative() -> StrictlyNegativeInt(value)
+        value.isStrictlyNegative() -> StrictlyNegativeInt.of(value)
         else -> null
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -3,7 +3,7 @@ package kotools.types.number
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
@@ -163,7 +163,7 @@ public operator fun NegativeInt.rem(other: NonZeroInt): NegativeInt {
 
 internal object NegativeIntSerializer : AnyIntSerializer<NegativeInt> {
     override val serialName: Result<NotBlankString> by lazy {
-        "${Package.number}.NegativeInt".toNotBlankString()
+        "$NUMBER_PACKAGE.NegativeInt".toNotBlankString()
     }
 
     override fun deserialize(value: Int): NegativeInt = value.toNegativeInt()

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -11,7 +11,6 @@ import kotools.types.range.NotEmptyRange
 import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
-import kotlin.jvm.JvmSynthetic
 
 /**
  * Returns this number as an encapsulated [NegativeInt], which may involve
@@ -169,7 +168,3 @@ internal object NegativeIntSerializer : AnyIntSerializer<NegativeInt> {
             throw SerializationException(message)
         }
 }
-
-@JvmSynthetic
-internal fun Number.shouldBeNegativeMessage(): String =
-    "Number should be negative (tried with $this)."

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -45,7 +45,7 @@ public fun Number.toNonZeroInt(): Result<NonZeroInt> = toInt().runCatching {
 public fun Number.toNonZeroIntOrNull(): NonZeroInt? {
     val value: Int = toInt()
     return when {
-        value.isStrictlyPositive() -> StrictlyPositiveInt(value)
+        value.isStrictlyPositive() -> StrictlyPositiveInt.of(value)
         value.isStrictlyNegative() -> StrictlyNegativeInt.of(value)
         else -> null
     }

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -47,7 +47,7 @@ public fun Number.toNonZeroIntOrNull(): NonZeroInt? {
     val value: Int = toInt()
     return when {
         value.isStrictlyPositive() -> StrictlyPositiveInt(value)
-        value.isStrictlyNegative() -> StrictlyNegativeInt(value)
+        value.isStrictlyNegative() -> StrictlyNegativeInt.of(value)
         else -> null
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -12,7 +12,6 @@ import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
-import kotlin.jvm.JvmSynthetic
 
 /**
  * Returns this number as an encapsulated [NonZeroInt], which may involve
@@ -158,7 +157,3 @@ internal object NonZeroIntSerializer : AnyIntSerializer<NonZeroInt> {
         .getOrNull()
         ?: throw SerializationException(ZERO_ERROR_MESSAGE)
 }
-
-@JvmSynthetic
-internal const val ZERO_ERROR_MESSAGE: String =
-    "Number should be other than zero."

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -3,7 +3,7 @@ package kotools.types.number
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.collection.NotEmptySet
 import kotools.types.collection.notEmptySetOf
@@ -152,7 +152,7 @@ public operator fun Int.rem(other: NonZeroInt): Int = this % other.toInt()
 
 internal object NonZeroIntSerializer : AnyIntSerializer<NonZeroInt> {
     override val serialName: Result<NotBlankString> by lazy {
-        "${Package.number}.NonZeroInt".toNotBlankString()
+        "$NUMBER_PACKAGE.NonZeroInt".toNotBlankString()
     }
 
     override fun deserialize(value: Int): NonZeroInt = value.toNonZeroInt()

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -3,7 +3,7 @@ package kotools.types.number
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
@@ -165,7 +165,7 @@ public operator fun PositiveInt.rem(other: NonZeroInt): PositiveInt {
 
 internal object PositiveIntSerializer : AnyIntSerializer<PositiveInt> {
     override val serialName: Result<NotBlankString> by lazy {
-        "${Package.number}.PositiveInt".toNotBlankString()
+        "$NUMBER_PACKAGE.PositiveInt".toNotBlankString()
     }
 
     override fun deserialize(value: Int): PositiveInt = value.toPositiveInt()

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -49,7 +49,7 @@ public fun Number.toPositiveIntOrNull(): PositiveInt? {
     val value: Int = toInt()
     return when {
         value == 0 -> ZeroInt
-        value.isStrictlyPositive() -> StrictlyPositiveInt(value)
+        value.isStrictlyPositive() -> StrictlyPositiveInt.of(value)
         else -> null
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -11,7 +11,6 @@ import kotools.types.range.NotEmptyRange
 import kotools.types.range.notEmptyRangeOf
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
-import kotlin.jvm.JvmSynthetic
 
 /**
  * Returns this number as an encapsulated [PositiveInt], which may involve
@@ -169,7 +168,3 @@ internal object PositiveIntSerializer : AnyIntSerializer<PositiveInt> {
             throw SerializationException(message)
         }
 }
-
-@JvmSynthetic
-internal fun Number.shouldBePositiveMessage(): String =
-    "Number should be positive (tried with $this)."

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -3,7 +3,7 @@ package kotools.types.number
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
@@ -146,9 +146,9 @@ public operator fun StrictlyNegativeInt.unaryMinus(): StrictlyPositiveInt =
 
 internal object StrictlyNegativeIntSerializer :
     AnyIntSerializer<StrictlyNegativeInt> {
-    override val serialName: Result<NotBlankString> by lazy(
-        "${Package.number}.StrictlyNegativeInt"::toNotBlankString
-    )
+    override val serialName: Result<NotBlankString> by lazy {
+        "$NUMBER_PACKAGE.StrictlyNegativeInt".toNotBlankString()
+    }
 
     override fun deserialize(value: Int): StrictlyNegativeInt = value
         .toStrictlyNegativeInt()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -122,6 +122,7 @@ internal constructor(private val value: Int) : NonZeroInt, NegativeInt {
             notEmptyRangeOf { start.inclusive to end.inclusive }
         }
 
+        @JvmSynthetic
         internal infix fun errorMessageFor(number: Number): NotBlankString =
             "Number should be strictly negative (tried with $number)."
                 .toNotBlankString()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -161,7 +161,3 @@ internal object StrictlyNegativeIntSerializer :
             throw SerializationException(message)
         }
 }
-
-@JvmSynthetic
-internal fun Number.shouldBeStrictlyNegativeMessage(): String =
-    "Number should be strictly negative (tried with $this)."

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -10,8 +10,10 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.ExperimentalSinceKotoolsTypes
 import kotools.types.NUMBER_PACKAGE
+import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalNumberApi
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
 private fun Double.isStrictlyPositive(): Boolean = this > 0.0
 
@@ -25,7 +27,7 @@ private fun Double.isStrictlyPositive(): Boolean = this > 0.0
 public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
     runCatching {
         val value: Double = toDouble()
-        StrictlyPositiveDouble(value)
+        StrictlyPositiveDouble.of(value)
     }
 
 /**
@@ -51,7 +53,7 @@ public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
 public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
     val value: Double = toDouble()
     val isValid: Boolean = value.isStrictlyPositive()
-    return if (isValid) StrictlyPositiveDouble(value) else null
+    return if (isValid) StrictlyPositiveDouble.of(value) else null
 }
 
 /**
@@ -75,7 +77,7 @@ public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyPositiveDoubleOrThrow(): StrictlyPositiveDouble {
     val value: Double = toDouble()
-    return StrictlyPositiveDouble(value)
+    return StrictlyPositiveDouble.of(value)
 }
 
 /**
@@ -86,7 +88,7 @@ public fun Number.toStrictlyPositiveDoubleOrThrow(): StrictlyPositiveDouble {
 @ExperimentalSinceKotoolsTypes("4.2")
 @JvmInline
 @Serializable(StrictlyPositiveDoubleSerializer::class)
-public value class StrictlyPositiveDouble internal constructor(
+public value class StrictlyPositiveDouble private constructor(
     private val value: Double
 ) : Comparable<StrictlyPositiveDouble> {
     init {
@@ -111,6 +113,14 @@ public value class StrictlyPositiveDouble internal constructor(
 
     /** Returns the string representation of this floating-point number. */
     override fun toString(): String = "$value"
+
+    /** Contains static declarations for the [StrictlyPositiveDouble] type. */
+    @SinceKotoolsTypes("4.3.2")
+    public companion object {
+        @JvmSynthetic
+        internal fun of(value: Double): StrictlyPositiveDouble =
+            StrictlyPositiveDouble(value)
+    }
 }
 
 @ExperimentalNumberApi

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotlin.jvm.JvmInline
 
@@ -118,7 +118,7 @@ internal object StrictlyPositiveDoubleSerializer :
     KSerializer<StrictlyPositiveDouble> {
     override val descriptor: SerialDescriptor by lazy {
         PrimitiveSerialDescriptor(
-            serialName = "${Package.number}.StrictlyPositiveDouble",
+            serialName = "$NUMBER_PACKAGE.StrictlyPositiveDouble",
             kind = PrimitiveKind.DOUBLE
         )
     }

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -93,7 +93,7 @@ public value class StrictlyPositiveDouble private constructor(
 ) : Comparable<StrictlyPositiveDouble> {
     init {
         val isValid: Boolean = value.isStrictlyPositive()
-        require(isValid) { StrictlyPositiveDoubleException(value).message }
+        require(isValid) { value.shouldBeStrictlyPositiveMessage() }
     }
 
     /**
@@ -140,21 +140,9 @@ internal object StrictlyPositiveDoubleSerializer :
 
     override fun deserialize(decoder: Decoder): StrictlyPositiveDouble {
         val value: Double = decoder.decodeDouble()
-        return value.toStrictlyPositiveDoubleOrNull()
-            ?: throw StrictlyPositiveDoubleSerializationException(value)
-    }
-}
-
-internal class StrictlyPositiveDoubleException(number: Number) :
-    IllegalArgumentException() {
-    override val message: String by lazy {
-        "Number should be strictly positive (tried with $number)."
-    }
-}
-
-private class StrictlyPositiveDoubleSerializationException(number: Number) :
-    SerializationException() {
-    override val message: String by lazy {
-        "Number should be strictly positive (tried with $number)."
+        return value.toStrictlyPositiveDoubleOrNull() ?: value.let {
+            val message: String = it.shouldBeStrictlyPositiveMessage()
+            throw SerializationException(message)
+        }
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -3,7 +3,7 @@ package kotools.types.number
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
@@ -147,9 +147,9 @@ public operator fun StrictlyPositiveInt.unaryMinus(): StrictlyNegativeInt =
 
 internal object StrictlyPositiveIntSerializer :
     AnyIntSerializer<StrictlyPositiveInt> {
-    override val serialName: Result<NotBlankString> by lazy(
-        "${Package.number}.StrictlyPositiveInt"::toNotBlankString
-    )
+    override val serialName: Result<NotBlankString> by lazy {
+        "$NUMBER_PACKAGE.StrictlyPositiveInt".toNotBlankString()
+    }
 
     override fun deserialize(value: Int): StrictlyPositiveInt = value
         .toStrictlyPositiveInt()

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -87,7 +87,8 @@ private fun Int.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt =
 public value class StrictlyPositiveInt
 internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
     init {
-        require(value.isStrictlyPositive()) { errorMessageFor(value) }
+        val isValid: Boolean = value.isStrictlyPositive()
+        require(isValid) { value.shouldBeStrictlyPositiveMessage() }
     }
 
     @SinceKotoolsTypes("4.0")
@@ -123,11 +124,6 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
             notEmptyRangeOf { start.inclusive to end.inclusive }
         }
 
-        internal infix fun errorMessageFor(number: Number): NotBlankString =
-            "Number should be strictly positive (tried with $number)."
-                .toNotBlankString()
-                .getOrThrow()
-
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): StrictlyPositiveInt = (min.value..max.value)
@@ -154,7 +150,8 @@ internal object StrictlyPositiveIntSerializer :
     override fun deserialize(value: Int): StrictlyPositiveInt = value
         .toStrictlyPositiveInt()
         .getOrNull()
-        ?: throw SerializationException(
-            "${StrictlyPositiveInt errorMessageFor value}"
-        )
+        ?: Unit.let {
+            val message: String = value.shouldBeStrictlyPositiveMessage()
+            throw SerializationException(message)
+        }
 }

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -24,7 +24,10 @@ internal fun Int.isStrictlyPositive(): Boolean = this > 0
  */
 @SinceKotoolsTypes("4.1")
 public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
-    runCatching { StrictlyPositiveInt(toInt()) }
+    runCatching {
+        val value: Int = toInt()
+        StrictlyPositiveInt.of(value)
+    }
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding or
@@ -78,14 +81,14 @@ public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt = toInt()
     .toStrictlyPositiveIntOrThrow()
 
 private fun Int.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt =
-    StrictlyPositiveInt(this)
+    StrictlyPositiveInt.of(this)
 
 /** Representation of positive integers excluding [zero][ZeroInt]. */
 @JvmInline
 @Serializable(StrictlyPositiveIntSerializer::class)
 @SinceKotoolsTypes("1.1")
 public value class StrictlyPositiveInt
-internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
+private constructor(private val value: Int) : NonZeroInt, PositiveInt {
     init {
         val isValid: Boolean = value.isStrictlyPositive()
         require(isValid) { value.shouldBeStrictlyPositiveMessage() }
@@ -123,6 +126,10 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
                 .getOrThrow()
             notEmptyRangeOf { start.inclusive to end.inclusive }
         }
+
+        @JvmSynthetic
+        internal fun of(value: Int): StrictlyPositiveInt =
+            StrictlyPositiveInt(value)
 
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")

--- a/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
@@ -2,7 +2,7 @@ package kotools.types.number
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
@@ -16,9 +16,9 @@ public object ZeroInt : PositiveInt, NegativeInt {
 }
 
 internal object ZeroIntSerializer : AnyIntSerializer<ZeroInt> {
-    override val serialName: Result<NotBlankString> by lazy(
-        "${Package.number}.ZeroInt"::toNotBlankString
-    )
+    override val serialName: Result<NotBlankString> by lazy {
+        "$NUMBER_PACKAGE.ZeroInt".toNotBlankString()
+    }
 
     override fun deserialize(value: Int): ZeroInt = if (value == 0) ZeroInt
     else throw SerializationException(

--- a/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
@@ -2,10 +2,10 @@ package kotools.types.number
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
+import kotlin.jvm.JvmSynthetic
 
 /** Representation of the zero integer. */
 @Serializable(ZeroIntSerializer::class)
@@ -17,11 +17,18 @@ public object ZeroInt : PositiveInt, NegativeInt {
 
 internal object ZeroIntSerializer : AnyIntSerializer<ZeroInt> {
     override val serialName: Result<NotBlankString> by lazy {
-        "$NUMBER_PACKAGE.ZeroInt".toNotBlankString()
+        val value: String = ZeroInt::class.qualifiedName
+            ?: error("Unable to get qualified name of 'ZeroInt'.")
+        value.toNotBlankString()
     }
 
     override fun deserialize(value: Int): ZeroInt = if (value == 0) ZeroInt
-    else throw SerializationException(
-        "Unable to deserialize $value to ZeroInt."
-    )
+    else {
+        val message: String = deserializationErrorMessage(value)
+        throw SerializationException(message)
+    }
+
+    @JvmSynthetic
+    internal fun deserializationErrorMessage(value: Int): String =
+        "Unable to deserialize '$value' to ${ZeroInt::class.simpleName}."
 }

--- a/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
@@ -2,6 +2,7 @@ package kotools.types.number
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.SinceKotoolsTypes
 import kotools.types.text.NotBlankString
 import kotools.types.text.toNotBlankString
@@ -11,15 +12,19 @@ import kotlin.jvm.JvmSynthetic
 @Serializable(ZeroIntSerializer::class)
 @SinceKotoolsTypes("4.0")
 public object ZeroInt : PositiveInt, NegativeInt {
+    @JvmSynthetic
+    internal const val SIMPLE_NAME: String = "ZeroInt"
+
+    @JvmSynthetic
+    internal const val QUALIFIED_NAME: String = "$NUMBER_PACKAGE.$SIMPLE_NAME"
+
     override fun toInt(): Int = 0
     override fun toString(): String = "${toInt()}"
 }
 
 internal object ZeroIntSerializer : AnyIntSerializer<ZeroInt> {
     override val serialName: Result<NotBlankString> by lazy {
-        val value: String = ZeroInt::class.qualifiedName
-            ?: error("Unable to get qualified name of 'ZeroInt'.")
-        value.toNotBlankString()
+        ZeroInt.QUALIFIED_NAME.toNotBlankString()
     }
 
     override fun deserialize(value: Int): ZeroInt = if (value == 0) ZeroInt
@@ -30,5 +35,5 @@ internal object ZeroIntSerializer : AnyIntSerializer<ZeroInt> {
 
     @JvmSynthetic
     internal fun deserializationErrorMessage(value: Int): String =
-        "Unable to deserialize '$value' to ${ZeroInt::class.simpleName}."
+        "Unable to deserialize '$value' to ${ZeroInt.SIMPLE_NAME}."
 }

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -42,6 +42,12 @@ private constructor(override val value: T) : Bound<T> {
 @ExperimentalRangeApi
 @ExperimentalSinceKotoolsTypes("4.2")
 public class ExclusiveBound<out T : Comparable<@UnsafeVariance T>>
-internal constructor(override val value: T) : Bound<T> {
+private constructor(override val value: T) : Bound<T> {
     override fun toString(): String = "$value"
+
+    internal companion object {
+        @JvmSynthetic
+        internal fun <T : Comparable<T>> of(value: T): ExclusiveBound<T> =
+            ExclusiveBound(value)
+    }
 }

--- a/src/commonMain/kotlin/kotools/types/range/Bound.kt
+++ b/src/commonMain/kotlin/kotools/types/range/Bound.kt
@@ -2,6 +2,7 @@ package kotools.types.range
 
 import kotools.types.ExperimentalSinceKotoolsTypes
 import kotools.types.experimental.ExperimentalRangeApi
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Represents a bound in a [range][NotEmptyRange].
@@ -24,8 +25,14 @@ public sealed interface Bound<out T : Comparable<@UnsafeVariance T>> {
 @ExperimentalRangeApi
 @ExperimentalSinceKotoolsTypes("4.2")
 public class InclusiveBound<out T : Comparable<@UnsafeVariance T>>
-internal constructor(override val value: T) : Bound<T> {
+private constructor(override val value: T) : Bound<T> {
     override fun toString(): String = "$value"
+
+    internal companion object {
+        @JvmSynthetic
+        internal fun <T : Comparable<T>> of(value: T): InclusiveBound<T> =
+            InclusiveBound(value)
+    }
 }
 
 /**

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -55,7 +55,8 @@ internal constructor(
             get() = InclusiveBound.of(this)
 
         /** Returns this value as an exclusive bound. */
-        public val T.exclusive: ExclusiveBound<T> get() = ExclusiveBound(this)
+        public val T.exclusive: ExclusiveBound<T>
+            get() = ExclusiveBound.of(this)
     }
 }
 

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -51,7 +51,8 @@ internal constructor(
     /** Class responsible for configuring an instance of [NotEmptyRange]. */
     public class BuilderScope<T : Comparable<T>> internal constructor() {
         /** Returns this value as an inclusive bound. */
-        public val T.inclusive: InclusiveBound<T> get() = InclusiveBound(this)
+        public val T.inclusive: InclusiveBound<T>
+            get() = InclusiveBound.of(this)
 
         /** Returns this value as an exclusive bound. */
         public val T.exclusive: ExclusiveBound<T> get() = ExclusiveBound(this)

--- a/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
+++ b/src/commonMain/kotlin/kotools/types/range/NotEmptyRange.kt
@@ -2,6 +2,7 @@ package kotools.types.range
 
 import kotools.types.ExperimentalSinceKotoolsTypes
 import kotools.types.experimental.ExperimentalRangeApi
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Returns a not empty range with the given pair of [bounds].
@@ -15,11 +16,11 @@ public fun <T : Comparable<T>> notEmptyRangeOf(
 ): NotEmptyRange<T> = NotEmptyRange.BuilderScope<T>()
     .bounds()
     .run {
-        if (first.value < second.value) NotEmptyRange(
+        if (first.value < second.value) NotEmptyRange.of(
             start = first,
             end = second
         )
-        else NotEmptyRange(start = second, end = first)
+        else NotEmptyRange.of(start = second, end = first)
     }
 
 /**
@@ -29,7 +30,7 @@ public fun <T : Comparable<T>> notEmptyRangeOf(
 @ExperimentalRangeApi
 @ExperimentalSinceKotoolsTypes("4.2")
 public class NotEmptyRange<out T : Comparable<@UnsafeVariance T>>
-internal constructor(
+private constructor(
     /** The start of this range. */
     public val start: Bound<T>,
     /** The end of this range. */
@@ -46,6 +47,14 @@ internal constructor(
             is ExclusiveBound -> '['
         }
         return "$prefix$start;$end$suffix"
+    }
+
+    internal companion object {
+        @JvmSynthetic
+        internal fun <T : Comparable<T>> of(
+            start: Bound<T>,
+            end: Bound<T>
+        ): NotEmptyRange<T> = NotEmptyRange(start, end)
     }
 
     /** Class responsible for configuring an instance of [NotEmptyRange]. */

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -15,6 +15,7 @@ import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.toStrictlyPositiveInt
 import kotlin.jvm.JvmInline
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Returns this string as an encapsulated [NotBlankString], or returns an
@@ -23,7 +24,7 @@ import kotlin.jvm.JvmInline
  */
 @SinceKotoolsTypes("4.0")
 public fun String.toNotBlankString(): Result<NotBlankString> =
-    runCatching { NotBlankString(this) }
+    runCatching { NotBlankString.of(this) }
 
 /**
  * Returns this string as a [NotBlankString], or returns `null` if this string
@@ -69,7 +70,7 @@ public fun String.toNotBlankStringOrNull(): NotBlankString? =
 @ExperimentalSinceKotoolsTypes("4.3.1")
 @ExperimentalTextApi
 public fun String.toNotBlankStringOrThrow(): NotBlankString =
-    NotBlankString(this)
+    NotBlankString.of(this)
 
 /**
  * Representation of strings that have at least one character, excluding
@@ -78,7 +79,7 @@ public fun String.toNotBlankStringOrThrow(): NotBlankString =
 @JvmInline
 @Serializable(NotBlankStringSerializer::class)
 @SinceKotoolsTypes("4.0")
-public value class NotBlankString internal constructor(
+public value class NotBlankString private constructor(
     private val value: String
 ) : Comparable<NotBlankString> {
     /** Returns the length of this string. */
@@ -102,6 +103,13 @@ public value class NotBlankString internal constructor(
 
     /** Returns this string as a [String]. */
     override fun toString(): String = value
+
+    /** Contains static declarations for the [NotBlankString] type. */
+    @SinceKotoolsTypes("4.3.2")
+    public companion object {
+        @JvmSynthetic
+        internal fun of(value: String): NotBlankString = NotBlankString(value)
+    }
 }
 
 /** Concatenates this string with the [other] one. */

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -9,8 +9,8 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotools.types.ExperimentalSinceKotoolsTypes
-import kotools.types.Package
 import kotools.types.SinceKotoolsTypes
+import kotools.types.TEXT_PACKAGE
 import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.toStrictlyPositiveInt
@@ -133,10 +133,12 @@ public operator fun Char.plus(other: NotBlankString): NotBlankString =
         .getOrThrow()
 
 internal object NotBlankStringSerializer : KSerializer<NotBlankString> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
-        serialName = "${Package.text}.NotBlankString",
-        PrimitiveKind.STRING
-    )
+    override val descriptor: SerialDescriptor by lazy {
+        PrimitiveSerialDescriptor(
+            serialName = "$TEXT_PACKAGE.NotBlankString",
+            PrimitiveKind.STRING
+        )
+    }
 
     override fun serialize(encoder: Encoder, value: NotBlankString): Unit =
         encoder.encodeString("$value")

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -88,7 +88,8 @@ public value class NotBlankString private constructor(
             .getOrThrow()
 
     init {
-        require(value.isNotBlank()) { NotBlankStringException.message }
+        val isValid: Boolean = value.isNotBlank()
+        require(isValid) { stringShouldNotBeBlankMessage() }
     }
 
     /**
@@ -155,9 +156,12 @@ internal object NotBlankStringSerializer : KSerializer<NotBlankString> {
         .decodeString()
         .toNotBlankString()
         .getOrNull()
-        ?: throw SerializationException(NotBlankStringException)
+        ?: Unit.let {
+            val message: String = stringShouldNotBeBlankMessage()
+            throw SerializationException(message)
+        }
 }
 
-internal object NotBlankStringException : IllegalArgumentException() {
-    override val message: String = "Given string shouldn't be blank."
-}
+@JvmSynthetic
+internal fun stringShouldNotBeBlankMessage(): String =
+    "Given string shouldn't be blank."

--- a/src/commonTest/kotlin/kotools/types/Assertions.kt
+++ b/src/commonTest/kotlin/kotools/types/Assertions.kt
@@ -11,6 +11,11 @@ import kotlin.test.assertTrue
 
 infix fun <T> T.shouldEqual(expected: T): Unit = assertEquals(expected, this)
 
+inline fun <T> T.shouldEqual(expected: () -> T) {
+    val expectedValue: T = expected()
+    assertEquals(expectedValue, this)
+}
+
 infix fun <T> T.shouldNotEqual(illegal: T): Unit =
     assertNotEquals(illegal, this)
 

--- a/src/commonTest/kotlin/kotools/types/collection/NotEmptyListTest.kt
+++ b/src/commonTest/kotlin/kotools/types/collection/NotEmptyListTest.kt
@@ -85,7 +85,7 @@ class NotEmptyListTest {
             collection.toNotEmptyListOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = EmptyCollectionException.message
+        val expectedMessage: String = EMPTY_COLLECTION_ERROR_MESSAGE
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/collection/NotEmptyMapTest.kt
+++ b/src/commonTest/kotlin/kotools/types/collection/NotEmptyMapTest.kt
@@ -92,7 +92,7 @@ class NotEmptyMapTest {
             map.toNotEmptyMapOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = EmptyMapException.message
+        val expectedMessage: String = EMPTY_MAP_ERROR_MESSAGE
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/collection/NotEmptySetTest.kt
+++ b/src/commonTest/kotlin/kotools/types/collection/NotEmptySetTest.kt
@@ -86,7 +86,7 @@ class NotEmptySetTest {
             collection.toNotEmptySetOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = EmptyCollectionException.message
+        val expectedMessage: String = EMPTY_COLLECTION_ERROR_MESSAGE
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/AnyIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/AnyIntTest.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.shouldEqual
 import kotlin.random.Random
@@ -144,7 +144,7 @@ class AnyIntSerializerTest {
     @ExperimentalSerializationApi
     @Test
     fun descriptor_should_have_the_qualified_name_of_AnyInt_as_serial_name(): Unit =
-        serializer.descriptor.serialName shouldEqual "${Package.number}.AnyInt"
+        serializer.descriptor.serialName shouldEqual "$NUMBER_PACKAGE.AnyInt"
 
     @Test
     fun serialize_should_behave_like_an_Int() {

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -74,8 +74,7 @@ class NegativeIntTest {
             result.getOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = NegativeIntConstructionException(number)
-            .message
+        val expectedMessage: String = number.shouldBeNegativeMessage()
         assertEquals(expectedMessage, actualMessage)
     }
 
@@ -114,8 +113,7 @@ class NegativeIntTest {
             number.toNegativeIntOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = NegativeIntConstructionException(number)
-            .message
+        val expectedMessage: String = number.shouldBeNegativeMessage()
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
@@ -160,7 +160,7 @@ class NegativeIntSerializerTest {
     @Test
     fun descriptor_should_have_the_qualified_name_of_NegativeInt_as_serial_name() {
         val result: String = NegativeIntSerializer.descriptor.serialName
-        result shouldEqual "${Package.number}.NegativeInt"
+        result shouldEqual "$NUMBER_PACKAGE.NegativeInt"
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
@@ -149,7 +149,7 @@ class NonZeroIntSerializerTest {
     @Test
     fun descriptor_should_have_the_qualified_name_of_NonZeroInt_as_serial_name(): Unit =
         serializer.descriptor
-            .serialName shouldEqual "${Package.number}.NonZeroInt"
+            .serialName shouldEqual "$NUMBER_PACKAGE.NonZeroInt"
 
     @Test
     fun serialization_should_behave_like_an_Int() {

--- a/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
@@ -71,7 +71,7 @@ class NonZeroIntTest {
             result.getOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = NonZeroIntConstructionException.message
+        val expectedMessage: String = ZERO_ERROR_MESSAGE
         assertEquals(expectedMessage, actualMessage)
     }
 
@@ -110,7 +110,7 @@ class NonZeroIntTest {
             number.toNonZeroIntOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = NonZeroIntConstructionException.message
+        val expectedMessage: String = ZERO_ERROR_MESSAGE
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -75,8 +75,7 @@ class PositiveIntTest {
             result.getOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = PositiveIntConstructionException(number)
-            .message
+        val expectedMessage: String = number.shouldBePositiveMessage()
         assertEquals(expectedMessage, actualMessage)
     }
 
@@ -115,8 +114,7 @@ class PositiveIntTest {
             number.toPositiveIntOrThrow()
         }
         val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = PositiveIntConstructionException(number)
-            .message
+        val expectedMessage: String = number.shouldBePositiveMessage()
         assertEquals(expectedMessage, actualMessage)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
@@ -163,7 +163,7 @@ class PositiveIntSerializerTest {
     @Test
     fun descriptor_should_have_the_qualified_name_of_PositiveInt_as_serial_name(): Unit =
         serializer.descriptor
-            .serialName shouldEqual "${Package.number}.PositiveInt"
+            .serialName shouldEqual "$NUMBER_PACKAGE.PositiveInt"
 
     @Test
     fun serialization_should_behave_like_an_Int() {

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
@@ -137,7 +137,7 @@ class StrictlyNegativeIntSerializerTest {
     fun descriptor_should_have_the_qualified_name_of_StrictlyNegativeInt_as_serial_name(): Unit =
         StrictlyNegativeInt.serializer()
             .descriptor
-            .serialName shouldEqual "${Package.number}.StrictlyNegativeInt"
+            .serialName shouldEqual "$NUMBER_PACKAGE.StrictlyNegativeInt"
 
     @Test
     fun serialization_should_behave_like_an_Int() {

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -14,6 +14,7 @@ import kotools.types.shouldBeNotNull
 import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldNotEqual
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -22,21 +23,22 @@ import kotlin.test.assertTrue
 
 class StrictlyNegativeIntTest {
     @Test
-    fun number_toStrictlyNegativeInt_should_pass_with_a_strictly_negative_Int() {
-        val value: Number = StrictlyNegativeInt.random().toInt()
-        val result: Result<StrictlyNegativeInt> = value.toStrictlyNegativeInt()
-        result.getOrThrow().toInt() shouldEqual value
+    fun toStrictlyNegativeInt_should_pass_with_a_strictly_negative_Number() {
+        val number: Number = Random.nextInt(from = Int.MIN_VALUE, until = 0)
+        val result: Result<StrictlyNegativeInt> = number.toStrictlyNegativeInt()
+        result.getOrThrow()
+            .toInt()
+            .shouldEqual(number)
     }
 
     @Test
-    fun number_toStrictlyNegativeInt_should_fail_with_a_positive_Int() {
-        val number: Number = PositiveInt.random().toInt()
+    fun toStrictlyNegativeInt_should_fail_with_a_positive_Number() {
+        val number: Number = Random.nextInt(from = 0, until = Int.MAX_VALUE)
         val result: Result<StrictlyNegativeInt> = number.toStrictlyNegativeInt()
-        val exception: IllegalArgumentException =
-            assertFailsWith { result.getOrThrow() }
-        val actualMessage: String = assertNotNull(exception.message)
-        val expectedMessage: String = number.shouldBeStrictlyNegativeMessage()
-        assertEquals(expectedMessage, actualMessage)
+        assertFailsWith<IllegalArgumentException> { result.getOrThrow() }
+            .message
+            .shouldBeNotNull()
+            .shouldEqual { number.shouldBeStrictlyNegativeMessage() }
     }
 
     @ExperimentalNumberApi

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -20,44 +20,6 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class StrictlyNegativeIntCompanionTest {
-    @Test
-    fun min_should_equal_the_minimum_value_of_Int() {
-        val result: StrictlyNegativeInt = StrictlyNegativeInt.min
-        result.toInt() shouldEqual Int.MIN_VALUE
-    }
-
-    @Test
-    fun max_should_equal_minus_one() {
-        val result: StrictlyNegativeInt = StrictlyNegativeInt.max
-        result.toInt() shouldEqual -1
-    }
-
-    @ExperimentalRangeApi
-    @Test
-    fun range_should_start_with_an_InclusiveBound_that_equals_the_minimum_value_of_Int() {
-        val range: NotEmptyRange<StrictlyNegativeInt> =
-            StrictlyNegativeInt.range
-        assertTrue { range.start is InclusiveBound }
-        range.start.value.toInt() shouldEqual Int.MIN_VALUE
-    }
-
-    @ExperimentalRangeApi
-    @Test
-    fun range_should_end_with_an_InclusiveBound_that_equals_minus_one() {
-        val range: NotEmptyRange<StrictlyNegativeInt> =
-            StrictlyNegativeInt.range
-        assertTrue { range.end is InclusiveBound }
-        range.end.value.toInt() shouldEqual -1
-    }
-
-    @Test
-    fun random_should_return_different_values() {
-        val result: StrictlyNegativeInt = StrictlyNegativeInt.random()
-        result.toInt() shouldNotEqual StrictlyNegativeInt.random()
-    }
-}
-
 class StrictlyNegativeIntTest {
     @Test
     fun number_toStrictlyNegativeInt_should_pass_with_a_strictly_negative_Int() {
@@ -124,6 +86,44 @@ class StrictlyNegativeIntTest {
     fun toString_should_behave_like_an_Int() {
         val x: StrictlyNegativeInt = StrictlyNegativeInt.random()
         "$x" shouldEqual "${x.toInt()}"
+    }
+}
+
+class StrictlyNegativeIntCompanionTest {
+    @Test
+    fun min_should_equal_the_minimum_value_of_Int() {
+        val result: StrictlyNegativeInt = StrictlyNegativeInt.min
+        result.toInt() shouldEqual Int.MIN_VALUE
+    }
+
+    @Test
+    fun max_should_equal_minus_one() {
+        val result: StrictlyNegativeInt = StrictlyNegativeInt.max
+        result.toInt() shouldEqual -1
+    }
+
+    @ExperimentalRangeApi
+    @Test
+    fun range_should_start_with_an_InclusiveBound_that_equals_the_minimum_value_of_Int() {
+        val range: NotEmptyRange<StrictlyNegativeInt> =
+            StrictlyNegativeInt.range
+        assertTrue { range.start is InclusiveBound }
+        range.start.value.toInt() shouldEqual Int.MIN_VALUE
+    }
+
+    @ExperimentalRangeApi
+    @Test
+    fun range_should_end_with_an_InclusiveBound_that_equals_minus_one() {
+        val range: NotEmptyRange<StrictlyNegativeInt> =
+            StrictlyNegativeInt.range
+        assertTrue { range.end is InclusiveBound }
+        range.end.value.toInt() shouldEqual -1
+    }
+
+    @Test
+    fun random_should_return_different_values() {
+        val result: StrictlyNegativeInt = StrictlyNegativeInt.random()
+        result.toInt() shouldNotEqual StrictlyNegativeInt.random()
     }
 }
 

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -13,11 +13,11 @@ import kotools.types.range.NotEmptyRange
 import kotools.types.shouldBeNotNull
 import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
-import kotools.types.shouldFailWithIllegalArgumentException
 import kotools.types.shouldNotEqual
-import kotools.types.text.toNotBlankString
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class StrictlyNegativeIntCompanionTest {
@@ -70,12 +70,11 @@ class StrictlyNegativeIntTest {
     fun number_toStrictlyNegativeInt_should_fail_with_a_positive_Int() {
         val number: Number = PositiveInt.random().toInt()
         val result: Result<StrictlyNegativeInt> = number.toStrictlyNegativeInt()
-        result.shouldFailWithIllegalArgumentException { getOrThrow() }
-            .message
-            .shouldBeNotNull()
-            .toNotBlankString()
-            .getOrThrow()
-            .shouldEqual(StrictlyNegativeInt errorMessageFor number)
+        val exception: IllegalArgumentException =
+            assertFailsWith { result.getOrThrow() }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = number.shouldBeStrictlyNegativeMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi
@@ -106,14 +105,11 @@ class StrictlyNegativeIntTest {
     @Test
     fun number_toStrictlyNegativeIntOrThrow_should_throw_with_a_positive_Int() {
         val number: Number = PositiveInt.random().toInt()
-        val error: IllegalArgumentException =
-            number.shouldFailWithIllegalArgumentException {
-                toStrictlyNegativeIntOrThrow()
-            }
-        error.message.shouldBeNotNull()
-            .toNotBlankString()
-            .getOrThrow()
-            .shouldEqual(StrictlyNegativeInt errorMessageFor number)
+        val exception: IllegalArgumentException =
+            assertFailsWith { number.toStrictlyNegativeIntOrThrow() }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = number.shouldBeStrictlyNegativeMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi
@@ -161,9 +157,8 @@ class StrictlyNegativeIntSerializerTest {
         val exception: SerializationException = assertFailsWith {
             Json.decodeFromString<StrictlyNegativeInt>(encoded)
         }
-        exception.message.shouldBeNotNull()
-            .toNotBlankString()
-            .getOrThrow()
-            .shouldEqual(StrictlyNegativeInt errorMessageFor value)
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = value.shouldBeStrictlyNegativeMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 }

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.shouldBeNotNull
 import kotools.types.shouldBeNull
@@ -142,7 +142,7 @@ class StrictlyPositiveDoubleSerializerTest {
         // WHEN
         val actual: String = serializer.descriptor.serialName
         // THEN
-        val expected = "${Package.number}.StrictlyPositiveDouble"
+        val expected = "$NUMBER_PACKAGE.StrictlyPositiveDouble"
         assertEquals(expected, actual)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -75,8 +75,7 @@ class StrictlyPositiveDoubleTest {
         val exception: IllegalArgumentException = assertFailsWith {
             value.toStrictlyPositiveDoubleOrThrow()
         }
-        val expectedMessage: String = StrictlyPositiveDoubleException(value)
-            .message
+        val expectedMessage: String = value.shouldBeStrictlyPositiveMessage()
         exception.message shouldEqual expectedMessage
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -13,13 +13,13 @@ import kotools.types.range.NotEmptyRange
 import kotools.types.shouldBeNotNull
 import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
-import kotools.types.shouldFailWithIllegalArgumentException
-import kotools.types.shouldFailWithSerializationException
 import kotools.types.shouldNotEqual
-import kotools.types.text.toNotBlankString
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class StrictlyPositiveIntCompanionTest {
@@ -72,12 +72,11 @@ class StrictlyPositiveIntTest {
     fun toStrictlyPositiveInt_should_fail_with_a_negative_Number() {
         val number: Number = Random.nextInt(Int.MIN_VALUE..0)
         val result: Result<StrictlyPositiveInt> = number.toStrictlyPositiveInt()
-        result.shouldFailWithIllegalArgumentException { getOrThrow() }
-            .message
-            .shouldBeNotNull()
-            .toNotBlankString()
-            .getOrThrow()
-            .shouldEqual(StrictlyPositiveInt errorMessageFor number)
+        val exception: IllegalArgumentException =
+            assertFailsWith { result.getOrThrow() }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = number.shouldBeStrictlyPositiveMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi
@@ -108,14 +107,12 @@ class StrictlyPositiveIntTest {
     @Test
     fun toStrictlyPositiveIntOrThrow_should_fail_with_a_negative_Number() {
         val number: Number = Random.nextInt(Int.MIN_VALUE..0)
-        val error: IllegalArgumentException =
-            number.shouldFailWithIllegalArgumentException {
-                toStrictlyPositiveIntOrThrow()
-            }
-        error.message.shouldBeNotNull()
-            .toNotBlankString()
-            .getOrThrow()
-            .shouldEqual(StrictlyPositiveInt errorMessageFor number)
+        val exception: IllegalArgumentException = assertFailsWith {
+            number.toStrictlyPositiveIntOrThrow()
+        }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = number.shouldBeStrictlyPositiveMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalNumberApi
@@ -159,13 +156,11 @@ class StrictlyPositiveIntSerializerTest {
     fun deserialization_should_fail_with_a_negative_Int() {
         val value: Int = NegativeInt.random().toInt()
         val encoded: String = Json.encodeToString(value)
-        val error: SerializationException =
-            Json.shouldFailWithSerializationException {
-                decodeFromString<StrictlyPositiveInt>(encoded)
-            }
-        error.message.shouldBeNotNull()
-            .toNotBlankString()
-            .getOrThrow()
-            .shouldEqual(StrictlyPositiveInt errorMessageFor value)
+        val exception: SerializationException = assertFailsWith {
+            Json.decodeFromString<StrictlyPositiveInt>(encoded)
+        }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = value.shouldBeStrictlyPositiveMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 }

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
@@ -138,7 +138,7 @@ class StrictlyPositiveIntSerializerTest {
     fun descriptor_should_have_the_qualified_name_of_StrictlyPositiveInt_as_serial_name(): Unit =
         StrictlyPositiveInt.serializer()
             .descriptor
-            .serialName shouldEqual "${Package.number}.StrictlyPositiveInt"
+            .serialName shouldEqual "$NUMBER_PACKAGE.StrictlyPositiveInt"
 
     @Test
     fun serialization_should_behave_like_an_Int() {

--- a/src/commonTest/kotlin/kotools/types/number/ZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/ZeroIntTest.kt
@@ -26,7 +26,7 @@ class ZeroIntSerializerTest {
     @Test
     fun descriptor_should_have_the_qualified_name_of_ZeroInt_as_serial_name() {
         val actual: String = ZeroInt.serializer().descriptor.serialName
-        val expected: String = assertNotNull(ZeroInt::class.qualifiedName)
+        val expected: String = ZeroInt.QUALIFIED_NAME
         assertEquals(expected, actual)
     }
 

--- a/src/commonTest/kotlin/kotools/types/number/ZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/ZeroIntTest.kt
@@ -5,11 +5,11 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.NUMBER_PACKAGE
 import kotools.types.shouldEqual
-import kotools.types.shouldHaveAMessage
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 class ZeroIntTest {
     @Test
@@ -25,20 +25,23 @@ class ZeroIntSerializerTest {
     @ExperimentalSerializationApi
     @Test
     fun descriptor_should_have_the_qualified_name_of_ZeroInt_as_serial_name() {
-        val result: String = ZeroInt.serializer().descriptor.serialName
-        result shouldEqual "$NUMBER_PACKAGE.ZeroInt"
+        val actual: String = ZeroInt.serializer().descriptor.serialName
+        val expected: String = assertNotNull(ZeroInt::class.qualifiedName)
+        assertEquals(expected, actual)
     }
 
     @Test
     fun serialize_should_behave_like_the_zero_integer() {
-        val result: String = Json.encodeToString(ZeroInt)
-        result shouldEqual Json.encodeToString(0)
+        val actual: String = Json.encodeToString(ZeroInt)
+        val expected: String = Json.encodeToString(0)
+        assertEquals(expected, actual)
     }
 
     @Test
     fun deserialize_should_pass_with_the_zero_integer() {
-        val result: ZeroInt = Json.decodeFromString("0")
-        result shouldEqual ZeroInt
+        val actual: ZeroInt = Json.decodeFromString("0")
+        val expected = ZeroInt
+        assertEquals(expected, actual)
     }
 
     @Test
@@ -48,6 +51,9 @@ class ZeroIntSerializerTest {
         val encoded: String = Json.encodeToString(value)
         val exception: SerializationException =
             assertFailsWith { Json.decodeFromString<ZeroInt>(encoded) }
-        exception.shouldHaveAMessage()
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String =
+            ZeroIntSerializer.deserializationErrorMessage(value)
+        assertEquals(expectedMessage, actualMessage)
     }
 }

--- a/src/commonTest/kotlin/kotools/types/number/ZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/ZeroIntTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.NUMBER_PACKAGE
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotlin.test.Test
@@ -26,7 +26,7 @@ class ZeroIntSerializerTest {
     @Test
     fun descriptor_should_have_the_qualified_name_of_ZeroInt_as_serial_name() {
         val result: String = ZeroInt.serializer().descriptor.serialName
-        result shouldEqual "${Package.number}.ZeroInt"
+        result shouldEqual "$NUMBER_PACKAGE.ZeroInt"
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
@@ -13,10 +13,9 @@ class InclusiveBoundTest {
     @Ignore
     @Test
     fun equals_should_pass_with_an_inclusive_bound_having_the_same_value() {
-        // GIVEN
-        val x: InclusiveBound<Int> = InclusiveBound(Random.nextInt())
-        val y: InclusiveBound<Int> = InclusiveBound(x.value)
-        // WHEN & THEN
+        val x: InclusiveBound<Int> = Random.nextInt()
+            .let { InclusiveBound.of(it) }
+        val y: InclusiveBound<Int> = InclusiveBound.of(x.value)
         "The equals operation should be reflexive.".let {
             assertEquals(expected = x, actual = x, message = it)
             assertEquals(expected = y, actual = y, message = it)
@@ -26,7 +25,7 @@ class InclusiveBoundTest {
             assertEquals(expected = y, actual = x, message = it)
         }
         "The equals operation should be transitive.".let {
-            val z: InclusiveBound<Int> = InclusiveBound(y.value)
+            val z: InclusiveBound<Int> = InclusiveBound.of(y.value)
             assertEquals(expected = x, actual = y, message = it)
             assertEquals(expected = y, actual = z, message = it)
             assertEquals(expected = x, actual = z, message = it)
@@ -41,22 +40,18 @@ class InclusiveBoundTest {
     @Ignore
     @Test
     fun equals_should_fail_with_an_inclusive_bound_having_another_value() {
-        // GIVEN
-        val x: InclusiveBound<Int> = InclusiveBound(Random.nextInt())
-        val y: InclusiveBound<Int> = InclusiveBound(Random.nextInt())
-        // WHEN & THEN
+        val x: InclusiveBound<Int> = Random.nextInt()
+            .let { InclusiveBound.of(it) }
+        val y: InclusiveBound<Int> = Random.nextInt()
+            .let { InclusiveBound.of(it) }
         assertNotEquals(illegal = x, actual = y)
     }
 
     @Test
     fun toString_should_return_the_string_representation_of_its_value() {
-        // GIVEN
         val value: Int = Random.nextInt()
-        val bound: InclusiveBound<Int> = InclusiveBound(value)
-        // WHEN
-        val result = "$bound"
-        // THEN
-        assertEquals(expected = "$value", actual = result)
+        val bound: InclusiveBound<Int> = InclusiveBound.of(value)
+        assertEquals(expected = "$value", actual = "$bound")
     }
 }
 

--- a/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
+++ b/src/commonTest/kotlin/kotools/types/range/BoundTest.kt
@@ -61,10 +61,9 @@ class ExclusiveBoundTest {
     @Ignore
     @Test
     fun equals_should_pass_with_an_exclusive_bound_having_the_same_value() {
-        // GIVEN
-        val x: ExclusiveBound<Int> = ExclusiveBound(Random.nextInt())
-        val y: ExclusiveBound<Int> = ExclusiveBound(x.value)
-        // WHEN & THEN
+        val x: ExclusiveBound<Int> = Random.nextInt()
+            .let { ExclusiveBound.of(it) }
+        val y: ExclusiveBound<Int> = ExclusiveBound.of(x.value)
         "The equals operation should be reflexive.".let {
             assertEquals(expected = x, actual = x, message = it)
             assertEquals(expected = y, actual = y, message = it)
@@ -74,7 +73,7 @@ class ExclusiveBoundTest {
             assertEquals(expected = y, actual = x, message = it)
         }
         "The equals operation should be transitive.".let {
-            val z: ExclusiveBound<Int> = ExclusiveBound(y.value)
+            val z: ExclusiveBound<Int> = ExclusiveBound.of(y.value)
             assertEquals(expected = x, actual = y, message = it)
             assertEquals(expected = y, actual = z, message = it)
             assertEquals(expected = x, actual = z, message = it)
@@ -89,21 +88,17 @@ class ExclusiveBoundTest {
     @Ignore
     @Test
     fun equals_should_fail_with_an_exclusive_bound_having_another_value() {
-        // GIVEN
-        val x: ExclusiveBound<Int> = ExclusiveBound(Random.nextInt())
-        val y: ExclusiveBound<Int> = ExclusiveBound(Random.nextInt())
-        // WHEN & THEN
+        val x: ExclusiveBound<Int> = Random.nextInt()
+            .let { ExclusiveBound.of(it) }
+        val y: ExclusiveBound<Int> = Random.nextInt()
+            .let { ExclusiveBound.of(it) }
         assertNotEquals(illegal = x, actual = y)
     }
 
     @Test
     fun toString_should_return_the_string_representation_of_its_value() {
-        // GIVEN
         val value: Int = Random.nextInt()
-        val bound: ExclusiveBound<Int> = ExclusiveBound(value)
-        // WHEN
-        val result = "$bound"
-        // THEN
-        assertEquals(expected = "$value", actual = result)
+        val bound: ExclusiveBound<Int> = ExclusiveBound.of(value)
+        assertEquals(expected = "$value", actual = "$bound")
     }
 }

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotools.types.Package
+import kotools.types.TEXT_PACKAGE
 import kotools.types.experimental.ExperimentalTextApi
 import kotools.types.number.StrictlyPositiveInt
 import kotools.types.number.ZeroInt
@@ -163,7 +163,7 @@ class NotBlankStringSerializerTest {
     @Test
     fun descriptor_should_be_named_with_the_qualified_name_of_NotBlankString() {
         val result: String = NotBlankStringSerializer.descriptor.serialName
-        result shouldEqual "${Package.text}.NotBlankString"
+        result shouldEqual "$TEXT_PACKAGE.NotBlankString"
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -12,10 +12,11 @@ import kotools.types.number.ZeroInt
 import kotools.types.shouldBeNotNull
 import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
-import kotools.types.shouldFailWithIllegalArgumentException
 import kotools.types.shouldHaveAMessage
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 private object StringExample {
@@ -35,10 +36,11 @@ class NotBlankStringTest {
     fun toNotBlankString_should_fail_with_a_blank_String() {
         val result: Result<NotBlankString> =
             StringExample.BLANK.toNotBlankString()
-        result.shouldFailWithIllegalArgumentException { getOrThrow() }
-            .message
-            .shouldBeNotNull()
-            .shouldEqual(NotBlankStringException.message)
+        val exception: IllegalArgumentException =
+            assertFailsWith { result.getOrThrow() }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = stringShouldNotBeBlankMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @ExperimentalTextApi
@@ -68,13 +70,11 @@ class NotBlankStringTest {
     @ExperimentalTextApi
     @Test
     fun toNotBlankStringOrThrow_should_fail_with_a_blank_String() {
-        val string: String = StringExample.BLANK
-        val error: IllegalArgumentException =
-            string.shouldFailWithIllegalArgumentException {
-                toNotBlankStringOrThrow()
-            }
-        error.message.shouldBeNotNull()
-            .shouldEqual(NotBlankStringException.message)
+        val exception: IllegalArgumentException =
+            assertFailsWith { StringExample.BLANK.toNotBlankStringOrThrow() }
+        val actualMessage: String = assertNotNull(exception.message)
+        val expectedMessage: String = stringShouldNotBeBlankMessage()
+        assertEquals(expectedMessage, actualMessage)
     }
 
     @Test


### PR DESCRIPTION
This request closes #234 by marking some internal declarations with the [JvmSynthetic](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.jvm/-jvm-synthetic/) annotation for hiding them from Java.