### PR TITLE
Update copyright notice in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-[//]: # (Copyright 2022-2023 Loïc Lamarque.)
-[//]: # (Use of this source code is governed by the MIT license.)
+<!--
+    Copyright 2022-2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
 
 # Changelog
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,7 @@
-[//]: # (Copyright 2023 Loïc Lamarque.)
-[//]: # (Use of this source code is governed by the MIT license.)
+<!--
+    Copyright 2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
 
 # Contributor Covenant Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
-[//]: # (Copyright 2023 Loïc Lamarque.)
-[//]: # (Use of this source code is governed by the MIT license.)
+<!--
+    Copyright 2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
 
 # Contributing guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[//]: # (Copyright 2022-2023 Loïc Lamarque.)
-[//]: # (Use of this source code is governed by the MIT license.)
+<!--
+    Copyright 2022-2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
 
 # Kotools Types
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
-[//]: # (Copyright 2023 Loïc Lamarque.)
-[//]: # (Use of this source code is governed by the MIT license.)
+<!--
+    Copyright 2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
 
 # Security Policy
 


### PR DESCRIPTION
This request closes #257 by converting the single line comments to multiline comments in the Markdown files.
