### PR TITLE
Add entries about copyright notices in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
   security updates and how to report a security vulnerability (issue [#250]).
 - Versions [4.1.0], [4.0.1], [4.0.0], [3.2.0], [2.0.0] and [1.3.1] in
   [API reference] (issue [#261]).
+- Copyright notice at the top of each relevant file (issue [#257]).
 
 [4.1.0]: https://github.com/kotools/types/releases/tag/4.1.0
 [4.0.1]: https://github.com/kotools/types/releases/tag/4.0.1
@@ -37,6 +38,7 @@ All notable changes to this project will be documented in this file.
 [2.0.0]: https://github.com/kotools/types-legacy/releases/tag/v2.0.0
 [1.3.1]: https://github.com/kotools/types-legacy/releases/tag/v1.3.1
 [#250]: https://github.com/kotools/types/issues/250
+[#257]: https://github.com/kotools/types/issues/257
 
 ### Changed
 
@@ -57,6 +59,7 @@ All notable changes to this project will be documented in this file.
 
 - The usage examples in the documentation of the `toStrictlyNegativeIntOrThrow`
   function (PR [#252]).
+- The copyright notice in the [license](LICENSE.txt) (issue [#257]).
 
 [#252]: https://github.com/kotools/types/pull/252
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ All notable changes to this project will be documented in this file.
 
 - The usage examples in the documentation of the `toStrictlyNegativeIntOrThrow`
   function (PR [#252]).
-- The copyright notice in the [license](LICENSE.txt) (issue [#257]).
+- The copyright notice in the license (issue [#257]).
 
 [#252]: https://github.com/kotools/types/pull/252
 


### PR DESCRIPTION
This request resolves #257 by adding the missing entries in the `Unreleased` section of the changelog.