### PR TITLE
Add release notes and update changelog for v4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,127 +67,64 @@ All notable changes to this project will be documented in this file.
 
 ## 4.3.1
 
-_Release date: 2023-09-25._
+_Release date: 2023-09-25 | Commits: [4.3.0...4.3.1]._
 
-_See the [full changelog][4.3.0-4.3.1] from version [4.3.0][tag/4.3.0]._
-
-[4.3.0-4.3.1]: https://github.com/kotools/types/compare/4.3.0...4.3.1
-[tag/4.3.0]: https://github.com/kotools/types/releases/tag/4.3.0
+[4.3.0...4.3.1]: https://github.com/kotools/types/compare/4.3.0...4.3.1
 
 ### Added
 
-#### Experimental annotation for collections
+- `ExperimentalCollectionApi` annotation for marking experimental declarations
+  of the `kotools.types.collection` package (issue [#177]).
+- Experimental type converters suffixed by `OrNull` and `OrThrow` for the
+  following types:
+    - `NonZeroInt` (issue [#173])
+    - `PositiveInt` (issue [#155])
+    - `NegativeInt` (issue [#171])
+    - `StrictlyPositiveInt` (issue [#141])
+    - `StrictlyNegativeInt` (issue [#149], [@o-korpi] contributed in PR [#167])
+    - `StrictlyPositiveDouble` (issue [#132])
+    - `NotBlankString` (issue [#174])
+    - `NotEmptyList` (issue [#176])
+    - `NotEmptySet` (issue [#178])
+    - `NotEmptyMap` (issue [#179]).
 
-This version introduces an `ExperimentalCollectionApi` annotation in the
-`kotools.types.experimental` package for marking experimental declarations
-of the `kotools.types.collection` package (issue [#177] fixed by PRs [#183] and
-[#201]).
-
-[#177]: https://github.com/kotools/types/issues/177
-[#183]: https://github.com/kotools/types/pull/183
-[#201]: https://github.com/kotools/types/pull/201
-
-#### Builders suffixed by `OrNull` and `OrThrow`
-
-For aligning with Kotlin standards incrementally, like discussed in the idea
-[#104], we've added **experimental** builders that, in case of a failure,
-should return `null` if the builder is suffixed by `OrNull` or throw an
-exception if it's suffixed by `OrThrow`.
-This change applies for the following types:
-
-- `NonZeroInt` (issue [#173])
-- `PositiveInt` (issue [#155] fixed by PR [#236])
-- `NegativeInt` (issue [#171])
-- `StrictlyPositiveInt` (issue [#141] fixed by PRs [#164] and [#202])
-- `StrictlyNegativeInt` (issue [#149] fixed by PRs [#181] and [#203], and by
-  [@o-korpi] in PR [#167])
-- `StrictlyPositiveDouble` (issue [#132] fixed by PRs [#233] and [#235])
-- `NotBlankString` (issue [#174] fixed by PRs [#182] and [#204])
-- `NotEmptyList` (issue [#176])
-- `NotEmptySet` (issue [#178])
-- `NotEmptyMap` (issue [#179]).
-
-Here's an example for the `StrictlyPositiveInt` type:
-
-```kotlin
-// before
-1.toStrictlyPositiveInt().getOrNull()
-2.toStrictlyPositiveInt().getOrThrow()
-// after
-1.toStrictlyPositiveIntOrNull()
-2.toStrictlyPositiveIntOrThrow()
-```
-
+[@o-korpi]: https://github.com/o-korpi
 [#104]: https://github.com/kotools/types/discussions/104
 [#132]: https://github.com/kotools/types/issues/132
 [#141]: https://github.com/kotools/types/issues/141
 [#149]: https://github.com/kotools/types/issues/149
 [#155]: https://github.com/kotools/types/issues/155
-[#164]: https://github.com/kotools/types/pull/164
 [#167]: https://github.com/kotools/types/pull/167
 [#171]: https://github.com/kotools/types/issues/171
 [#173]: https://github.com/kotools/types/issues/173
 [#174]: https://github.com/kotools/types/issues/174
 [#176]: https://github.com/kotools/types/issues/176
+[#177]: https://github.com/kotools/types/issues/177
 [#178]: https://github.com/kotools/types/issues/178
 [#179]: https://github.com/kotools/types/issues/179
-[#181]: https://github.com/kotools/types/pull/181
-[#182]: https://github.com/kotools/types/pull/182
-[#202]: https://github.com/kotools/types/pull/202
-[#203]: https://github.com/kotools/types/pull/203
-[#204]: https://github.com/kotools/types/pull/204
-[#233]: https://github.com/kotools/types/pull/233
-[#235]: https://github.com/kotools/types/pull/235
-[#236]: https://github.com/kotools/types/pull/236
-[@o-korpi]: https://github.com/o-korpi
 
 ### Changed
 
-#### Source compatibility with Kotlin
-
-In this new version, we've improved the source compatibility with Kotlin by
-supporting its versions 1.5 through 1.7 (PR [#213]).
-
-Please note that since [Kotools Types 4.3.0], this project is compiled with
-[Kotlin 1.7.21] by default.
-
-[#213]: https://github.com/kotools/types/pull/213
-[Kotools Types 4.3.0]: https://github.com/kotools/types/releases/tag/4.3.0
-
-#### Multiple versions in API reference
-
-The configuration of the [API reference] was improved for supporting multiple
-versions, starting from version [4.2.0][tag/4.2.0] (PR [#198] and issue [#205]
-fixed by PR [#206]).
-We recommend you to only use the versions documented in the API reference for a
-better experience while working with Kotools Types.
-
-The [API reference] is also securely deployed using a [SSH deploy key] when a
-release is published (issue [#207] fixed by PR [#208]).
+- Source compatibility with Kotlin improved by supporting its versions 1.5
+  through 1.7 (PR [#213]).
+- Support multiple versions in the [API reference] starting from version 4.2.0
+  (PR [#198] and issue [#205]).
+- Secure deployments of the [API reference] by using an [SSH deploy key] (issue
+  [#207]).
+- Centralize Gradle plugins and dependencies declarations in a version catalog
+  for reducing the overall complexity of the build script (PR [#199]).
 
 [#198]: https://github.com/kotools/types/pull/198
+[#199]: https://github.com/kotools/types/pull/199
 [#205]: https://github.com/kotools/types/issues/205
-[#206]: https://github.com/kotools/types/pull/206
 [#207]: https://github.com/kotools/types/issues/207
-[#208]: https://github.com/kotools/types/pull/208
+[#213]: https://github.com/kotools/types/pull/213
 [API reference]: https://types.kotools.org
 [SSH deploy key]: https://docs.github.com/fr/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys
 
-#### Centralizing Gradle plugins and dependencies
-
-For reducing the overall complexity of the
-[Gradle build script](library/build.gradle.kts), we've centralized the plugins
-and the dependencies in a [version catalog](gradle/libs.versions.toml) instead
-of defining them in the build script (PR [#199]).
-
-[#199]: https://github.com/kotools/types/pull/199
-
 ### Fixed
 
-#### Documentation typo
-
-We've fixed a little typo in the documentation of the `notEmptyRangeOf`
-function (PR [#222]).
+- Typo in the documentation of the `notEmptyRangeOf` function (PR [#222]).
 
 [#222]: https://github.com/kotools/types/pull/222
 

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -88,9 +88,9 @@ println(secondResult) // 2
 
 [@o-korpi]: https://github.com/o-korpi
 
-### Better source compatibility with Kotlin
+### Better source compatibility with [Kotlin]
 
-In this new version, we've improved the source compatibility with Kotlin by
+In this new version, we've improved the source compatibility with [Kotlin] by
 supporting its versions 1.5 through 1.7.
 
 Please note that since [Kotools Types 4.3.0], this project is compiled with

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -164,9 +164,7 @@ function.
 
 ## External contributions
 
-As an Open-Source project, Kotools Types is in need of new contributors!
-We have issues suited for all levels, from entry to advanced.
-All are welcome in this project.
+As an Open-Source project, we love getting contributions from our community!
 
 If you are looking to contribute, have questions, or want to keep up-to-date
 about what's happening, please follow us here and say hi!

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -1,10 +1,11 @@
 # 4.3.1
 
-_Release date: 2023-09-25._
+_Release date: 2023-09-25. Full changelog: [4.3.0...4.3.1]._
 
 This patch release includes new experimental type converters suffixed by
 `OrNull` and `OrThrow`, and improves the source compatibility with [Kotlin].
 
+[4.3.0...4.3.1]: https://github.com/kotools/types/compare/4.3.0...4.3.1
 [kotlin]: https://kotlinlang.org
 
 ## Installation

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -1,3 +1,8 @@
+<!--
+    Copyright 2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
+
 # 4.3.1
 
 _Release date: 2023-09-25 | [Full changelog]._

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -1,11 +1,11 @@
 # 4.3.1
 
-_Release date: 2023-09-25. Full changelog: [4.3.0...4.3.1]._
+_Release date: 2023-09-25 | [Full changelog]._
 
 This patch release includes new experimental type converters suffixed by
 `OrNull` and `OrThrow`, and improves the source compatibility with [Kotlin].
 
-[4.3.0...4.3.1]: https://github.com/kotools/types/compare/4.3.0...4.3.1
+[full changelog]: https://github.com/kotools/types/blob/main/CHANGELOG.md#431
 [kotlin]: https://kotlinlang.org
 
 ## Installation

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -3,7 +3,8 @@
 _Release date: 2023-09-25 | [Full changelog]._
 
 This patch release includes new experimental type converters suffixed by
-`OrNull` and `OrThrow`, and improves the source compatibility with [Kotlin].
+`OrNull` and `OrThrow`, source compatibility improvements with [Kotlin] and
+documentation updates.
 
 [full changelog]: https://github.com/kotools/types/blob/main/CHANGELOG.md#431
 [kotlin]: https://kotlinlang.org
@@ -47,7 +48,7 @@ library.
 
 [api reference]: https://types.kotools.org
 
-## New features and improvements
+## Features and improvements
 
 ### New type converters suffixed by `OrNull` and `OrThrow`
 
@@ -91,7 +92,7 @@ println(secondResult) // 2
 [@o-korpi]: https://github.com/o-korpi
 [#167]: https://github.com/kotools/types/pull/167
 
-### Better source compatibility with [Kotlin]
+### Source compatibility with [Kotlin]
 
 In this new version, we've improved the source compatibility with [Kotlin] by
 supporting its versions 1.5 through 1.7.
@@ -102,10 +103,17 @@ Please note that since [Kotools Types 4.3.0], this project is compiled with
 [Kotools Types 4.3.0]: https://github.com/kotools/types/releases/tag/4.3.0
 [Kotlin 1.7.21]: https://github.com/JetBrains/kotlin/releases/tag/v1.7.21
 
-### Documentation fix
+### Documentation
+
+The documentation was improved by supporting multiple versions in the
+[API reference] starting from version [4.2.0].
+It is recommended to only use versions documented in the [API reference] for
+having a better experience while working with this library.
 
 We've also fixed a little typo in the documentation of the `notEmptyRangeOf`
 function.
+
+[4.2.0]: https://github.com/kotools/types/releases/tag/4.2.0
 
 ## Fixed issues
 

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -124,7 +124,8 @@ function.
 
 21 issues and 21 requests have been resolved in Kotools Types 4.3.1.
 
-### Issues
+<details>
+<summary>Issues</summary>
 
 - [#84] - New `DeprecatedSinceKotoolsTypes` annotation.
 - [#132] - New type converters suffixed by `OrNull` and `OrThrow` for
@@ -179,8 +180,10 @@ function.
 [#221]: https://github.com/kotools/types/issues/221
 [#237]: https://github.com/kotools/types/issues/237
 [#244]: https://github.com/kotools/types/issues/244
+</details>
 
-### Requests
+<details>
+<summary>Requests</summary>
 
 - [#164] - Add type converters suffixed by `OrNull` and `OrThrow` for
   `StrictlyPositiveInt`.
@@ -233,6 +236,7 @@ function.
 [#233]: https://github.com/kotools/types/pull/233
 [#235]: https://github.com/kotools/types/pull/235
 [#236]: https://github.com/kotools/types/pull/236
+</details>
 
 ## External contributions
 

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -64,7 +64,7 @@ These type converters were added for the following types:
 - `PositiveInt`
 - `NegativeInt`
 - `StrictlyPositiveInt`
-- `StrictlyNegativeInt` (thanks to [@o-korpi])
+- `StrictlyNegativeInt` by [@o-korpi] in PR [#167]
 - `StrictlyPositiveDouble`
 - `NotBlankString`
 - `NotEmptyList`
@@ -89,6 +89,7 @@ println(secondResult) // 2
 ```
 
 [@o-korpi]: https://github.com/o-korpi
+[#167]: https://github.com/kotools/types/pull/167
 
 ### Better source compatibility with [Kotlin]
 

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -120,9 +120,11 @@ function.
 
 [4.2.0]: https://github.com/kotools/types/releases/tag/4.2.0
 
-## Fixed issues
+## Resolved issues and requests
 
-20 issues have been resolved in Kotools Types 4.3.1.
+21 issues and 21 requests have been resolved in Kotools Types 4.3.1.
+
+### Issues
 
 - [#84] - New `DeprecatedSinceKotoolsTypes` annotation.
 - [#132] - New type converters suffixed by `OrNull` and `OrThrow` for
@@ -151,6 +153,7 @@ function.
 - [#207] - Deploy API reference with SSH key.
 - [#216] - Splitting tests in integration workflow.
 - [#217] - Improving Gradle build script.
+- [#218] - Release version 4.3.1.
 - [#221] - Document types in README.
 - [#237] - Secure API reference deployments.
 - [#244] - Restoring project structure.
@@ -172,9 +175,64 @@ function.
 [#207]: https://github.com/kotools/types/issues/207
 [#216]: https://github.com/kotools/types/issues/216
 [#217]: https://github.com/kotools/types/issues/217
+[#218]: https://github.com/kotools/types/issues/218
 [#221]: https://github.com/kotools/types/issues/221
 [#237]: https://github.com/kotools/types/issues/237
 [#244]: https://github.com/kotools/types/issues/244
+
+### Requests
+
+- [#164] - Add type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyPositiveInt`.
+- [#167] by [@o-korpi] - Add type converters suffixed by `OrNull` and `OrThrow`
+  for `StrictlyNegativeInt`.
+- [#181] - Update construction of `StrictlyNegativeInt`.
+- [#182] - Add type converters suffixed by `OrNull` and `OrThrow` for
+  `NotBlankString`.
+- [#183] - Add `ExperimentalCollectionApi` annotation.
+- [#195] - Add `DeprecatedSinceKotoolsTypes` annotation.
+- [#197] - Document pull requests in changelog.
+- [#198] - Support multiple versions in API reference.
+- [#199] - Extract versions from Gradle build script.
+- [#201] - Fix version of `ExperimentalCollectionApi` annotation.
+- [#202] - Fix version of type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyPositiveInt`.
+- [#203] - Fix version of type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyNegativeInt`.
+- [#204] - Fix version of type converters suffixed by `OrNull` and `OrThrow` for
+  `NotBlankString`.
+- [#206] - Move API references to a dedicated branch.
+- [#208] - Enable API reference deployments with SSH key.
+- [#210] - Support Kotlin 1.5 through 1.7 - v1.
+- [#213] - Support Kotlin 1.5 through 1.7 - v2.
+- [#222] - Fix documentation of `notEmptyRangeOf` function.
+- [#233] - Add type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyPositiveDouble`.
+- [#235] - Fix documentation of type converters suffixed by `OrNull` and
+  `OrThrow` for `StrictlyPositiveDouble`.
+- [#236] - Add type converters suffixed by `OrNull` and `OrThrow` for
+  `PositiveInt`.
+
+[#164]: https://github.com/kotools/types/pull/164
+[#181]: https://github.com/kotools/types/pull/181
+[#182]: https://github.com/kotools/types/pull/182
+[#183]: https://github.com/kotools/types/pull/183
+[#195]: https://github.com/kotools/types/pull/195
+[#197]: https://github.com/kotools/types/pull/197
+[#198]: https://github.com/kotools/types/pull/198
+[#199]: https://github.com/kotools/types/pull/199
+[#201]: https://github.com/kotools/types/pull/201
+[#202]: https://github.com/kotools/types/pull/202
+[#203]: https://github.com/kotools/types/pull/203
+[#204]: https://github.com/kotools/types/pull/204
+[#206]: https://github.com/kotools/types/pull/206
+[#208]: https://github.com/kotools/types/pull/208
+[#210]: https://github.com/kotools/types/pull/210
+[#213]: https://github.com/kotools/types/pull/213
+[#222]: https://github.com/kotools/types/pull/222
+[#233]: https://github.com/kotools/types/pull/233
+[#235]: https://github.com/kotools/types/pull/235
+[#236]: https://github.com/kotools/types/pull/236
 
 ## External contributions
 

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -1,0 +1,191 @@
+# 4.3.1
+
+_Release date: 2023-09-25._
+
+This patch release includes new type converters and improves the source
+compatibility with [Kotlin].
+
+[kotlin]: https://kotlinlang.org
+
+## Installation
+
+Add the following dependency to your project for using Kotools Types 4.3.1.
+
+<details open>
+<summary>Gradle - Kotlin DSL</summary>
+
+```kotlin
+implementation("org.kotools:types:4.3.1")
+```
+</details>
+
+<details>
+<summary>Gradle - Groovy DSL</summary>
+
+```groovy
+implementation "org.kotools:types:4.3.1"
+```
+</details>
+
+<details>
+<summary>Maven</summary>
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.kotools</groupId>
+        <artifactId>types</artifactId>
+        <version>4.3.1</version>
+    </dependency>
+</dependencies>
+```
+</details>
+
+Visit the [API reference] for more details on the declarations provided by this
+library.
+
+[api reference]: https://types.kotools.org
+
+## New features and improvements
+
+### New type converters suffixed by `OrNull` and `OrThrow`
+
+We've introduced **experimental** type converters that, in case of a failure,
+should return `null` if it's suffixed by `OrNull`, or should throw an exception
+if it's suffixed by `OrThrow`.
+Suffixing explicitly the type converters improves the overall readability and
+the predictability of the API.
+
+These type converters were added for the following types:
+
+- `NonZeroInt`
+- `PositiveInt`
+- `NegativeInt`
+- `StrictlyPositiveInt`
+- `StrictlyNegativeInt` (thanks to [@o-korpi])
+- `StrictlyPositiveDouble`
+- `NotBlankString`
+- `NotEmptyList`
+- `NotEmptySet`
+- `NotEmptyMap`.
+
+Here's an example for the `StrictlyPositiveInt` type:
+
+```kotlin
+var firstResult: StrictlyPositiveInt?
+var secondResult: StrictlyPositiveInt
+// before
+firstResult = 1.toStrictlyPositiveInt().getOrNull()
+println(firstResult) // 1
+secondResult = 2.toStrictlyPositiveInt().getOrThrow()
+println(secondResult) // 2
+// after
+firstResult = 1.toStrictlyPositiveIntOrNull()
+println(firstResult) // 1
+secondResult = 2.toStrictlyPositiveIntOrThrow()
+println(secondResult) // 2
+```
+
+[@o-korpi]: https://github.com/o-korpi
+
+### Better source compatibility with Kotlin
+
+In this new version, we've improved the source compatibility with Kotlin by
+supporting its versions 1.5 through 1.7.
+
+Please note that since [Kotools Types 4.3.0], this project is compiled with
+[Kotlin 1.7.21] by default.
+
+[Kotools Types 4.3.0]: https://github.com/kotools/types/releases/tag/4.3.0
+[Kotlin 1.7.21]: https://github.com/JetBrains/kotlin/releases/tag/v1.7.21
+
+### Documentation fix
+
+We've also fixed a little typo in the documentation of the `notEmptyRangeOf`
+function.
+
+## Fixed issues
+
+20 issues have been resolved in Kotools Types 4.3.1.
+
+- [#84] - New `DeprecatedSinceKotoolsTypes` annotation.
+- [#132] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyPositiveDouble`.
+- [#141] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyPositiveInt`.
+- [#149] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `StrictlyNegativeInt`.
+- [#155] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `PositiveInt`.
+- [#170] - Refactoring construction of `StrictlyNegativeInt`.
+- [#171] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `NegativeInt`.
+- [#173] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `NonZeroInt`.
+- [#174] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `NotBlankString`.
+- [#176] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `NotEmptyList`.
+- [#177] - New `ExperimentalCollectionApi` annotation.
+- [#178] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `NotEmptySet`.
+- [#179] - New type converters suffixed by `OrNull` and `OrThrow` for
+  `NotEmptyMap`.
+- [#205] - API reference is deployed on every push.
+- [#207] - Deploy API reference with SSH key.
+- [#216] - Splitting tests in integration workflow.
+- [#217] - Improving Gradle build script.
+- [#221] - Document types in README.
+- [#237] - Secure API reference deployments.
+- [#244] - Restoring project structure.
+
+[#84]: https://github.com/kotools/types/issues/84
+[#132]: https://github.com/kotools/types/issues/132
+[#141]: https://github.com/kotools/types/issues/141
+[#149]: https://github.com/kotools/types/issues/149
+[#155]: https://github.com/kotools/types/issues/155
+[#170]: https://github.com/kotools/types/issues/170
+[#171]: https://github.com/kotools/types/issues/171
+[#173]: https://github.com/kotools/types/issues/173
+[#174]: https://github.com/kotools/types/issues/174
+[#176]: https://github.com/kotools/types/issues/176
+[#177]: https://github.com/kotools/types/issues/177
+[#178]: https://github.com/kotools/types/issues/178
+[#179]: https://github.com/kotools/types/issues/179
+[#205]: https://github.com/kotools/types/issues/205
+[#207]: https://github.com/kotools/types/issues/207
+[#216]: https://github.com/kotools/types/issues/216
+[#217]: https://github.com/kotools/types/issues/217
+[#221]: https://github.com/kotools/types/issues/221
+[#237]: https://github.com/kotools/types/issues/237
+[#244]: https://github.com/kotools/types/issues/244
+
+## External contributions
+
+As an Open-Source project, Kotools Types is in need of new contributors!
+We have issues suited for all levels, from entry to advanced.
+All are welcome in this project.
+
+If you are looking to contribute, have questions, or want to keep up-to-date
+about what's happening, please follow us here and say hi!
+
+- [GitHub Discussions]
+- [#kotools-types on Kotlin Slack]
+
+See the [contributing guidelines](/CONTRIBUTING.md) for more details.
+
+[#kotools-types on Kotlin Slack]: https://kotlinlang.slack.com/archives/C05H0L1LD25
+[gitHub discussions]: https://github.com/kotools/types/discussions
+
+## Reporting problems
+
+If you find a problem with this release, please [report a bug] on GitHub.
+
+[report a bug]: https://github.com/kotools/types/issues/new?assignees=&labels=bug&projects=&template=bug-template.md&title=Bug
+
+We hope you will build great things with Kotools Types, and we look forward to
+your feedback via [Slack][#kotools-types on Kotlin Slack], [Twitter] or on
+[GitHub].
+
+[github]: https://github.com/kotools
+[twitter]: https://twitter.com/KotoolsContact

--- a/documentation/release-notes/4.3.1.md
+++ b/documentation/release-notes/4.3.1.md
@@ -2,8 +2,8 @@
 
 _Release date: 2023-09-25._
 
-This patch release includes new type converters and improves the source
-compatibility with [Kotlin].
+This patch release includes new experimental type converters suffixed by
+`OrNull` and `OrThrow`, and improves the source compatibility with [Kotlin].
 
 [kotlin]: https://kotlinlang.org
 
@@ -50,9 +50,10 @@ library.
 
 ### New type converters suffixed by `OrNull` and `OrThrow`
 
-We've introduced **experimental** type converters that, in case of a failure,
-should return `null` if it's suffixed by `OrNull`, or should throw an exception
-if it's suffixed by `OrThrow`.
+We've introduced experimental type converters that, in case of a failure, should
+return `null` if it's suffixed by `OrNull`, or should throw an exception if it's
+suffixed by `OrThrow`.
+
 Suffixing explicitly the type converters improves the overall readability and
 the predictability of the API.
 


### PR DESCRIPTION
This request resolves #275 by introducing release notes for version 4.3.1 and by updating its changelog.
The new release notes are available in the `documentation/release-notes` directory.
