### PR TITLE
Fix documentation of `toStrictlyNegativeIntOrThrow` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ All notable changes to this project will be documented in this file.
 
 #### Documentation
 
-We've fixed the usage examples of the `toStrictlyNegativeIntOrThrow` function.
+We've fixed the usage examples of the `toStrictlyNegativeIntOrThrow` function 
+(PR [#252]).
+
+[#252]: https://github.com/kotools/types/pull/252
 
 ## 4.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+#### Documentation
+
+We've fixed the usage examples of the `toStrictlyNegativeIntOrThrow` function.
+
 ## 4.3.1
 
 _Release date: 2023-09-25._

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -62,7 +62,7 @@ public fun Number.toStrictlyNegativeIntOrNull(): StrictlyNegativeInt? = toInt()
  *
  * ```kotlin
  * val result: StrictlyNegativeInt = (-1).toStrictlyNegativeIntOrThrow()
- * println(result) // 1
+ * println(result) // -1
  *
  * 0.toStrictlyNegativeIntOrThrow() // IllegalArgumentException
  * 1.toStrictlyNegativeIntOrThrow() // IllegalArgumentException


### PR DESCRIPTION
This request fixes the usage examples documented for the `toStrictlyNegativeIntOrThrow` function.