### PR TITLE
Add roadmap documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,8 +186,14 @@ implementation "org.kotools:types:$version"
 ```
 </details>
 
-See the [API reference](https://types.kotools.org) for more information about
-using this library.
+## Documentation
+
+Here's useful links to additional documentation for learning more about this
+project:
+
+- [API reference][api-reference]
+- [Roadmap](documentation/roadmap.md)
+- [Security Policy](SECURITY.md)
 
 ## Community
 
@@ -226,3 +232,5 @@ as bug reports, feature suggestions and so on.
 ## License
 
 This project is licensed under the [MIT License](LICENSE.txt).
+
+[api-reference]: https://types.kotools.org

--- a/README.md
+++ b/README.md
@@ -188,8 +188,7 @@ implementation "org.kotools:types:$version"
 
 ## Documentation
 
-Here's useful links to additional documentation for learning more about this
-project:
+Here's additional documentation for learning more about this project:
 
 - [API reference][api-reference]
 - [Roadmap](documentation/roadmap.md)

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -1,5 +1,5 @@
 <!--
-    Copyright 2023 Loïc Lamarque.
+    Copyright 2023 Kotools.
     Use of this source code is governed by the MIT license.
 -->
 

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -27,10 +27,10 @@ Here’s a list of the most important things we focus on delivering:
 
 ### Experimental API <a id="v4.3.2-experimental-api"></a>
 
-- Moving experimental declarations to the `kotools.types.experimental` package.
 - New `ExperimentalKotoolsTypesApi` annotation.
-- Deprecation of all annotations in the `kotools.types.experimental` package
-  for using the `ExperimentalKotoolsTypesApi` annotation instead.
+- Deletion of deprecated annotations in the `kotools.types.experimental`
+  package, except the `ExperimentalKotoolsTypesApi` annotation.
+- Moving experimental declarations to the `kotools.types.experimental` package.
 - New factory functions named `of` or `from` for all types (issue [#316]).
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
   types.
@@ -48,6 +48,7 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 
 ### Experimental API <a id="v4.4.0-experimental-api"></a>
 
+- New equality operations to bounds and ranges.
 - New type converters on `AnyInt` to [Byte][kotlin.byte],
   [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
   [Double][kotlin.double].
@@ -63,14 +64,8 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 
 ### Stable API <a id="v5.0.0-stable-api"></a>
 
-- Removing factory functions using [Result][kotlin.result] (issue [#267]).
-- The deprecated `ResultContext` type.
-
-### Experimental API <a id="v5.0.0-experimental-api"></a>
-
-- New equality operations to bounds and ranges.
-- Deletion of deprecated annotations in the `kotools.types.experimental`
-  package, except the `ExperimentalKotoolsTypesApi` annotation.
+- Deletion of factory functions using [Result][kotlin.result] (issue [#267]).
+- Deletion of the `ResultContext` type and its declarations (issue [#270]).
 
 See the [corresponding milestone][milestone-5.0.0] for more details.
 
@@ -90,6 +85,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264
 [#267]: https://github.com/kotools/types/issues/267
+[#270]: https://github.com/kotools/types/issues/270
 [#287]: https://github.com/kotools/types/discussions/287
 [#303]: https://github.com/kotools/types/issues/303
 [#312]: https://github.com/kotools/types/issues/312

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -16,16 +16,16 @@ Here’s a list of the most important things we focus on delivering:
 
 ## Version 4.3.2 <a id="v4.3.2"></a>
 
-### General
+### General <a id="v4.3.2-general"></a>
 
 - Improving documentation on the repository and on the
   [API reference][api-reference] (issue [#317]).
 
-### Stable API
+### Stable API <a id="v4.3.2-stable-api"></a>
 
 - Adhering to [Semantic Versioning][semantic-versioning] (issue [#215]).
 
-### Experimental API
+### Experimental API <a id="v4.3.2-experimental-api"></a>
 
 - Moving experimental declarations to the `kotools.types.experimental` package.
 - New `ExperimentalKotoolsTypesApi` annotation.
@@ -39,14 +39,14 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 
 ## Version 4.4.0 <a id="v4.4.0"></a>
 
-### Stable API
+### Stable API <a id="v4.4.0-stable-api"></a>
 
 - Stabilization of factory functions named `of` or `from`.
 - Deprecation of factory functions using [Result][kotlin.result] (issue
   [#263]).
 - Deprecation of the `ResultContext` type and its declarations (issue [#264]).
 
-### Experimental API
+### Experimental API <a id="v4.4.0-experimental-api"></a>
 
 - New type converters on `AnyInt` to [Byte][kotlin.byte],
   [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
@@ -56,17 +56,17 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 
 ## Version 5.0.0 <a id="v5.0.0"></a>
 
-### General
+### General <a id="v5.0.0-general"></a>
 
 - Support [Kotlin 1.8.10][kotlin-1.8.10] (issue [#172]).
 - Hiding internals from Java (issue [#303]).
 
-### Stable API
+### Stable API <a id="v5.0.0-stable-api"></a>
 
 - Removing factory functions using [Result][kotlin.result] (issue [#267]).
 - The deprecated `ResultContext` type.
 
-### Experimental API
+### Experimental API <a id="v5.0.0-experimental-api"></a>
 
 - New equality operations to bounds and ranges.
 - Deletion of deprecated annotations in the `kotools.types.experimental`

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -55,7 +55,7 @@ See the [corresponding milestone][milestone-4.3.3] for more details.
 
 ### Stable API <a id="v4.4.0-stable-api"></a>
 
-- Stabilization of factory functions named `of` or `from`.
+- Stabilization of factory functions named `of` or `from` (issue [#321]).
 - Deprecation of factory functions using [Result][kotlin.result] (issue
   [#263]).
 - Deprecation of the `ResultContext` type and its declarations (issue [#264]).
@@ -109,6 +109,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#318]: https://github.com/kotools/types/issues/318
 [#319]: https://github.com/kotools/types/issues/319
 [#320]: https://github.com/kotools/types/issues/320
+[#321]: https://github.com/kotools/types/issues/321
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -78,10 +78,6 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 - Deletion of factory functions using [Result][kotlin.result] (issue [#267]).
 - Deletion of the `ResultContext` type and its declarations (issue [#270]).
 
-### Experimental API <a id="v5.0.0-experimental-api"></a>
-
-- Remove deprecated annotations in the `kotools.types.experimental` package.
-
 See the [corresponding milestone][milestone-5.0.0] for more details.
 
 ## Discussing

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -31,11 +31,19 @@ Here’s a list of the most important things we focus on delivering:
 - Deletion of deprecated annotations in the `kotools.types.experimental`
   package, except the `ExperimentalKotoolsTypesApi` annotation.
 - Moving experimental declarations to the `kotools.types.experimental` package.
+
+See the [corresponding milestone][milestone-4.3.2] for more details.
+
+## Version 4.3.3 <a id="v4.3.3"></a>
+
+### Experimental API <a id="v4.3.3-experimental-api"></a>
+
 - New factory functions named `of` or `from` for all types (issue [#316]).
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
   types.
+- New equality operations to bounds and ranges.
 
-See the [corresponding milestone][milestone-4.3.2] for more details.
+See the [corresponding milestone][milestone-4.3.3] for more details.
 
 ## Version 4.4.0 <a id="v4.4.0"></a>
 
@@ -48,7 +56,6 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 
 ### Experimental API <a id="v4.4.0-experimental-api"></a>
 
-- New equality operations to bounds and ranges.
 - New type converters on `AnyInt` to [Byte][kotlin.byte],
   [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
   [Double][kotlin.double].
@@ -103,6 +110,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [kotlin.result]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result
 [kotlin.short]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-short
 [milestone-4.3.2]: https://github.com/kotools/types/milestone/22
+[milestone-4.3.3]: https://github.com/kotools/types/milestone/29
 [milestone-4.4.0]: https://github.com/kotools/types/milestone/7
 [milestone-5.0.0]: https://github.com/kotools/types/milestone/27
 [semantic-versioning]: https://semver.org

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -25,11 +25,11 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 ## Version 4.4.0 <a id="v4.4.0"></a>
 
 - New `ConvertibleToInt` stable type.
-- Stabilization of type converters suffixed by `OrNull`.
+- Stabilization of type converters suffixed by `OrNull` (see issue [#262]).
 - Deprecations:
-    - Type converters using [Result][kotlin.result].
-    - Type converters suffixed by `OrThow`.
-    - The `ResultContext` type and its declarations.
+    - Type converters using [Result][kotlin.result] (see issue [#263]).
+    - Type converters suffixed by `OrThow` (see issue [#312]).
+    - The `ResultContext` type and its declarations (see issue [#264]).
 - Experimental API:
     - New `ExperimentalKotoolsTypesApi` annotation in the
       `kotools.types.experimental` package.
@@ -69,7 +69,11 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
   useful for holding primitives).
 - Stabilization of the `Bound` and the `NotEmptyRange` types.
 
+[#262]: https://github.com/kotools/types/issues/262
+[#263]: https://github.com/kotools/types/issues/263
+[#264]: https://github.com/kotools/types/issues/264
 [#303]: https://github.com/kotools/types/issues/303
+[#312]: https://github.com/kotools/types/issues/312
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -30,7 +30,7 @@ Here’s a list of the most important things we focus on delivering:
 
 - New `ExperimentalKotoolsTypesApi` annotation (issue [#191]).
 - Deprecate annotations in the `kotools.types.experimental` package for using
-  the `ExperimentalKotoolsTypesApi` annotation.
+  the `ExperimentalKotoolsTypesApi` annotation (issue [#318]).
 - Moving experimental declarations to the `kotools.types.experimental` package.
 
 See the [corresponding milestone][milestone-4.3.2] for more details.
@@ -105,6 +105,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#312]: https://github.com/kotools/types/issues/312
 [#315]: https://github.com/kotools/types/discussions/315
 [#316]: https://github.com/kotools/types/issues/316
+[#318]: https://github.com/kotools/types/issues/318
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -42,7 +42,7 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 
 - New factory functions named `of` or `from` for all types (issue [#316]).
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
-  types.
+  types (issue [#258]).
 - New equality operations to bounds and ranges.
 
 See the [corresponding milestone][milestone-4.3.3] for more details.
@@ -96,6 +96,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#172]: https://github.com/kotools/types/issues/172
 [#191]: https://github.com/kotools/types/issues/191
 [#215]: https://github.com/kotools/types/issues/215
+[#258]: https://github.com/kotools/types/issues/258
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264
 [#267]: https://github.com/kotools/types/issues/267

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -23,14 +23,14 @@ Here’s a list of the most important things we focus on delivering:
 
 ### General <a id="v4.3.2-general"></a>
 
-- Documentation of this project's versioning strategy (issue [#215]).
-- Documentation of this project's declarations lifecycle (issue [#307]).
+- Documentation of the versioning strategy (issue [#215]).
+- Documentation of the declarations lifecycle (issue [#307]).
 
 ### Experimental API <a id="v4.3.2-experimental-api"></a>
 
-- New `ExperimentalKotoolsTypesApi` annotation.
-- Deletion of deprecated annotations in the `kotools.types.experimental`
-  package, except the `ExperimentalKotoolsTypesApi` annotation.
+- New `ExperimentalKotoolsTypesApi` annotation (issue [#191]).
+- Deprecate annotations in the `kotools.types.experimental` package for using
+  the `ExperimentalKotoolsTypesApi` annotation.
 - Moving experimental declarations to the `kotools.types.experimental` package.
 
 See the [corresponding milestone][milestone-4.3.2] for more details.
@@ -75,6 +75,10 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 - Deletion of factory functions using [Result][kotlin.result] (issue [#267]).
 - Deletion of the `ResultContext` type and its declarations (issue [#270]).
 
+### Experimental API <a id="v5.0.0-experimental-api"></a>
+
+- Remove deprecated annotations in the `kotools.types.experimental` package.
+
 See the [corresponding milestone][milestone-5.0.0] for more details.
 
 ## Discussing
@@ -89,6 +93,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 - Converting extension functions to member functions.
 
 [#172]: https://github.com/kotools/types/issues/172
+[#191]: https://github.com/kotools/types/issues/191
 [#215]: https://github.com/kotools/types/issues/215
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -16,7 +16,6 @@ Here’s a list of the most important things we focus on delivering:
 
 ## Version 4.3.2 <a id="v4.3.2"></a>
 
-- Hiding internals from Java.
 - Improving documentation on the repository and on the
   [API reference][api-reference].
 - Adhering to [Semantic Versioning][semantic-versioning].
@@ -47,6 +46,7 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 ## Version 5.0.0 <a id="v5.0.0"></a>
 
 - Support [Kotlin 1.8.10][kotlin-1.8.10].
+- Hiding internals from Java (see issue [#303]).
 - New flattened type system of integer numbers.
 - Deletions:
     - Deprecated type converters using [Result][kotlin.result].
@@ -69,6 +69,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
   useful for holding primitives).
 - Stabilization of the `Bound` and the `NotEmptyRange` types.
 
+[#303]: https://github.com/kotools/types/issues/303
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -1,3 +1,8 @@
+<!--
+    Copyright 2023 Loïc Lamarque.
+    Use of this source code is governed by the MIT license.
+-->
+
 # Roadmap
 
 The goal of this roadmap is to give you a big picture about what is coming for

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -7,10 +7,10 @@ Here’s a list of the most important things we focus on delivering:
 
 - **Aligning factory functions with Java & Kotlin standards** by representing
   possible failures with the `null` expression and by conventioning their name
-  (see discussion [#315]).
+  (discussion [#315]).
 - **Clearing separation between the experimental API and the stable API** by
   centralizing experimental declarations in the `kotools.types.experimental`
-  package (see discussion [#287]).
+  package (discussion [#287]).
 - **Adhering back to [Semantic Versioning][semantic-versioning]** for
   communicating clearly what's changed in the stable API.
 

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -44,7 +44,7 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
   types (issue [#258]).
 - New equality operations for the `Bound` type (issue [#223]).
-- New equality operations for the `NotEmptyRange` type.
+- New equality operations for the `NotEmptyRange` type (issue [#225]).
 - New type converters on `AnyInt` to [Byte][kotlin.byte],
   [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
   [Double][kotlin.double].
@@ -95,6 +95,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#191]: https://github.com/kotools/types/issues/191
 [#215]: https://github.com/kotools/types/issues/215
 [#223]: https://github.com/kotools/types/issues/223
+[#225]: https://github.com/kotools/types/issues/225
 [#258]: https://github.com/kotools/types/issues/258
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -29,7 +29,8 @@ Here’s a list of the most important things we focus on delivering:
 ### Experimental API <a id="v4.3.2-experimental-api"></a>
 
 - New `ExperimentalKotoolsTypesApi` annotation (issue [#191]).
-- Moving experimental declarations to the `kotools.types.experimental` package.
+- Moving experimental declarations to the `kotools.types.experimental` package
+  (issue [#319]).
 - Deletion of annotations in the `kotools.types.experimental` package, except
   the `ExperimentalKotoolsTypesApi` annotation (issue [#318]).
 
@@ -106,6 +107,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#315]: https://github.com/kotools/types/discussions/315
 [#316]: https://github.com/kotools/types/issues/316
 [#318]: https://github.com/kotools/types/issues/318
+[#319]: https://github.com/kotools/types/issues/319
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -47,7 +47,7 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 - New equality operations for the `NotEmptyRange` type (issue [#225]).
 - New type converters on `AnyInt` to [Byte][kotlin.byte],
   [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
-  [Double][kotlin.double].
+  [Double][kotlin.double] (issue [#320]).
 
 See the [corresponding milestone][milestone-4.3.3] for more details.
 
@@ -109,6 +109,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#316]: https://github.com/kotools/types/issues/316
 [#318]: https://github.com/kotools/types/issues/318
 [#319]: https://github.com/kotools/types/issues/319
+[#320]: https://github.com/kotools/types/issues/320
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -15,7 +15,7 @@ Here’s a list of the most important things we focus on delivering:
   (discussion [#315]).
 - **Clearing separation between the experimental API and the stable API** by
   centralizing experimental declarations in the `kotools.types.experimental`
-  package (discussion [#287]).
+  package (issue [#319]).
 - **Adhering back to [Semantic Versioning][semantic-versioning]** for
   communicating clearly what's changed in the stable API (issue [#215]).
 
@@ -101,7 +101,6 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#264]: https://github.com/kotools/types/issues/264
 [#267]: https://github.com/kotools/types/issues/267
 [#270]: https://github.com/kotools/types/issues/270
-[#287]: https://github.com/kotools/types/discussions/287
 [#303]: https://github.com/kotools/types/issues/303
 [#307]: https://github.com/kotools/types/issues/307
 [#312]: https://github.com/kotools/types/issues/312

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -5,12 +5,12 @@ Kotools Types.
 
 Here’s a list of the most important things we focus on delivering:
 
-- **Aligning type converters with our design goals on error handling** by
-  suffixing them with `OrNull` if they can fail, or by not suffixing them if
-  they shouldn't fail, for being agnostic about how users handle errors.
-- **Clearing separation of the experimental API from the stable API** by
+- **Aligning factory functions with Java & Kotlin standards** by representing
+  possible failures with the `null` expression and by conventioning their name
+  (see discussion [#315]).
+- **Clearing separation between the experimental API and the stable API** by
   centralizing experimental declarations in the `kotools.types.experimental`
-  package.
+  package (see discussion [#287]).
 - **Adhering back to [Semantic Versioning][semantic-versioning]** for
   communicating clearly what's changed in the stable API.
 
@@ -72,8 +72,10 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#262]: https://github.com/kotools/types/issues/262
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264
+[#287]: https://github.com/kotools/types/discussions/287
 [#303]: https://github.com/kotools/types/issues/303
 [#312]: https://github.com/kotools/types/issues/312
+[#315]: https://github.com/kotools/types/discussions/315
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -1,0 +1,84 @@
+# Kotools Types roadmap
+
+The goal of this roadmap is to give you a big picture about what is coming for
+this project.
+
+Here’s a list of the most important things we focus on delivering:
+
+- **Aligning type converters with our design goals on error handling** by
+  suffixing them with `OrNull` if they can fail, or by not suffixing them if
+  they shouldn't fail, for being agnostic about how users handle errors.
+- **Clearing separation of the experimental API from the stable API** by
+  centralizing experimental declarations in the `kotools.types.experimental`
+  package.
+- **Adhering back to [Semantic Versioning][semantic-versioning]** for
+  communicating clearly what's changed in the stable API.
+
+## Version 4.3.2 <a id="v4.3.2"></a>
+
+- Hiding internals from Java.
+- Improving documentation on the repository and on the
+  [API reference][api-reference].
+- Adhering to [Semantic Versioning][semantic-versioning].
+
+See the [corresponding milestone][milestone-4.3.2] for more details.
+
+## Version 4.4.0 <a id="v4.4.0"></a>
+
+- New `ConvertibleToInt` stable type.
+- Stabilization of type converters suffixed by `OrNull`.
+- Deprecations:
+    - Type converters using [Result][kotlin.result].
+    - Type converters suffixed by `OrThow`.
+    - The `ResultContext` type and its declarations.
+- Experimental API:
+    - New `ExperimentalKotoolsTypesApi` annotation in the
+      `kotools.types.experimental` package.
+    - New `StrictlyPositiveDouble` type in the `kotools.types.experimental`
+      package and deprecate the same type in the `kotools.types.number` package.
+    - New `Bound` and `NotEmptyRange` types in the `kotools.types.experimental`
+      package and deprecate the same types in the `kotools.types.range` package.
+    - New type converters on `ConvertibleToInt` to [Byte][kotlin.byte],
+      [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
+      [Double][kotlin.double].
+
+See the [corresponding milestone][milestone-4.4.0] for more details.
+
+## Version 5.0.0 <a id="v5.0.0"></a>
+
+- Support [Kotlin 1.8.10][kotlin-1.8.10].
+- New flattened type system of integer numbers.
+- Deletions:
+    - Deprecated type converters using [Result][kotlin.result].
+    - Deprecated type converters suffixed by `OrThow`.
+    - The deprecated `ResultContext` type.
+- Experimental API:
+    - New equality operations to bounds and ranges.
+    - Removing experimental declarations from the stable API.
+    - Removing annotations from the `kotools.types.experimental` package, except
+      the `ExperimentalKotoolsTypesApi` annotation.
+
+See the [corresponding milestone][milestone-5.0.0] for more details.
+
+## Unplanned
+
+- Support [Kotlin 1.8.22][kotlin-1.8.22].
+- Support [Kotlin 1.9.10][kotlin-1.9.10].
+- Stabilization of concatenations for the `NotBlankString` type.
+- Converting collections to normal classes (because value classes are only
+  useful for holding primitives).
+
+[api-reference]: https://types.kotools.org
+[kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
+[kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22
+[kotlin-1.9.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.9.10
+[kotlin.byte]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-byte
+[kotlin.double]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-double
+[kotlin.float]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-float
+[kotlin.long]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-long
+[kotlin.result]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result
+[kotlin.short]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-short
+[milestone-4.3.2]: https://github.com/kotools/types/milestone/22
+[milestone-4.4.0]: https://github.com/kotools/types/milestone/7
+[milestone-5.0.0]: https://github.com/kotools/types/milestone/27
+[semantic-versioning]: https://semver.org

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -18,12 +18,8 @@ Here’s a list of the most important things we focus on delivering:
 
 ### General <a id="v4.3.2-general"></a>
 
-- Improving documentation on the repository and on the
-  [API reference][api-reference] (issue [#317]).
-
-### Stable API <a id="v4.3.2-stable-api"></a>
-
-- Adhering to [Semantic Versioning][semantic-versioning] (issue [#215]).
+- Documentation of this project's versioning strategy (issue [#215]).
+- Documentation of this project's declarations lifecycle (issue [#307]).
 
 ### Experimental API <a id="v4.3.2-experimental-api"></a>
 
@@ -95,10 +91,10 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#270]: https://github.com/kotools/types/issues/270
 [#287]: https://github.com/kotools/types/discussions/287
 [#303]: https://github.com/kotools/types/issues/303
+[#307]: https://github.com/kotools/types/issues/307
 [#312]: https://github.com/kotools/types/issues/312
 [#315]: https://github.com/kotools/types/discussions/315
 [#316]: https://github.com/kotools/types/issues/316
-[#317]: https://github.com/kotools/types/issues/317
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -1,7 +1,7 @@
-# Kotools Types roadmap
+# Roadmap
 
 The goal of this roadmap is to give you a big picture about what is coming for
-this project.
+Kotools Types.
 
 Here’s a list of the most important things we focus on delivering:
 

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -16,9 +16,24 @@ Here’s a list of the most important things we focus on delivering:
 
 ## Version 4.3.2 <a id="v4.3.2"></a>
 
-- Adhering to [Semantic Versioning][semantic-versioning] (see issue [#215]).
+### General
+
 - Improving documentation on the repository and on the
-  [API reference][api-reference] (see issue [#317]).
+  [API reference][api-reference] (issue [#317]).
+
+### Stable API
+
+- Adhering to [Semantic Versioning][semantic-versioning] (issue [#215]).
+
+### Experimental API
+
+- Moving experimental declarations in the `kotools.types.experimental` package.
+- New `ExperimentalKotoolsTypesApi` annotation.
+- Deprecating all annotations in the `kotools.types.experimental` package for
+  using the `ExperimentalKotoolsTypesApi` annotation instead.
+- New factory functions named `of` or `from` for all types (issue [#316]).
+- Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
+  types.
 
 See the [corresponding milestone][milestone-4.3.2] for more details.
 
@@ -31,12 +46,6 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
     - Type converters suffixed by `OrThow` (see issue [#312]).
     - The `ResultContext` type and its declarations (see issue [#264]).
 - Experimental API:
-    - New `ExperimentalKotoolsTypesApi` annotation in the
-      `kotools.types.experimental` package.
-    - New `StrictlyPositiveDouble` type in the `kotools.types.experimental`
-      package and deprecate the same type in the `kotools.types.number` package.
-    - New `Bound` and `NotEmptyRange` types in the `kotools.types.experimental`
-      package and deprecate the same types in the `kotools.types.range` package.
     - New type converters on `ConvertibleToInt` to [Byte][kotlin.byte],
       [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
       [Double][kotlin.double].
@@ -49,7 +58,6 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 - Hiding internals from Java (see issue [#303]).
 - Deletions:
     - Factory functions using [Result][kotlin.result] (see issue [#267]).
-    - Deprecated type converters suffixed by `OrThow`.
     - The deprecated `ResultContext` type.
 - Experimental API:
     - New equality operations to bounds and ranges.
@@ -71,7 +79,6 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 
 [#172]: https://github.com/kotools/types/issues/172
 [#215]: https://github.com/kotools/types/issues/215
-[#262]: https://github.com/kotools/types/issues/262
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264
 [#267]: https://github.com/kotools/types/issues/267
@@ -79,6 +86,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#303]: https://github.com/kotools/types/issues/303
 [#312]: https://github.com/kotools/types/issues/312
 [#315]: https://github.com/kotools/types/discussions/315
+[#316]: https://github.com/kotools/types/issues/316
 [#317]: https://github.com/kotools/types/issues/317
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -60,6 +60,10 @@ See the [corresponding milestone][milestone-4.3.3] for more details.
   [#263]).
 - Deprecation of the `ResultContext` type and its declarations (issue [#264]).
 
+### Experimental API <a id="v4.4.0-experimental-api"></a>
+
+- Deletion of `Result.flatMap` function (issue [#125]).
+
 See the [corresponding milestone][milestone-4.4.0] for more details.
 
 ## Version 5.0.0 <a id="v5.0.0"></a>
@@ -91,6 +95,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 - New flattened type system of integer numbers.
 - Converting extension functions to member functions.
 
+[#125]: https://github.com/kotools/types/issues/125
 [#172]: https://github.com/kotools/types/issues/172
 [#191]: https://github.com/kotools/types/issues/191
 [#215]: https://github.com/kotools/types/issues/215

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -43,7 +43,7 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 - New factory functions named `of` or `from` for all types (issue [#316]).
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
   types (issue [#258]).
-- New equality operations for the `Bound` type.
+- New equality operations for the `Bound` type (issue [#223]).
 - New equality operations for the `NotEmptyRange` type.
 - New type converters on `AnyInt` to [Byte][kotlin.byte],
   [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
@@ -94,6 +94,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#172]: https://github.com/kotools/types/issues/172
 [#191]: https://github.com/kotools/types/issues/191
 [#215]: https://github.com/kotools/types/issues/215
+[#223]: https://github.com/kotools/types/issues/223
 [#258]: https://github.com/kotools/types/issues/258
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -29,8 +29,8 @@ Here’s a list of the most important things we focus on delivering:
 
 - Moving experimental declarations to the `kotools.types.experimental` package.
 - New `ExperimentalKotoolsTypesApi` annotation.
-- Deprecating all annotations in the `kotools.types.experimental` package for
-  using the `ExperimentalKotoolsTypesApi` annotation instead.
+- Deprecation of all annotations in the `kotools.types.experimental` package
+  for using the `ExperimentalKotoolsTypesApi` annotation instead.
 - New factory functions named `of` or `from` for all types (issue [#316]).
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
   types.
@@ -39,35 +39,42 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 
 ## Version 4.4.0 <a id="v4.4.0"></a>
 
-- New `ConvertibleToInt` stable type.
-- Stabilization of type converters suffixed by `OrNull` (see issue [#262]).
-- Deprecations:
-    - Type converters using [Result][kotlin.result] (see issue [#263]).
-    - Type converters suffixed by `OrThow` (see issue [#312]).
-    - The `ResultContext` type and its declarations (see issue [#264]).
-- Experimental API:
-    - New type converters on `ConvertibleToInt` to [Byte][kotlin.byte],
-      [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
-      [Double][kotlin.double].
+### Stable API
+
+- Stabilization of factory functions named `of` or `from`.
+- Deprecation of factory functions using [Result][kotlin.result] (issue
+  [#263]).
+- Deprecation of the `ResultContext` type and its declarations (issue [#264]).
+
+### Experimental API
+
+- New type converters on `AnyInt` to [Byte][kotlin.byte],
+  [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
+  [Double][kotlin.double].
 
 See the [corresponding milestone][milestone-4.4.0] for more details.
 
 ## Version 5.0.0 <a id="v5.0.0"></a>
 
-- Support [Kotlin 1.8.10][kotlin-1.8.10] (see issue [#172]).
-- Hiding internals from Java (see issue [#303]).
-- Deletions:
-    - Factory functions using [Result][kotlin.result] (see issue [#267]).
-    - The deprecated `ResultContext` type.
-- Experimental API:
-    - New equality operations to bounds and ranges.
-    - Removing experimental declarations from the stable API.
-    - Removing annotations from the `kotools.types.experimental` package, except
-      the `ExperimentalKotoolsTypesApi` annotation.
+### General
+
+- Support [Kotlin 1.8.10][kotlin-1.8.10] (issue [#172]).
+- Hiding internals from Java (issue [#303]).
+
+### Stable API
+
+- Removing factory functions using [Result][kotlin.result] (issue [#267]).
+- The deprecated `ResultContext` type.
+
+### Experimental API
+
+- New equality operations to bounds and ranges.
+- Deletion of deprecated annotations in the `kotools.types.experimental`
+  package, except the `ExperimentalKotoolsTypesApi` annotation.
 
 See the [corresponding milestone][milestone-5.0.0] for more details.
 
-## Unplanned
+## Discussing
 
 - Support [Kotlin 1.8.22][kotlin-1.8.22].
 - Support [Kotlin 1.9.10][kotlin-1.9.10].
@@ -76,6 +83,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
   useful for holding primitives).
 - Stabilization of the `Bound` and the `NotEmptyRange` types.
 - New flattened type system of integer numbers.
+- Converting extension functions to member functions.
 
 [#172]: https://github.com/kotools/types/issues/172
 [#215]: https://github.com/kotools/types/issues/215

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -29,9 +29,9 @@ Here’s a list of the most important things we focus on delivering:
 ### Experimental API <a id="v4.3.2-experimental-api"></a>
 
 - New `ExperimentalKotoolsTypesApi` annotation (issue [#191]).
-- Deprecate annotations in the `kotools.types.experimental` package for using
-  the `ExperimentalKotoolsTypesApi` annotation (issue [#318]).
 - Moving experimental declarations to the `kotools.types.experimental` package.
+- Deletion of annotations in the `kotools.types.experimental` package, except
+  the `ExperimentalKotoolsTypesApi` annotation (issue [#318]).
 
 See the [corresponding milestone][milestone-4.3.2] for more details.
 

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -27,7 +27,7 @@ Here’s a list of the most important things we focus on delivering:
 
 ### Experimental API
 
-- Moving experimental declarations in the `kotools.types.experimental` package.
+- Moving experimental declarations to the `kotools.types.experimental` package.
 - New `ExperimentalKotoolsTypesApi` annotation.
 - Deprecating all annotations in the `kotools.types.experimental` package for
   using the `ExperimentalKotoolsTypesApi` annotation instead.

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -12,7 +12,7 @@ Here’s a list of the most important things we focus on delivering:
   centralizing experimental declarations in the `kotools.types.experimental`
   package (discussion [#287]).
 - **Adhering back to [Semantic Versioning][semantic-versioning]** for
-  communicating clearly what's changed in the stable API.
+  communicating clearly what's changed in the stable API (issue [#215]).
 
 ## Version 4.3.2 <a id="v4.3.2"></a>
 

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -67,6 +67,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 - Stabilization of concatenations for the `NotBlankString` type.
 - Converting collections to normal classes (because value classes are only
   useful for holding primitives).
+- Stabilization of the `Bound` and the `NotEmptyRange` types.
 
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -45,11 +45,10 @@ See the [corresponding milestone][milestone-4.4.0] for more details.
 
 ## Version 5.0.0 <a id="v5.0.0"></a>
 
-- Support [Kotlin 1.8.10][kotlin-1.8.10].
+- Support [Kotlin 1.8.10][kotlin-1.8.10] (see issue [#172]).
 - Hiding internals from Java (see issue [#303]).
-- New flattened type system of integer numbers.
 - Deletions:
-    - Deprecated type converters using [Result][kotlin.result].
+    - Factory functions using [Result][kotlin.result] (see issue [#267]).
     - Deprecated type converters suffixed by `OrThow`.
     - The deprecated `ResultContext` type.
 - Experimental API:
@@ -68,11 +67,14 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 - Converting collections to normal classes (because value classes are only
   useful for holding primitives).
 - Stabilization of the `Bound` and the `NotEmptyRange` types.
+- New flattened type system of integer numbers.
 
+[#172]: https://github.com/kotools/types/issues/172
 [#215]: https://github.com/kotools/types/issues/215
 [#262]: https://github.com/kotools/types/issues/262
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264
+[#267]: https://github.com/kotools/types/issues/267
 [#287]: https://github.com/kotools/types/discussions/287
 [#303]: https://github.com/kotools/types/issues/303
 [#312]: https://github.com/kotools/types/issues/312

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -43,7 +43,11 @@ See the [corresponding milestone][milestone-4.3.2] for more details.
 - New factory functions named `of` or `from` for all types (issue [#316]).
 - Deletion of factory functions suffixed by `OrNull` and `OrThrow` for all
   types (issue [#258]).
-- New equality operations to bounds and ranges.
+- New equality operations for the `Bound` type.
+- New equality operations for the `NotEmptyRange` type.
+- New type converters on `AnyInt` to [Byte][kotlin.byte],
+  [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
+  [Double][kotlin.double].
 
 See the [corresponding milestone][milestone-4.3.3] for more details.
 
@@ -55,12 +59,6 @@ See the [corresponding milestone][milestone-4.3.3] for more details.
 - Deprecation of factory functions using [Result][kotlin.result] (issue
   [#263]).
 - Deprecation of the `ResultContext` type and its declarations (issue [#264]).
-
-### Experimental API <a id="v4.4.0-experimental-api"></a>
-
-- New type converters on `AnyInt` to [Byte][kotlin.byte],
-  [Short][kotlin.short], [Long][kotlin.long], [Float][kotlin.float] and
-  [Double][kotlin.double].
 
 See the [corresponding milestone][milestone-4.4.0] for more details.
 

--- a/documentation/roadmap.md
+++ b/documentation/roadmap.md
@@ -16,9 +16,9 @@ Here’s a list of the most important things we focus on delivering:
 
 ## Version 4.3.2 <a id="v4.3.2"></a>
 
+- Adhering to [Semantic Versioning][semantic-versioning] (see issue [#215]).
 - Improving documentation on the repository and on the
-  [API reference][api-reference].
-- Adhering to [Semantic Versioning][semantic-versioning].
+  [API reference][api-reference] (see issue [#317]).
 
 See the [corresponding milestone][milestone-4.3.2] for more details.
 
@@ -69,6 +69,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
   useful for holding primitives).
 - Stabilization of the `Bound` and the `NotEmptyRange` types.
 
+[#215]: https://github.com/kotools/types/issues/215
 [#262]: https://github.com/kotools/types/issues/262
 [#263]: https://github.com/kotools/types/issues/263
 [#264]: https://github.com/kotools/types/issues/264
@@ -76,6 +77,7 @@ See the [corresponding milestone][milestone-5.0.0] for more details.
 [#303]: https://github.com/kotools/types/issues/303
 [#312]: https://github.com/kotools/types/issues/312
 [#315]: https://github.com/kotools/types/discussions/315
+[#317]: https://github.com/kotools/types/issues/317
 [api-reference]: https://types.kotools.org
 [kotlin-1.8.10]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.10
 [kotlin-1.8.22]: https://github.com/JetBrains/kotlin/releases/tag/v1.8.22


### PR DESCRIPTION
This request documents the roadmap of Kotools Types and references this documentation in the README.

## Checklist

Here's the checklist to address before reviewing this request:

- [x] Delete the [4.5.0 milestone](https://github.com/kotools/types/milestone/9).
- [x] Delete the [4.6.0 milestone](https://github.com/kotools/types/milestone/26).
- [x] Delete the [4.7.0 milestone](https://github.com/kotools/types/milestone/28).
- [x] Update introduction in the roadmap.
- [x] Update the roadmap of v4.3.2.
- [x] Link items in the roadmap of v4.3.2 to issues for letting users track our progress.
- [x] Update the [4.3.2 milestone](https://github.com/kotools/types/milestone/22).
- [x] Update the roadmap of v4.3.3.
- [x] Link items in the roadmap of v4.3.3 to issues for letting users track our progress.
- [x] Update the [4.3.3 milestone](https://github.com/kotools/types/milestone/29).
- [x] Update the roadmap of v4.4.0.
- [x] Link items in the roadmap of v4.4.0 to issues for letting users track our progress.
- [x] Update the [4.4.0 milestone](https://github.com/kotools/types/milestone/7).
- [x] Update the roadmap of v5.0.0.
- [x] Link items in the roadmap of v5.0.0 to issues for letting users track our progress.
- [x] Update the [5.0.0 milestone](https://github.com/kotools/types/milestone/27).
