### PR TITLE
Add the `ExperimentalKotoolsTypesApi` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to this project will be documented in this file.
 - Copyright notice at the top of each relevant file (issue [#257]).
 - Versioning strategy documentation (issue [#215]).
 - Template for release notes (issue [#283]).
+- The `ExperimentalKotoolsTypesApi` annotation for marking experimental
+  declarations of this project (issue [#191]).
 
 [4.1.0]: https://github.com/kotools/types/releases/tag/4.1.0
 [4.0.1]: https://github.com/kotools/types/releases/tag/4.0.1
@@ -42,6 +44,7 @@ All notable changes to this project will be documented in this file.
 [2.0.0]: https://github.com/kotools/types-legacy/releases/tag/v2.0.0
 [1.3.1]: https://github.com/kotools/types-legacy/releases/tag/v1.3.1
 [#215]: https://github.com/kotools/types/issues/215
+[#191]: https://github.com/kotools/types/issues/191
 [#250]: https://github.com/kotools/types/issues/250
 [#257]: https://github.com/kotools/types/issues/257
 [#283]: https://github.com/kotools/types/issues/283

--- a/api/types.api
+++ b/api/types.api
@@ -112,6 +112,9 @@ public final class kotools/types/collection/NotEmptySetKt {
 public abstract interface annotation class kotools/types/experimental/ExperimentalCollectionApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class kotools/types/experimental/ExperimentalKotoolsTypesApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class kotools/types/experimental/ExperimentalNumberApi : java/lang/annotation/Annotation {
 }
 

--- a/src/commonMain/kotlin/experimental/KotoolsTypesApi.kt
+++ b/src/commonMain/kotlin/experimental/KotoolsTypesApi.kt
@@ -1,0 +1,16 @@
+package kotools.types.experimental
+
+import kotools.types.SinceKotoolsTypes
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.TYPEALIAS
+
+/** Marks declarations that are still **experimental** in the API. */
+@MustBeDocumented
+@RequiresOptIn
+@Retention(BINARY)
+@SinceKotoolsTypes("4.3.2")
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+public annotation class ExperimentalKotoolsTypesApi


### PR DESCRIPTION
This request resolves #191 by introducing the new `ExperimentalKotoolsTypesApi` annotation in the `kotools.types.experimental` package.
