### PR TITLE
Typo in the security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 
 ## Supported Versions
 
-Here's the versions of Kotools Types that currently supported with security
+Here's the versions of Kotools Types that are currently supported with security
 updates:
 
 | Version | Supported          |


### PR DESCRIPTION
This request resolves #250 by adding the missing word `are` the `Supported Versions` section of the security policy.