### PR TITLE
Document security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-template.md
+++ b/.github/ISSUE_TEMPLATE/security-template.md
@@ -1,0 +1,17 @@
+---
+name: Security vulnerability
+about: Report a security vulnerability
+title: Security vulnerability
+labels: security
+---
+
+## Description
+
+> Security vulnerability encountered in version `version`.
+
+[//]: # (Describe the bug right here.)
+
+## Checklist
+
+- [ ] Fix the security vulnerability.
+- [ ] Update the `Unreleased` section in the changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,9 @@ println(result) // null
 
 #### Security policy
 
-We've documented the security policy of Kotools Types indicating which versions
-are supported with security updates and how to report a security vulnerability
-(issue [#250]).
-For now, only versions [4.3.0][tag/4.3.0] and [4.2.0][tag/4.2.0] are supported
-for security updates.
+We've documented the [security policy](SECURITY.md) of Kotools Types indicating
+which versions are supported with security updates and how to report a security
+vulnerability (issue [#250]).
 
 [#250]: https://github.com/kotools/types/issues/250
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ println(result) // null
 
 [#242]: https://github.com/kotools/types/issues/242
 
+#### Security policy
+
+We've documented the security policy of Kotools Types indicating which versions
+are supported with security updates and how to report a security vulnerability
+(issue [#250]).
+For now, only versions [4.3.0][tag/4.3.0] and [4.2.0][tag/4.2.0] are supported
+for security updates.
+
+[#250]: https://github.com/kotools/types/issues/250
+
 ### Fixed
 
 #### Documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Here's the versions of Kotools Types that currently supported with security
+updates:
+
+| Version | Supported          |
+|---------|--------------------|
+| 4.3.x   | :white_check_mark: |
+| 4.2.x   | :white_check_mark: |
+| < 4.2.0 | :x:                |
+
+## Reporting a Vulnerability
+
+If you've noticed a security vulnerability, you can [check the open issues] if
+this vulnerability was already reported by another contributor.
+If this is the case, please add a comment in the corresponding issue for being
+noticed when it will be solved.
+If not, please report it by [creating an issue].
+
+[check the open issues]: https://github.com/kotools/types/issues?q=is%3Aopen+is%3Aissue+label%3Asecurity
+[creating an issue]: https://github.com/kotools/types/issues/new?template=security-template.md


### PR DESCRIPTION
This request closes #250 by documenting the security policy of Kotools Types, indicating which versions are supported for security updates and how to report vulnerabilities.