### PR TITLE
Add static builders named `of` for all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,38 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+#### Static builders named `of`
+
+For aligning with
+[our design goals on error handling](README.md#error-handling-agnostic), we've
+introduced **experimental** static builders named `of` responsible for creating
+the corresponding type (issue [#242]).
+
+This change applies for the following types: `NonZeroInt`, `PositiveInt`, 
+`NegativeInt`, `StrictlyPositiveInt`, `StrictlyNegativeInt`, 
+`StrictlyPositiveDouble`, `NotBlankString`, `NotEmptyList`, `NotEmptySet` and
+`NotEmptyMap`.
+
+Here's an example for the `PositiveInt` type:
+
+```kotlin
+// before
+var result: PositiveInt? = 1.toPositiveInt().getOrNull()
+println(result) // 1
+result = (-1).toPositiveInt().getOrNull()
+println(result) // null
+
+// after
+result = PositiveInt.of(1)
+println(result) // 1
+result = PositiveInt.of(-1)
+println(result) // null
+```
+
+[#242]: https://github.com/kotools/types/issues/242
+
 ### Fixed
 
 #### Documentation

--- a/api/types.api
+++ b/api/types.api
@@ -100,6 +100,7 @@ public final class kotools/types/collection/NotEmptySet : kotools/types/collecti
 }
 
 public final class kotools/types/collection/NotEmptySet$Companion {
+	public final fun of-K89ylr4 (Ljava/util/Collection;)Ljava/util/Set;
 	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -293,6 +293,7 @@ public final class kotools/types/number/StrictlyPositiveDouble : java/lang/Compa
 }
 
 public final class kotools/types/number/StrictlyPositiveDouble$Companion {
+	public final fun of-UyRxpnU (Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveDouble;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -260,6 +260,7 @@ public final class kotools/types/number/StrictlyNegativeInt$Companion {
 	public final fun getMax-r6XGqFM ()I
 	public final fun getMin-r6XGqFM ()I
 	public final fun getRange ()Lkotools/types/range/NotEmptyRange;
+	public final fun of-1FaSkl4 (Ljava/lang/Number;)Lkotools/types/number/StrictlyNegativeInt;
 	public final fun random-r6XGqFM ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/api/types.api
+++ b/api/types.api
@@ -320,6 +320,7 @@ public final class kotools/types/number/StrictlyPositiveInt$Companion {
 	public final fun getMax-qaD5h0E ()I
 	public final fun getMin-qaD5h0E ()I
 	public final fun getRange ()Lkotools/types/range/NotEmptyRange;
+	public final fun of-t2HtXUs (Ljava/lang/Number;)Lkotools/types/number/StrictlyPositiveInt;
 	public final fun random-qaD5h0E ()I
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/api/types.api
+++ b/api/types.api
@@ -36,6 +36,7 @@ public final class kotools/types/collection/NotEmptyList : kotools/types/collect
 }
 
 public final class kotools/types/collection/NotEmptyList$Companion {
+	public final fun of-HcebRes (Ljava/util/Collection;)Ljava/util/List;
 	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -68,6 +68,7 @@ public final class kotools/types/collection/NotEmptyMap {
 }
 
 public final class kotools/types/collection/NotEmptyMap$Companion {
+	public final fun of-5NFL4K8 (Ljava/util/Map;)Ljava/util/Map;
 	public final fun serializer (Lkotlinx/serialization/KSerializer;Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
 }
 

--- a/api/types.api
+++ b/api/types.api
@@ -193,6 +193,7 @@ public final class kotools/types/number/NonZeroInt$Companion {
 	public final fun getMin-r6XGqFM ()I
 	public final fun getNegativeRange ()Lkotools/types/range/NotEmptyRange;
 	public final fun getPositiveRange ()Lkotools/types/range/NotEmptyRange;
+	public final fun of (Ljava/lang/Number;)Lkotools/types/number/NonZeroInt;
 	public final fun random ()Lkotools/types/number/NonZeroInt;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/api/types.api
+++ b/api/types.api
@@ -164,6 +164,7 @@ public final class kotools/types/number/NegativeInt$Companion {
 	public final fun getMax ()Lkotools/types/number/ZeroInt;
 	public final fun getMin-r6XGqFM ()I
 	public final fun getRange ()Lkotools/types/range/NotEmptyRange;
+	public final fun of (Ljava/lang/Number;)Lkotools/types/number/NegativeInt;
 	public final fun random ()Lkotools/types/number/NegativeInt;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/api/types.api
+++ b/api/types.api
@@ -221,6 +221,7 @@ public final class kotools/types/number/PositiveInt$Companion {
 	public final fun getMax-qaD5h0E ()I
 	public final fun getMin ()Lkotools/types/number/ZeroInt;
 	public final fun getRange ()Lkotools/types/range/NotEmptyRange;
+	public final fun of (Ljava/lang/Number;)Lkotools/types/number/PositiveInt;
 	public final fun random ()Lkotools/types/number/PositiveInt;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/api/types.api
+++ b/api/types.api
@@ -429,6 +429,7 @@ public final class kotools/types/text/NotBlankString : java/lang/Comparable {
 }
 
 public final class kotools/types/text/NotBlankString$Companion {
+	public final fun of-AlFjtQg (Ljava/lang/String;)Ljava/lang/String;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -185,6 +185,9 @@ public value class NotEmptyList<out E> internal constructor(
     public fun toList(): List<E> = elements
 
     override fun toString(): String = "$elements"
+
+    /** Contains static declarations for the [NotEmptyList] type. */
+    public companion object
 }
 
 internal class NotEmptyListSerializer<E>(elementSerializer: KSerializer<E>) :

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -139,8 +139,10 @@ public fun <E> Collection<E>.toNotEmptyListOrNull(): NotEmptyList<E>? =
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <E> Collection<E>.toNotEmptyListOrThrow(): NotEmptyList<E> =
-    NotEmptyList.of(this) ?: throw EmptyCollectionException
+public fun <E> Collection<E>.toNotEmptyListOrThrow(): NotEmptyList<E> {
+    val elements: NotEmptyList<E>? = NotEmptyList.of(this)
+    return requireNotNull(elements) { EmptyCollectionException.message }
+}
 
 /**
  * Represents a list with at least one element of type [E].

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -187,7 +187,43 @@ public value class NotEmptyList<out E> internal constructor(
     override fun toString(): String = "$elements"
 
     /** Contains static declarations for the [NotEmptyList] type. */
-    public companion object
+    public companion object {
+        /**
+         * Returns a [NotEmptyList] containing all the elements of the given
+         * [collection], or returns `null` if the [collection] is
+         * [empty][Collection.isEmpty].
+         *
+         * ```kotlin
+         * var collection: Collection<Int> = listOf(1, 2, 3)
+         * var result: NotEmptyList<Int>? = NotEmptyList.of(collection)
+         * println(result) // [1, 2, 3]
+         *
+         * collection = emptyList()
+         * result = NotEmptyList.of(collection)
+         * println(result) // null
+         * ```
+         *
+         * Please note that changes made to the original [collection] will not
+         * be reflected on the resulting [NotEmptyList].
+         *
+         * ```kotlin
+         * val original: MutableCollection<Int> = mutableListOf(1, 2, 3)
+         * val notEmptyList: NotEmptyList<Int>? = NotEmptyList.of(original)
+         * println(original) // [1, 2, 3]
+         * println(notEmptyList) // [1, 2, 3]
+         *
+         * original.clear()
+         * println(original) // []
+         * println(notEmptyList) // [1, 2, 3]
+         * ```
+         */
+        @ExperimentalCollectionApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun <E> of(collection: Collection<E>): NotEmptyList<E>? =
+            collection.takeIf { it.isNotEmpty() }
+                ?.toList()
+                ?.let { NotEmptyList(it) }
+    }
 }
 
 internal class NotEmptyListSerializer<E>(elementSerializer: KSerializer<E>) :

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -102,11 +102,8 @@ public fun <E> Collection<E>.toNotEmptyList(): Result<NotEmptyList<E>> =
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <E> Collection<E>.toNotEmptyListOrNull(): NotEmptyList<E>? {
-    if (isEmpty()) return null
-    val elements: List<E> = toList()
-    return NotEmptyList(elements)
-}
+public fun <E> Collection<E>.toNotEmptyListOrNull(): NotEmptyList<E>? =
+    NotEmptyList.of(this)
 
 /**
  * Returns a [NotEmptyList] containing all the elements of this collection, or
@@ -142,10 +139,8 @@ public fun <E> Collection<E>.toNotEmptyListOrNull(): NotEmptyList<E>? {
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <E> Collection<E>.toNotEmptyListOrThrow(): NotEmptyList<E> {
-    val elements: List<E> = toList()
-    return NotEmptyList(elements)
-}
+public fun <E> Collection<E>.toNotEmptyListOrThrow(): NotEmptyList<E> =
+    NotEmptyList.of(this) ?: throw EmptyCollectionException
 
 /**
  * Represents a list with at least one element of type [E].

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyList.kt
@@ -216,10 +216,11 @@ public value class NotEmptyList<out E> internal constructor(
          */
         @ExperimentalCollectionApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun <E> of(collection: Collection<E>): NotEmptyList<E>? =
-            collection.takeIf { it.isNotEmpty() }
-                ?.toList()
-                ?.let { NotEmptyList(it) }
+        public fun <E> of(collection: Collection<E>): NotEmptyList<E>? {
+            if (collection.isEmpty()) return null
+            val elements: List<E> = collection.toList()
+            return NotEmptyList(elements)
+        }
     }
 }
 

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -106,7 +106,7 @@ public fun <K, V> Map<K, V>.toNotEmptyMap(): Result<NotEmptyMap<K, V>> =
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun <K, V> Map<K, V>.toNotEmptyMapOrNull(): NotEmptyMap<K, V>? =
-    if (isEmpty()) null else NotEmptyMap(entries)
+    NotEmptyMap.of(this)
 
 /**
  * Returns a [NotEmptyMap] containing all the entries of this map, or throws an
@@ -142,7 +142,7 @@ public fun <K, V> Map<K, V>.toNotEmptyMapOrNull(): NotEmptyMap<K, V>? =
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun <K, V> Map<K, V>.toNotEmptyMapOrThrow(): NotEmptyMap<K, V> =
-    NotEmptyMap(entries)
+    NotEmptyMap.of(this) ?: throw EmptyMapException
 
 /**
  * Represents a map with at least one entry with a key of type [K] and a value

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -141,8 +141,10 @@ public fun <K, V> Map<K, V>.toNotEmptyMapOrNull(): NotEmptyMap<K, V>? =
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <K, V> Map<K, V>.toNotEmptyMapOrThrow(): NotEmptyMap<K, V> =
-    NotEmptyMap.of(this) ?: throw EmptyMapException
+public fun <K, V> Map<K, V>.toNotEmptyMapOrThrow(): NotEmptyMap<K, V> {
+    val entries: NotEmptyMap<K, V>? = NotEmptyMap.of(this)
+    return requireNotNull(entries) { EmptyMapException.message }
+}
 
 /**
  * Represents a map with at least one entry with a key of type [K] and a value

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -336,9 +336,8 @@ public value class NotEmptyMap<K, out V> private constructor(
          */
         @ExperimentalCollectionApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun <K, V> of(map: Map<K, V>): NotEmptyMap<K, V>? = map
-            .takeIf { it.isNotEmpty() }
-            ?.let { NotEmptyMap(it.entries) }
+        public fun <K, V> of(map: Map<K, V>): NotEmptyMap<K, V>? =
+            if (map.isEmpty()) null else NotEmptyMap(map.entries)
     }
 }
 

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -302,7 +302,42 @@ public value class NotEmptyMap<K, out V> private constructor(
     override fun toString(): String = "$delegate"
 
     /** Contains static declarations for the [NotEmptyMap] type. */
-    public companion object
+    public companion object {
+        /**
+         * Returns a [NotEmptyMap] containing all the entries of the given
+         * [map], or returns `null` if the [map] is [empty][Map.isEmpty].
+         *
+         * ```kotlin
+         * var map: Map<Char, Int> = mapOf('a' to 1, 'b' to 2)
+         * var result: NotEmptyMap<Char, Int>? = NotEmptyMap.of(map)
+         * println(result) // {a=1, b=2}
+         *
+         * map = emptyMap()
+         * result = NotEmptyMap.of(map)
+         * println(result) // null
+         * ```
+         *
+         * Please note that changes made to the original [map] will not be
+         * reflected on the resulting [NotEmptyMap].
+         *
+         * ```kotlin
+         * val original: MutableMap<Char, Int> =
+         *     mutableMapOf('a' to 1, 'b' to 2)
+         * val notEmptyMap: NotEmptyMap<Char, Int>? = NotEmptyMap.of(original)
+         * println(original) // {a=1, b=2}
+         * println(notEmptyMap) // {a=1, b=2}
+         *
+         * original.clear()
+         * println(original) // {}
+         * println(notEmptyMap) // {a=1, b=2}
+         * ```
+         */
+        @ExperimentalCollectionApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun <K, V> of(map: Map<K, V>): NotEmptyMap<K, V>? = map
+            .takeIf { it.isNotEmpty() }
+            ?.let { NotEmptyMap(it.entries) }
+    }
 }
 
 internal class NotEmptyMapSerializer<K, V>(

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptyMap.kt
@@ -300,6 +300,9 @@ public value class NotEmptyMap<K, out V> private constructor(
      * ```
      */
     override fun toString(): String = "$delegate"
+
+    /** Contains static declarations for the [NotEmptyMap] type. */
+    public companion object
 }
 
 internal class NotEmptyMapSerializer<K, V>(

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -216,10 +216,11 @@ public value class NotEmptySet<out E> internal constructor(
          */
         @ExperimentalCollectionApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun <E> of(collection: Collection<E>): NotEmptySet<E>? =
-            collection.takeIf { it.isNotEmpty() }
-                ?.toSet()
-                ?.let { NotEmptySet(it) }
+        public fun <E> of(collection: Collection<E>): NotEmptySet<E>? {
+            if (collection.isEmpty()) return null
+            val elements: Set<E> = collection.toSet()
+            return NotEmptySet(elements)
+        }
     }
 }
 

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -102,11 +102,8 @@ public fun <E> Collection<E>.toNotEmptySet(): Result<NotEmptySet<E>> =
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <E> Collection<E>.toNotEmptySetOrNull(): NotEmptySet<E>? {
-    if (isEmpty()) return null
-    val elements: Set<E> = toSet()
-    return NotEmptySet(elements)
-}
+public fun <E> Collection<E>.toNotEmptySetOrNull(): NotEmptySet<E>? =
+    NotEmptySet.of(this)
 
 /**
  * Returns a [NotEmptySet] containing all the elements of this collection, or
@@ -142,10 +139,8 @@ public fun <E> Collection<E>.toNotEmptySetOrNull(): NotEmptySet<E>? {
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <E> Collection<E>.toNotEmptySetOrThrow(): NotEmptySet<E> {
-    val elements: Set<E> = toSet()
-    return NotEmptySet(elements)
-}
+public fun <E> Collection<E>.toNotEmptySetOrThrow(): NotEmptySet<E> =
+    NotEmptySet.of(this) ?: throw EmptyCollectionException
 
 /**
  * Represents a set with at least one element of type [E].

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -185,6 +185,9 @@ public value class NotEmptySet<out E> internal constructor(
     public fun toSet(): Set<E> = elements
 
     override fun toString(): String = "$elements"
+
+    /** Contains static declarations for the [NotEmptySet] type. */
+    public companion object
 }
 
 internal class NotEmptySetSerializer<E>(elementSerializer: KSerializer<E>) :

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -187,7 +187,43 @@ public value class NotEmptySet<out E> internal constructor(
     override fun toString(): String = "$elements"
 
     /** Contains static declarations for the [NotEmptySet] type. */
-    public companion object
+    public companion object {
+        /**
+         * Returns a [NotEmptySet] containing all the elements of the given
+         * [collection], or returns `null` if the [collection] is
+         * [empty][Collection.isEmpty].
+         *
+         * ```kotlin
+         * var collection: Collection<Int> = setOf(1, 2, 3, 1)
+         * var result: NotEmptySet<Int>? = NotEmptySet.of(collection)
+         * println(result) // [1, 2, 3]
+         *
+         * collection = emptySet()
+         * result = NotEmptySet.of(collection)
+         * println(result) // null
+         * ```
+         *
+         * Please note that changes made to the original [collection] will not
+         * be reflected on the resulting [NotEmptySet].
+         *
+         * ```kotlin
+         * val original: MutableCollection<Int> = mutableSetOf(1, 2, 3, 1)
+         * val notEmptySet: NotEmptySet<Int>? = NotEmptySet.of(original)
+         * println(original) // [1, 2, 3]
+         * println(notEmptySet) // [1, 2, 3]
+         *
+         * original.clear()
+         * println(original) // []
+         * println(notEmptySet) // [1, 2, 3]
+         * ```
+         */
+        @ExperimentalCollectionApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun <E> of(collection: Collection<E>): NotEmptySet<E>? =
+            collection.takeIf { it.isNotEmpty() }
+                ?.toSet()
+                ?.let { NotEmptySet(it) }
+    }
 }
 
 internal class NotEmptySetSerializer<E>(elementSerializer: KSerializer<E>) :

--- a/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
+++ b/src/commonMain/kotlin/kotools/types/collection/NotEmptySet.kt
@@ -139,8 +139,10 @@ public fun <E> Collection<E>.toNotEmptySetOrNull(): NotEmptySet<E>? =
  */
 @ExperimentalCollectionApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun <E> Collection<E>.toNotEmptySetOrThrow(): NotEmptySet<E> =
-    NotEmptySet.of(this) ?: throw EmptyCollectionException
+public fun <E> Collection<E>.toNotEmptySetOrThrow(): NotEmptySet<E> {
+    val elements: NotEmptySet<E>? = NotEmptySet.of(this)
+    return requireNotNull(elements) { EmptyCollectionException.message }
+}
 
 /**
  * Represents a set with at least one element of type [E].

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -106,6 +106,28 @@ public sealed interface NegativeInt : AnyInt {
             notEmptyRangeOf { start.inclusive to ZeroInt.inclusive }
         }
 
+        /**
+         * Converts the given [number] to a [NegativeInt], which may involve
+         * rounding or truncation, or returns `null` if the [number] is
+         * [strictly positive][StrictlyPositiveInt].
+         *
+         * ```kotlin
+         * var result: NegativeInt? = NegativeInt.of(-1)
+         * println(result) // -1
+         *
+         * result = NegativeInt.of(0)
+         * println(result) // 0
+         *
+         * result = NegativeInt.of(1)
+         * println(result) // null
+         * ```
+         */
+        @ExperimentalNumberApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun of(number: Number): NegativeInt? = number.toInt()
+            .takeIf { it <= ZeroInt.toInt() }
+            ?.let { StrictlyNegativeInt.of(it) ?: ZeroInt }
+
         /** Returns a random [NegativeInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): NegativeInt = (min.toInt()..max.toInt())

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -76,8 +76,10 @@ public fun Number.toNegativeIntOrNull(): NegativeInt? = NegativeInt.of(this)
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toNegativeIntOrThrow(): NegativeInt {
-    val x: NegativeInt? = NegativeInt.of(this)
-    return requireNotNull(x) { NegativeIntConstructionException(this).message }
+    val value: NegativeInt? = NegativeInt.of(this)
+    return requireNotNull(value) {
+        NegativeIntConstructionException(this).message
+    }
 }
 
 /** Representation of negative integers including [zero][ZeroInt]. */

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -119,9 +119,11 @@ public sealed interface NegativeInt : AnyInt {
          */
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun of(number: Number): NegativeInt? = number.toInt()
-            .takeIf { it <= ZeroInt.toInt() }
-            ?.let { StrictlyNegativeInt.of(it) ?: ZeroInt }
+        public fun of(number: Number): NegativeInt? {
+            val value: Int = number.toInt()
+            return if (value > ZeroInt) null
+            else StrictlyNegativeInt.of(value) ?: ZeroInt
+        }
 
         /** Returns a random [NegativeInt]. */
         @SinceKotoolsTypes("3.0")

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -107,7 +107,7 @@ public sealed interface NegativeInt : AnyInt {
         }
 
         /**
-         * Converts the given [number] to a [NegativeInt], which may involve
+         * Returns the given [number] as a [NegativeInt], which may involve
          * rounding or truncation, or returns `null` if the [number] is
          * [strictly positive][StrictlyPositiveInt].
          *

--- a/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NegativeInt.kt
@@ -52,14 +52,7 @@ public fun Number.toNegativeInt(): Result<NegativeInt> {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toNegativeIntOrNull(): NegativeInt? {
-    val value: Int = toInt()
-    return when {
-        value == 0 -> ZeroInt
-        value.isStrictlyNegative() -> StrictlyNegativeInt(value)
-        else -> null
-    }
-}
+public fun Number.toNegativeIntOrNull(): NegativeInt? = NegativeInt.of(this)
 
 /**
  * Returns this number as a [NegativeInt], which may involve rounding or
@@ -82,8 +75,10 @@ public fun Number.toNegativeIntOrNull(): NegativeInt? {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toNegativeIntOrThrow(): NegativeInt =
-    toNegativeIntOrNull() ?: throw NegativeIntConstructionException(this)
+public fun Number.toNegativeIntOrThrow(): NegativeInt {
+    val x: NegativeInt? = NegativeInt.of(this)
+    return requireNotNull(x) { NegativeIntConstructionException(this).message }
+}
 
 /** Representation of negative integers including [zero][ZeroInt]. */
 @Serializable(NegativeIntSerializer::class)

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -119,13 +119,13 @@ public sealed interface NonZeroInt : AnyInt {
          */
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun of(number: Number): NonZeroInt? = number.toInt()
-            .takeIf { it != ZeroInt.toInt() }
-            ?.let {
-                StrictlyPositiveInt.of(it)
-                    ?: StrictlyNegativeInt.of(it)
-                    ?: error("Unexpected error")
-            }
+        public fun of(number: Number): NonZeroInt? {
+            val value: Int = number.toInt()
+            return if (value == ZeroInt.toInt()) null
+            else StrictlyPositiveInt.of(value)
+                ?: StrictlyNegativeInt.of(value)
+                ?: error("Unable to return '$number' as a 'NonZeroInt'")
+        }
 
         /** Returns a random [NonZeroInt]. */
         @SinceKotoolsTypes("3.0")

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -46,14 +46,7 @@ public fun Number.toNonZeroInt(): Result<NonZeroInt> {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toNonZeroIntOrNull(): NonZeroInt? {
-    val value: Int = toInt()
-    return when {
-        value.isStrictlyPositive() -> StrictlyPositiveInt(value)
-        value.isStrictlyNegative() -> StrictlyNegativeInt(value)
-        else -> null
-    }
-}
+public fun Number.toNonZeroIntOrNull(): NonZeroInt? = NonZeroInt.of(this)
 
 /**
  * Returns this number as a [NonZeroInt], which may involve rounding or
@@ -73,8 +66,10 @@ public fun Number.toNonZeroIntOrNull(): NonZeroInt? {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toNonZeroIntOrThrow(): NonZeroInt =
-    toNonZeroIntOrNull() ?: throw NonZeroIntConstructionException
+public fun Number.toNonZeroIntOrThrow(): NonZeroInt {
+    val x: NonZeroInt? = NonZeroInt.of(this)
+    return requireNotNull(x) { NonZeroIntConstructionException.message }
+}
 
 /** Representation of integers other than [zero][ZeroInt]. */
 @Serializable(NonZeroIntSerializer::class)

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -121,7 +121,8 @@ public sealed interface NonZeroInt : AnyInt {
         @ExperimentalSinceKotoolsTypes("4.3.2")
         public fun of(number: Number): NonZeroInt? {
             val value: Int = number.toInt()
-            return if (value == ZeroInt.toInt()) null
+            val zero: Int = ZeroInt.toInt()
+            return if (value == zero) null
             else StrictlyPositiveInt.of(value)
                 ?: StrictlyNegativeInt.of(value)
                 ?: error("Unable to return '$number' as a 'NonZeroInt'")

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -107,7 +107,7 @@ public sealed interface NonZeroInt : AnyInt {
         )
 
         /**
-         * Converts the given [number] to a [NonZeroInt], which may involve
+         * Returns the given [number] as a [NonZeroInt], which may involve
          * rounding or truncation, or returns `null` if the [number] equals
          * [zero][ZeroInt].
          *

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -106,6 +106,32 @@ public sealed interface NonZeroInt : AnyInt {
             StrictlyPositiveInt.Companion::range
         )
 
+        /**
+         * Converts the given [number] to a [NonZeroInt], which may involve
+         * rounding or truncation, or returns `null` if the [number] equals
+         * [zero][ZeroInt].
+         *
+         * ```kotlin
+         * var result: NonZeroInt? = NonZeroInt.of(1)
+         * println(result) // 1
+         *
+         * result = NonZeroInt.of(0)
+         * println(result) // null
+         *
+         * result = NonZeroInt.of(-1)
+         * println(result) // -1
+         * ```
+         */
+        @ExperimentalNumberApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun of(number: Number): NonZeroInt? = number.toInt()
+            .takeIf { it != ZeroInt.toInt() }
+            ?.let {
+                StrictlyPositiveInt.of(it)
+                    ?: StrictlyNegativeInt.of(it)
+                    ?: error("Unexpected error")
+            }
+
         /** Returns a random [NonZeroInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): NonZeroInt {

--- a/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/NonZeroInt.kt
@@ -67,8 +67,8 @@ public fun Number.toNonZeroIntOrNull(): NonZeroInt? = NonZeroInt.of(this)
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toNonZeroIntOrThrow(): NonZeroInt {
-    val x: NonZeroInt? = NonZeroInt.of(this)
-    return requireNotNull(x) { NonZeroIntConstructionException.message }
+    val value: NonZeroInt? = NonZeroInt.of(this)
+    return requireNotNull(value) { NonZeroIntConstructionException.message }
 }
 
 /** Representation of integers other than [zero][ZeroInt]. */

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -108,6 +108,28 @@ public sealed interface PositiveInt : AnyInt {
             notEmptyRangeOf { ZeroInt.inclusive to end.inclusive }
         }
 
+        /**
+         * Converts the given [number] to a [PositiveInt], which may involve
+         * rounding or truncation, or returns `null` if the [number] is
+         * [strictly negative][StrictlyNegativeInt].
+         *
+         * ```kotlin
+         * var result: PositiveInt? = PositiveInt.of(1)
+         * println(result) // 1
+         *
+         * result = PositiveInt.of(0)
+         * println(result) // 0
+         *
+         * result = PositiveInt.of(-1)
+         * println(result) // null
+         * ```
+         */
+        @ExperimentalNumberApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun of(number: Number): PositiveInt? = number.toInt()
+            .takeIf { it >= ZeroInt.toInt() }
+            ?.let { StrictlyPositiveInt.of(it) ?: ZeroInt }
+
         /** Returns a random [PositiveInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): PositiveInt = (min.toInt()..max.toInt())

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -126,9 +126,11 @@ public sealed interface PositiveInt : AnyInt {
          */
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun of(number: Number): PositiveInt? = number.toInt()
-            .takeIf { it >= ZeroInt.toInt() }
-            ?.let { StrictlyPositiveInt.of(it) ?: ZeroInt }
+        public fun of(number: Number): PositiveInt? {
+            val value: Int = number.toInt()
+            return if (value < ZeroInt) null
+            else StrictlyPositiveInt.of(value) ?: ZeroInt
+        }
 
         /** Returns a random [PositiveInt]. */
         @SinceKotoolsTypes("3.0")

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -109,7 +109,7 @@ public sealed interface PositiveInt : AnyInt {
         }
 
         /**
-         * Converts the given [number] to a [PositiveInt], which may involve
+         * Returns the given [number] as a [PositiveInt], which may involve
          * rounding or truncation, or returns `null` if the [number] is
          * [strictly negative][StrictlyNegativeInt].
          *

--- a/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/PositiveInt.kt
@@ -52,14 +52,7 @@ public fun Number.toPositiveInt(): Result<PositiveInt> {
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toPositiveIntOrNull(): PositiveInt? {
-    val value: Int = toInt()
-    return when {
-        value == 0 -> ZeroInt
-        value.isStrictlyPositive() -> StrictlyPositiveInt(value)
-        else -> null
-    }
-}
+public fun Number.toPositiveIntOrNull(): PositiveInt? = PositiveInt.of(this)
 
 /**
  * Returns this number as a [PositiveInt], which may involve rounding or
@@ -83,9 +76,10 @@ public fun Number.toPositiveIntOrNull(): PositiveInt? {
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toPositiveIntOrThrow(): PositiveInt {
-    val value: Int = toInt()
-    require(value >= 0) { PositiveIntConstructionException(value).message }
-    return if (value == 0) ZeroInt else StrictlyPositiveInt(value)
+    val value: PositiveInt? = PositiveInt.of(this)
+    return requireNotNull(value) {
+        PositiveIntConstructionException(this).message
+    }
 }
 
 /** Representation of positive integers including [zero][ZeroInt]. */

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -146,7 +146,7 @@ internal constructor(private val value: Int) : NonZeroInt, NegativeInt {
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
         public fun of(number: Number): StrictlyNegativeInt? = number.toInt()
-            .takeIf { it < 0 }
+            .takeIf { it < ZeroInt.toInt() }
             ?.let { StrictlyNegativeInt(it) }
 
         /** Returns a random [StrictlyNegativeInt]. */

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -128,7 +128,7 @@ internal constructor(private val value: Int) : NonZeroInt, NegativeInt {
                 .getOrThrow()
 
         /**
-         * Converts the given [number] to a [StrictlyNegativeInt], which may
+         * Returns the given [number] as a [StrictlyNegativeInt], which may
          * involve rounding or truncation, or returns `null` if the [number] is
          * [positive][PositiveInt].
          *

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -145,9 +145,10 @@ internal constructor(private val value: Int) : NonZeroInt, NegativeInt {
          */
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun of(number: Number): StrictlyNegativeInt? = number.toInt()
-            .takeIf { it < ZeroInt.toInt() }
-            ?.let { StrictlyNegativeInt(it) }
+        public fun of(number: Number): StrictlyNegativeInt? {
+            val value: Int = number.toInt()
+            return if (value >= ZeroInt) null else StrictlyNegativeInt(value)
+        }
 
         /** Returns a random [StrictlyNegativeInt]. */
         @SinceKotoolsTypes("3.0")

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -49,9 +49,8 @@ public fun Number.toStrictlyNegativeInt(): Result<StrictlyNegativeInt> =
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toStrictlyNegativeIntOrNull(): StrictlyNegativeInt? = toInt()
-    .takeIf { it.isStrictlyNegative() }
-    ?.toStrictlyNegativeIntOrThrow()
+public fun Number.toStrictlyNegativeIntOrNull(): StrictlyNegativeInt? =
+    StrictlyNegativeInt.of(this)
 
 /**
  * Returns this number as a [StrictlyNegativeInt], which may involve rounding or
@@ -74,8 +73,10 @@ public fun Number.toStrictlyNegativeIntOrNull(): StrictlyNegativeInt? = toInt()
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toStrictlyNegativeIntOrThrow(): StrictlyNegativeInt = toInt()
-    .toStrictlyNegativeIntOrThrow()
+public fun Number.toStrictlyNegativeIntOrThrow(): StrictlyNegativeInt {
+    val value: StrictlyNegativeInt? = StrictlyNegativeInt.of(this)
+    return requireNotNull(value) { StrictlyNegativeInt.errorMessageFor(this) }
+}
 
 private fun Int.toStrictlyNegativeIntOrThrow(): StrictlyNegativeInt =
     StrictlyNegativeInt(this)

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyNegativeInt.kt
@@ -127,6 +127,28 @@ internal constructor(private val value: Int) : NonZeroInt, NegativeInt {
                 .toNotBlankString()
                 .getOrThrow()
 
+        /**
+         * Converts the given [number] to a [StrictlyNegativeInt], which may
+         * involve rounding or truncation, or returns `null` if the [number] is
+         * [positive][PositiveInt].
+         *
+         * ```kotlin
+         * var result: StrictlyNegativeInt? = StrictlyNegativeInt.of(-1)
+         * println(result) // -1
+         *
+         * result = StrictlyNegativeInt.of(0)
+         * println(result) // null
+         *
+         * result = StrictlyNegativeInt.of(1)
+         * println(result) // null
+         * ```
+         */
+        @ExperimentalNumberApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun of(number: Number): StrictlyNegativeInt? = number.toInt()
+            .takeIf { it < 0 }
+            ?.let { StrictlyNegativeInt(it) }
+
         /** Returns a random [StrictlyNegativeInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): StrictlyNegativeInt = (min.value..max.value)

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -111,6 +111,32 @@ public value class StrictlyPositiveDouble internal constructor(
 
     /** Returns the string representation of this floating-point number. */
     override fun toString(): String = "$value"
+
+    /** Contains static declarations for the [StrictlyPositiveDouble] type. */
+    public companion object {
+        /**
+         * Converts the given [number] to a [StrictlyPositiveDouble], which may
+         * involve rounding or truncation, or returns `null` if the [number] is
+         * negative.
+         *
+         * ```kotlin
+         * var result: StrictlyPositiveDouble? = StrictlyPositiveDouble.of(1)
+         * println(result) // 1.0
+         *
+         * result = StrictlyPositiveDouble.of(0)
+         * println(result) // null
+         *
+         * result = StrictlyPositiveDouble.of(-1)
+         * println(result) // null
+         * ```
+         */
+        @ExperimentalNumberApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun of(number: Number): StrictlyPositiveDouble? = number
+            .toDouble()
+            .takeIf { it > 0.0 }
+            ?.let { StrictlyPositiveDouble(it) }
+    }
 }
 
 @ExperimentalNumberApi

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -133,8 +133,7 @@ public value class StrictlyPositiveDouble internal constructor(
         @ExperimentalSinceKotoolsTypes("4.3.2")
         public fun of(number: Number): StrictlyPositiveDouble? {
             val value: Double = number.toDouble()
-            return if (value <= 0.0) null
-            else StrictlyPositiveDouble(value)
+            return if (value <= 0.0) null else StrictlyPositiveDouble(value)
         }
     }
 }

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -132,10 +132,11 @@ public value class StrictlyPositiveDouble internal constructor(
          */
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun of(number: Number): StrictlyPositiveDouble? = number
-            .toDouble()
-            .takeIf { it > 0.0 }
-            ?.let { StrictlyPositiveDouble(it) }
+        public fun of(number: Number): StrictlyPositiveDouble? {
+            val value: Double = number.toDouble()
+            return if (value <= 0.0) null
+            else StrictlyPositiveDouble(value)
+        }
     }
 }
 

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -115,7 +115,7 @@ public value class StrictlyPositiveDouble internal constructor(
     /** Contains static declarations for the [StrictlyPositiveDouble] type. */
     public companion object {
         /**
-         * Converts the given [number] to a [StrictlyPositiveDouble], which may
+         * Returns the given [number] as a [StrictlyPositiveDouble], which may
          * involve rounding or truncation, or returns `null` if the [number] is
          * negative.
          *

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveDouble.kt
@@ -48,11 +48,8 @@ public fun Number.toStrictlyPositiveDouble(): Result<StrictlyPositiveDouble> =
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
-    val value: Double = toDouble()
-    val isValid: Boolean = value.isStrictlyPositive()
-    return if (isValid) StrictlyPositiveDouble(value) else null
-}
+public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? =
+    StrictlyPositiveDouble.of(this)
 
 /**
  * Returns this number as a [StrictlyPositiveDouble], which may involve rounding
@@ -74,8 +71,10 @@ public fun Number.toStrictlyPositiveDoubleOrNull(): StrictlyPositiveDouble? {
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
 public fun Number.toStrictlyPositiveDoubleOrThrow(): StrictlyPositiveDouble {
-    val value: Double = toDouble()
-    return StrictlyPositiveDouble(value)
+    val value: StrictlyPositiveDouble? = StrictlyPositiveDouble.of(this)
+    return requireNotNull(value) {
+        StrictlyPositiveDoubleException(this).message
+    }
 }
 
 /**

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -49,9 +49,8 @@ public fun Number.toStrictlyPositiveInt(): Result<StrictlyPositiveInt> =
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = toInt()
-    .takeIf { it.isStrictlyPositive() }
-    ?.toStrictlyPositiveIntOrThrow()
+public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? =
+    StrictlyPositiveInt.of(this)
 
 /**
  * Returns this number as a [StrictlyPositiveInt], which may involve rounding or
@@ -74,8 +73,10 @@ public fun Number.toStrictlyPositiveIntOrNull(): StrictlyPositiveInt? = toInt()
  */
 @ExperimentalNumberApi
 @ExperimentalSinceKotoolsTypes("4.3.1")
-public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt = toInt()
-    .toStrictlyPositiveIntOrThrow()
+public fun Number.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt {
+    val value: StrictlyPositiveInt? = StrictlyPositiveInt.of(this)
+    return requireNotNull(value) { StrictlyPositiveInt.errorMessageFor(this) }
+}
 
 private fun Int.toStrictlyPositiveIntOrThrow(): StrictlyPositiveInt =
     StrictlyPositiveInt(this)

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -129,7 +129,7 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
                 .getOrThrow()
 
         /**
-         * Converts the given [number] to a [StrictlyPositiveInt], which may
+         * Returns the given [number] as a [StrictlyPositiveInt], which may
          * involve rounding or truncation, or returns `null` if the [number] is
          * [negative][NegativeInt].
          *

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -128,6 +128,28 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
                 .toNotBlankString()
                 .getOrThrow()
 
+        /**
+         * Converts the given [number] to a [StrictlyPositiveInt], which may
+         * involve rounding or truncation, or returns `null` if the [number] is
+         * [negative][NegativeInt].
+         *
+         * ```kotlin
+         * var result: StrictlyPositiveInt? = StrictlyPositiveInt.of(1)
+         * println(result) // 1
+         *
+         * result = StrictlyPositiveInt.of(0)
+         * println(result) // null
+         *
+         * result = StrictlyPositiveInt.of(-1)
+         * println(result) // null
+         * ```
+         */
+        @ExperimentalNumberApi
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        public fun of(number: Number): StrictlyPositiveInt? = number.toInt()
+            .takeIf { it > 0 }
+            ?.let { StrictlyPositiveInt(it) }
+
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")
         public fun random(): StrictlyPositiveInt = (min.value..max.value)

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -147,7 +147,7 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
         public fun of(number: Number): StrictlyPositiveInt? = number.toInt()
-            .takeIf { it > 0 }
+            .takeIf { it > ZeroInt.toInt() }
             ?.let { StrictlyPositiveInt(it) }
 
         /** Returns a random [StrictlyPositiveInt]. */

--- a/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/StrictlyPositiveInt.kt
@@ -146,9 +146,10 @@ internal constructor(private val value: Int) : NonZeroInt, PositiveInt {
          */
         @ExperimentalNumberApi
         @ExperimentalSinceKotoolsTypes("4.3.2")
-        public fun of(number: Number): StrictlyPositiveInt? = number.toInt()
-            .takeIf { it > ZeroInt.toInt() }
-            ?.let { StrictlyPositiveInt(it) }
+        public fun of(number: Number): StrictlyPositiveInt? {
+            val value: Int = number.toInt()
+            return if (value <= ZeroInt) null else StrictlyPositiveInt(value)
+        }
 
         /** Returns a random [StrictlyPositiveInt]. */
         @SinceKotoolsTypes("3.0")

--- a/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
+++ b/src/commonMain/kotlin/kotools/types/number/ZeroInt.kt
@@ -15,6 +15,11 @@ public object ZeroInt : PositiveInt, NegativeInt {
     override fun toString(): String = "${toInt()}"
 }
 
+internal operator fun Int.compareTo(other: ZeroInt): Int {
+    val value: Int = other.toInt()
+    return compareTo(value)
+}
+
 internal object ZeroIntSerializer : AnyIntSerializer<ZeroInt> {
     override val serialName: Result<NotBlankString> by lazy(
         "${Package.number}.ZeroInt"::toNotBlankString

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -104,7 +104,25 @@ public value class NotBlankString internal constructor(
     override fun toString(): String = value
 
     /** Contains static declarations for the [NotBlankString] type. */
-    public companion object
+    public companion object {
+        /**
+         * Converts the given [string] as a [NotBlankString], or returns `null`
+         * if the [string] is [blank][CharSequence.isBlank].
+         *
+         * ```kotlin
+         * var result: NotBlankString? = NotBlankString.of("hello world")
+         * println(result) // hello world
+         *
+         * result = NotBlankString.of(" ")
+         * println(result) // null
+         * ```
+         */
+        @ExperimentalSinceKotoolsTypes("4.3.2")
+        @ExperimentalTextApi
+        public fun of(string: String): NotBlankString? = string
+            .takeIf { it.isNotBlank() }
+            ?.let { NotBlankString(it) }
+    }
 }
 
 /** Concatenates this string with the [other] one. */

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -106,7 +106,7 @@ public value class NotBlankString internal constructor(
     /** Contains static declarations for the [NotBlankString] type. */
     public companion object {
         /**
-         * Converts the given [string] as a [NotBlankString], or returns `null`
+         * Returns the given [string] as a [NotBlankString], or returns `null`
          * if the [string] is [blank][CharSequence.isBlank].
          *
          * ```kotlin

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -119,9 +119,8 @@ public value class NotBlankString internal constructor(
          */
         @ExperimentalSinceKotoolsTypes("4.3.2")
         @ExperimentalTextApi
-        public fun of(string: String): NotBlankString? = string
-            .takeIf { it.isNotBlank() }
-            ?.let { NotBlankString(it) }
+        public fun of(string: String): NotBlankString? =
+            if (string.isBlank()) null else NotBlankString(string)
     }
 }
 

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -102,6 +102,9 @@ public value class NotBlankString internal constructor(
 
     /** Returns this string as a [String]. */
     override fun toString(): String = value
+
+    /** Contains static declarations for the [NotBlankString] type. */
+    public companion object
 }
 
 /** Concatenates this string with the [other] one. */

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -46,8 +46,7 @@ public fun String.toNotBlankString(): Result<NotBlankString> =
 @ExperimentalSinceKotoolsTypes("4.3.1")
 @ExperimentalTextApi
 public fun String.toNotBlankStringOrNull(): NotBlankString? =
-    takeIf { it.isNotBlank() }
-        ?.toNotBlankStringOrThrow()
+    NotBlankString.of(this)
 
 /**
  * Returns this string as a [NotBlankString], or throws an
@@ -68,8 +67,10 @@ public fun String.toNotBlankStringOrNull(): NotBlankString? =
  */
 @ExperimentalSinceKotoolsTypes("4.3.1")
 @ExperimentalTextApi
-public fun String.toNotBlankStringOrThrow(): NotBlankString =
-    NotBlankString(this)
+public fun String.toNotBlankStringOrThrow(): NotBlankString {
+    val value: NotBlankString? = NotBlankString.of(this)
+    return requireNotNull(value) { NotBlankStringException.message }
+}
 
 /**
  * Representation of strings that have at least one character, excluding

--- a/src/commonTest/kotlin/kotools/types/collection/NotEmptyListTest.kt
+++ b/src/commonTest/kotlin/kotools/types/collection/NotEmptyListTest.kt
@@ -160,6 +160,26 @@ class NotEmptyListTest {
     }
 }
 
+class NotEmptyListCompanionTest {
+    @ExperimentalCollectionApi
+    @Test
+    fun of_should_pass_with_a_not_empty_Collection() {
+        val collection: Collection<Int> = List(3) { Random.nextInt() }
+        val result: NotEmptyList<Int>? = NotEmptyList.of(collection)
+        result.shouldBeNotNull()
+            .toList()
+            .contentShouldEqual(collection)
+    }
+
+    @ExperimentalCollectionApi
+    @Test
+    fun of_should_fail_with_an_empty_Collection() {
+        val collection: Collection<Int> = emptyList()
+        val result: NotEmptyList<Int>? = NotEmptyList.of(collection)
+        result.shouldBeNull()
+    }
+}
+
 class NotEmptyListIntegrationTest {
     @Test
     fun updating_the_original_MutableCollection_should_not_impact_the_NotEmptyList() {

--- a/src/commonTest/kotlin/kotools/types/collection/NotEmptyMapTest.kt
+++ b/src/commonTest/kotlin/kotools/types/collection/NotEmptyMapTest.kt
@@ -211,6 +211,27 @@ class NotEmptyMapTest {
 
 }
 
+class NotEmptyMapCompanionTest {
+    @ExperimentalCollectionApi
+    @Test
+    fun of_should_pass_with_a_not_empty_Map() {
+        val map: Map<Char, Int> = mapOf('a' to 1, 'b' to 2)
+        val result: NotEmptyMap<Char, Int>? = NotEmptyMap.of(map)
+        result.shouldBeNotNull()
+            .entries
+            .toSet()
+            .shouldEqual(map.entries)
+    }
+
+    @ExperimentalCollectionApi
+    @Test
+    fun of_should_fail_with_an_empty_Map() {
+        val map: Map<Char, Int> = emptyMap()
+        val result: NotEmptyMap<Char, Int>? = NotEmptyMap.of(map)
+        result.shouldBeNull()
+    }
+}
+
 class NotEmptyMapIntegrationTest {
     @Test
     fun updating_the_original_MutableMap_should_not_impact_the_NotEmptyMap() {

--- a/src/commonTest/kotlin/kotools/types/collection/NotEmptySetTest.kt
+++ b/src/commonTest/kotlin/kotools/types/collection/NotEmptySetTest.kt
@@ -166,6 +166,27 @@ class NotEmptySetTest {
     }
 }
 
+class NotEmptySetCompanionTest {
+    @ExperimentalCollectionApi
+    @Test
+    fun of_should_pass_with_a_not_empty_Collection() {
+        val collection: Collection<Int> = List(3) { Random.nextInt() }
+            .toSet()
+        val result: NotEmptySet<Int>? = NotEmptySet.of(collection)
+        result.shouldBeNotNull()
+            .toSet()
+            .contentShouldEqual(collection)
+    }
+
+    @ExperimentalCollectionApi
+    @Test
+    fun of_should_fail_with_an_empty_Collection() {
+        val collection: Collection<Int> = emptySet()
+        val result: NotEmptySet<Int>? = NotEmptySet.of(collection)
+        result.shouldBeNull()
+    }
+}
+
 class NotEmptySetIntegrationTest {
     @Test
     fun updating_the_original_MutableCollection_should_not_impact_the_NotEmptySet() {

--- a/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NegativeIntTest.kt
@@ -9,6 +9,8 @@ import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.shouldBeNotNull
+import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
@@ -47,6 +49,26 @@ class NegativeIntCompanionTest {
         val range: NotEmptyRange<NegativeInt> = NegativeInt.range
         assertTrue { range.end is InclusiveBound }
         range.end.value shouldEqual ZeroInt
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_pass_with_a_negative_Number() {
+        val number: Number = ZeroInt.toInt()
+            .let { Int.MIN_VALUE..it }
+            .random()
+        val result: NegativeInt? = NegativeInt.of(number)
+        result.shouldBeNotNull()
+            .toInt()
+            .shouldEqual(number)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_fail_with_a_strictly_positive_Number() {
+        val number: Number = (1..Int.MAX_VALUE).random()
+        val result: NegativeInt? = NegativeInt.of(number)
+        result.shouldBeNull()
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/NonZeroIntTest.kt
@@ -9,6 +9,8 @@ import kotools.types.Package
 import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.NotEmptyRange
+import kotools.types.shouldBeNotNull
+import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
@@ -44,6 +46,26 @@ class NonZeroIntCompanionTest {
     fun positiveRange_should_be_the_range_of_StrictlyPositiveInt() {
         val range: NotEmptyRange<StrictlyPositiveInt> = NonZeroInt.positiveRange
         range shouldEqual StrictlyPositiveInt.range
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_pass_with_a_Number_other_than_zero() {
+        val number: Number = setOf(Int.MIN_VALUE..-1, 1..Int.MAX_VALUE)
+            .random()
+            .random()
+        val result: NonZeroInt? = NonZeroInt.of(number)
+        result.shouldBeNotNull()
+            .toInt()
+            .shouldEqual(number)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_fail_with_zero() {
+        val number: Number = ZeroInt.toInt()
+        val result: NonZeroInt? = NonZeroInt.of(number)
+        result.shouldBeNull()
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/PositiveIntTest.kt
@@ -10,6 +10,8 @@ import kotools.types.experimental.ExperimentalNumberApi
 import kotools.types.experimental.ExperimentalRangeApi
 import kotools.types.range.InclusiveBound
 import kotools.types.range.NotEmptyRange
+import kotools.types.shouldBeNotNull
+import kotools.types.shouldBeNull
 import kotools.types.shouldEqual
 import kotools.types.shouldHaveAMessage
 import kotools.types.shouldNotEqual
@@ -48,6 +50,27 @@ class PositiveIntCompanionTest {
         val range: NotEmptyRange<PositiveInt> = PositiveInt.range
         assertTrue { range.end is InclusiveBound }
         range.end.value.toInt() shouldEqual Int.MAX_VALUE
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_pass_with_a_positive_Number() {
+        val number: Number = ZeroInt.toInt()
+            .rangeTo(Int.MAX_VALUE)
+            .random()
+        val result: PositiveInt? = PositiveInt.of(number)
+        result.shouldBeNotNull()
+            .toInt()
+            .shouldEqual(number)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_fail_with_a_strictly_negative_Number() {
+        val number: Number = Int.MIN_VALUE.rangeTo(-1)
+            .random()
+        val result: PositiveInt? = PositiveInt.of(number)
+        result.shouldBeNull()
     }
 
     @Test

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -51,6 +51,24 @@ class StrictlyNegativeIntCompanionTest {
         range.end.value.toInt() shouldEqual -1
     }
 
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_pass_with_a_strictly_negative_Number() {
+        val number: Number = (Int.MIN_VALUE..-1).random()
+        val result: StrictlyNegativeInt? = StrictlyNegativeInt.of(number)
+        result.shouldBeNotNull()
+            .toInt()
+            .shouldEqual(number)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_fail_with_a_positive_Number() {
+        val number: Number = (0..Int.MAX_VALUE).random()
+        val result: StrictlyNegativeInt? = StrictlyNegativeInt.of(number)
+        result.shouldBeNull()
+    }
+
     @Test
     fun random_should_return_different_values() {
         val result: StrictlyNegativeInt = StrictlyNegativeInt.random()

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyNegativeIntTest.kt
@@ -64,7 +64,8 @@ class StrictlyNegativeIntCompanionTest {
     @ExperimentalNumberApi
     @Test
     fun of_should_fail_with_a_positive_Number() {
-        val number: Number = (0..Int.MAX_VALUE).random()
+        val range: IntRange = ZeroInt.toInt()..Int.MAX_VALUE
+        val number: Number = range.random()
         val result: StrictlyNegativeInt? = StrictlyNegativeInt.of(number)
         result.shouldBeNull()
     }

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveDoubleTest.kt
@@ -129,6 +129,29 @@ class StrictlyPositiveDoubleTest {
 }
 
 @ExperimentalNumberApi
+class StrictlyPositiveDoubleCompanionTest {
+    @Test
+    fun of_should_pass_with_a_strictly_positive_Number() {
+        val number: Number = (1..Int.MAX_VALUE)
+            .random()
+            .toDouble()
+        val result: StrictlyPositiveDouble? = StrictlyPositiveDouble.of(number)
+        result.shouldBeNotNull()
+            .toDouble()
+            .shouldEqual(number)
+    }
+
+    @Test
+    fun of_should_fail_with_a_negative_Number() {
+        val number: Number = ZeroInt.toInt()
+            .let { Int.MIN_VALUE..it }
+            .random()
+        val result: StrictlyPositiveDouble? = StrictlyPositiveDouble.of(number)
+        result.shouldBeNull()
+    }
+}
+
+@ExperimentalNumberApi
 class StrictlyPositiveDoubleSerializerTest {
     private val serializer: KSerializer<StrictlyPositiveDouble> =
         StrictlyPositiveDoubleSerializer

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -53,6 +53,24 @@ class StrictlyPositiveIntCompanionTest {
         range.end.value.toInt() shouldEqual Int.MAX_VALUE
     }
 
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_pass_with_a_strictly_positive_Number() {
+        val number: Number = (1..Int.MAX_VALUE).random()
+        val result: StrictlyPositiveInt? = StrictlyPositiveInt.of(number)
+        result.shouldBeNotNull()
+            .toInt()
+            .shouldEqual(number)
+    }
+
+    @ExperimentalNumberApi
+    @Test
+    fun of_should_fail_with_a_negative_Number() {
+        val number: Number = (Int.MIN_VALUE..0).random()
+        val result: StrictlyPositiveInt? = StrictlyPositiveInt.of(number)
+        result.shouldBeNull()
+    }
+
     @Test
     fun random_should_return_different_values() {
         val result: StrictlyPositiveInt = StrictlyPositiveInt.random()

--- a/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
+++ b/src/commonTest/kotlin/kotools/types/number/StrictlyPositiveIntTest.kt
@@ -66,7 +66,8 @@ class StrictlyPositiveIntCompanionTest {
     @ExperimentalNumberApi
     @Test
     fun of_should_fail_with_a_negative_Number() {
-        val number: Number = (Int.MIN_VALUE..0).random()
+        val range: IntRange = Int.MIN_VALUE..ZeroInt.toInt()
+        val number: Number = range.random()
         val result: StrictlyPositiveInt? = StrictlyPositiveInt.of(number)
         result.shouldBeNull()
     }

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -158,6 +158,26 @@ class NotBlankStringTest {
     }
 }
 
+class NotBlankStringCompanionTest {
+    @ExperimentalTextApi
+    @Test
+    fun of_should_pass_with_a_not_blank_String() {
+        val string = "hello world"
+        val result: NotBlankString? = NotBlankString.of(string)
+        result.shouldBeNotNull()
+            .toString()
+            .shouldEqual(string)
+    }
+
+    @ExperimentalTextApi
+    @Test
+    fun of_should_fail_with_a_blank_String() {
+        val string = "   "
+        val result: NotBlankString? = NotBlankString.of(string)
+        result.shouldBeNull()
+    }
+}
+
 class NotBlankStringSerializerTest {
     @ExperimentalSerializationApi
     @Test


### PR DESCRIPTION
This request closes #242 by introducing **experimental** static builders named `of` for building all types.