### PR TITLE
Remove versioning annotations from binary output (duplicate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,16 +47,16 @@ All notable changes to this project will be documented in this file.
 - Retention of the `ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and
   the `DeprecatedSinceKotoolsTypes` annotations from
   [BINARY][kotlin.AnnotationRetention.BINARY] to
-  [SOURCE][kotlin.AnnotationRetention.SOURCE] (PR [#214]).
+  [SOURCE][kotlin.AnnotationRetention.SOURCE] (PR [#310]).
 - Flatten source code directory structure like
   [recommended by Kotlin][directory-structure-convention] (issue [#260]).
 - Align styles of version [4.2.0] with the latest ones in [API reference] (issue
   [#261]).
 
 [4.2.0]: https://github.com/kotools/types/releases/tag/4.2.0
-[#214]: https://github.com/kotools/types/pull/214
 [#260]: https://github.com/kotools/types/issues/260
 [#261]: https://github.com/kotools/types/issues/261
+[#310]: https://github.com/kotools/types/pull/310
 [directory-structure-convention]: https://kotlinlang.org/docs/coding-conventions.html#directory-structure
 [kotlin.AnnotationRetention.BINARY]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-b-i-n-a-r-y.html
 [kotlin.AnnotationRetention.SOURCE]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,15 +44,22 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Retention of the `ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and
+  the `DeprecatedSinceKotoolsTypes` annotations from
+  [BINARY][kotlin.AnnotationRetention.BINARY] to
+  [SOURCE][kotlin.AnnotationRetention.SOURCE] (PR [#214]).
 - Flatten source code directory structure like
   [recommended by Kotlin][directory-structure-convention] (issue [#260]).
 - Align styles of version [4.2.0] with the latest ones in [API reference] (issue
   [#261]).
 
 [4.2.0]: https://github.com/kotools/types/releases/tag/4.2.0
+[#214]: https://github.com/kotools/types/pull/214
 [#260]: https://github.com/kotools/types/issues/260
 [#261]: https://github.com/kotools/types/issues/261
 [directory-structure-convention]: https://kotlinlang.org/docs/coding-conventions.html#directory-structure
+[kotlin.AnnotationRetention.BINARY]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-b-i-n-a-r-y.html
+[kotlin.AnnotationRetention.SOURCE]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html
 
 ### Fixed
 

--- a/src/commonMain/kotlin/Annotations.kt
+++ b/src/commonMain/kotlin/Annotations.kt
@@ -5,7 +5,7 @@
 
 package kotools.types
 
-import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationRetention.SOURCE
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
@@ -20,7 +20,7 @@ import kotlin.annotation.AnnotationTarget.TYPEALIAS
  * integers without leading zeros.
  */
 @MustBeDocumented
-@Retention(BINARY)
+@Retention(SOURCE)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class ExperimentalSinceKotoolsTypes(val version: String)
 
@@ -33,7 +33,7 @@ internal annotation class ExperimentalSinceKotoolsTypes(val version: String)
  * integers without leading zeros.
  */
 @MustBeDocumented
-@Retention(BINARY)
+@Retention(SOURCE)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class SinceKotoolsTypes(val version: String)
 
@@ -53,7 +53,7 @@ internal annotation class SinceKotoolsTypes(val version: String)
  * integers without leading zeros.
  */
 @MustBeDocumented
-@Retention(BINARY)
+@Retention(SOURCE)
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
 internal annotation class DeprecatedSinceKotoolsTypes(
     val warningSince: String,


### PR DESCRIPTION
> Duplicates the pull request #214.

This request removes the `ExperimentalSinceKotoolsTypes`, the `SinceKotoolsTypes` and the `DeprecatedSinceKotoolsTypes` annotations from the binary output by setting their retention to [SOURCE](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.annotation/-annotation-retention/-s-o-u-r-c-e.html).