### PR TITLE
Document versioning strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Versions [4.1.0], [4.0.1], [4.0.0], [3.2.0], [2.0.0] and [1.3.1] in
   [API reference] (issue [#261]).
 - Copyright notice at the top of each relevant file (issue [#257]).
+- Versioning strategy documentation (issue [#215]).
 
 [4.1.0]: https://github.com/kotools/types/releases/tag/4.1.0
 [4.0.1]: https://github.com/kotools/types/releases/tag/4.0.1
@@ -39,6 +40,7 @@ All notable changes to this project will be documented in this file.
 [3.2.0]: https://github.com/kotools/libraries/releases/tag/types-v3.2.0
 [2.0.0]: https://github.com/kotools/types-legacy/releases/tag/v2.0.0
 [1.3.1]: https://github.com/kotools/types-legacy/releases/tag/v1.3.1
+[#215]: https://github.com/kotools/types/issues/215
 [#250]: https://github.com/kotools/types/issues/250
 [#257]: https://github.com/kotools/types/issues/257
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Here's additional documentation for learning more about this project:
 - [API reference][api-reference]
 - [Roadmap](documentation/roadmap.md)
 - [Security Policy](SECURITY.md)
+- [Versioning strategy](documentation/versioning-strategy.md)
 
 ## Community
 

--- a/documentation/versioning-strategy.md
+++ b/documentation/versioning-strategy.md
@@ -1,27 +1,28 @@
 # Versioning strategy
 
-The [Semantic Versioning][semantic-versioning] being a system widely used in
-open-source projects for indicating what type of changes are included in a new
-release, we will go back to this release strategy starting from version `4.3.2`.
-
-The goal of this change is to improve our communication about what's new in each
-version.
+The [Semantic Versioning][semantic-versioning] specifications being widely used
+in open-source projects for communicating what type of changes are included in
+a new release, the stable API of Kotools Types will follow this versioning
+strategy starting from version `4.3.2`.
 
 For instance, if the current version is `X.Y.Z`:
 
-- We will release a **patch** version `X.Y.(Z + 1)` if it introduces backward
-  compatible fixes to the public stable API. This includes implementation fixes,
-  documentation improvements, changes to the experimental API...
-- We will release a **minor** version `X.(Y + 1).0` if it introduces new
-  compatible changes to the public stable API. This includes stabilization of
-  experimental declarations, deprecations...
-- We will release a **major** version `(X + 1).0.0` if it introduces
-  incompatible changes to the public stable API. This includes removing
-  declarations from the stable API, adding a type to a sealed hierarchy...
+- We will release a **patch** version `X.Y.(Z + 1)` if we've introduced backward
+  compatible fixes to the stable API.
+  This includes implementation fixes, documentation improvements...
+- We will release a **minor** version `X.(Y + 1).0` if we've introduced
+  compatible changes to the stable API.
+  This includes stabilization of experimental declarations, deprecations of
+  stable declarations...
+- We will release a **major** version `(X + 1).0.0` if we've introduced
+  incompatible changes to the stable API.
+  This includes removing declarations, adding a type to a sealed type
+  hierarchy...
 
 Please note that the experimental API will not follow the
-[Semantic Versioning][semantic-versioning] specifications.
-This is because, by definition, the **experimental** declarations can evolve or
-can be removed at any point in time.
+[Semantic Versioning][semantic-versioning] specifications: its declarations can
+evolve or can be removed at any point in time.
+This means that we can ship changes to the experimental API in any type of
+release listed above.
 
-[semantic-versioning]: https://semver.org/
+[semantic-versioning]: https://semver.org

--- a/documentation/versioning-strategy.md
+++ b/documentation/versioning-strategy.md
@@ -1,0 +1,27 @@
+# Versioning strategy
+
+The [Semantic Versioning][semantic-versioning] being a system widely used in
+open-source projects for indicating what type of changes are included in a new
+release, we will go back to this release strategy starting from version `4.3.2`.
+
+The goal of this change is to improve our communication about what's new in each
+version.
+
+For instance, if the current version is `X.Y.Z`:
+
+- We will release a **patch** version `X.Y.(Z + 1)` if it introduces backward
+  compatible fixes to the public stable API. This includes implementation fixes,
+  documentation improvements, changes to the experimental API...
+- We will release a **minor** version `X.(Y + 1).0` if it introduces new
+  compatible changes to the public stable API. This includes stabilization of
+  experimental declarations, deprecations...
+- We will release a **major** version `(X + 1).0.0` if it introduces
+  incompatible changes to the public stable API. This includes removing
+  declarations from the stable API, adding a type to a sealed hierarchy...
+
+Please note that the experimental API will not follow the
+[Semantic Versioning][semantic-versioning] specifications.
+This is because, by definition, the **experimental** declarations can evolve or
+can be removed at any point in time.
+
+[semantic-versioning]: https://semver.org/

--- a/packages.md
+++ b/packages.md
@@ -9,6 +9,10 @@ Contains types such as `NotEmptyList` for manipulating collections.
 # Package kotools.types.experimental
 
 Experimental APIs, subject to change in future versions.
+This is the only package that doesn't follow the
+[Semantic Versioning][semantic-versioning] specifications.
+
+[semantic-versioning]: https://semver.org/
 
 # Package kotools.types.number
 
@@ -21,9 +25,9 @@ values.
 
 # Package kotools.types.result
 
-Contains declarations for manipulating the
-[Result](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/index.html)
-type.
+Contains declarations for manipulating the [Result][kotlin.Result] type.
+
+[kotlin.Result]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result/
 
 # Package kotools.types.text
 


### PR DESCRIPTION
This request resolves #215 by documenting the versioning strategy of Kotools Types starting from version `4.3.2`, and by updating the packages documentation in the API reference.
