### PR TITLE
Add template for release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
   [API reference] (issue [#261]).
 - Copyright notice at the top of each relevant file (issue [#257]).
 - Versioning strategy documentation (issue [#215]).
+- Template for release notes (issue [#283]).
 
 [4.1.0]: https://github.com/kotools/types/releases/tag/4.1.0
 [4.0.1]: https://github.com/kotools/types/releases/tag/4.0.1
@@ -43,6 +44,7 @@ All notable changes to this project will be documented in this file.
 [#215]: https://github.com/kotools/types/issues/215
 [#250]: https://github.com/kotools/types/issues/250
 [#257]: https://github.com/kotools/types/issues/257
+[#283]: https://github.com/kotools/types/issues/283
 
 ### Changed
 

--- a/documentation/release-notes/template.md
+++ b/documentation/release-notes/template.md
@@ -1,0 +1,94 @@
+<!--
+    Copyright $YEAR Kotools S.A.S.U.
+    Use of this source code is governed by the MIT license.
+-->
+
+# $VERSION
+
+_Release date: YYYY-MM-DD | [Full changelog][changelog]._
+
+This $TYPE release includes $HIGHLIGHTS.
+
+[changelog]: https://github.com/kotools/types/blob/main/CHANGELOG.md#VERSION
+
+## Installation
+
+Add the following dependency to your project for using Kotools Types $VERSION.
+
+<details open>
+<summary>Gradle - Kotlin DSL</summary>
+
+```kotlin
+implementation("org.kotools:types:$VERSION")
+```
+</details>
+
+<details>
+<summary>Gradle - Groovy DSL</summary>
+
+```groovy
+implementation "org.kotools:types:$VERSION"
+```
+</details>
+
+<details>
+<summary>Maven</summary>
+
+```xml
+<dependencies>
+    <dependency>
+        <groupId>org.kotools</groupId>
+        <artifactId>types</artifactId>
+        <version>${VERSION}</version>
+    </dependency>
+</dependencies>
+```
+</details>
+
+Visit the [API reference][api-reference] for more details on the declarations
+provided by this library.
+
+[api-reference]: https://types.kotools.org
+
+## Features and improvements
+
+## Resolved issues and requests
+
+$X issues and $X requests have been resolved in Kotools Types $VERSION.
+
+<details>
+<summary>Issues</summary>
+
+</details>
+
+<details>
+<summary>Requests</summary>
+
+</details>
+
+## External contributions
+
+As an Open-Source project, we love getting contributions from our community!
+
+If you are looking to contribute, have questions, or want to keep up-to-date
+about what's happening, please follow us here and say hi!
+
+- [GitHub Discussions][github-discussions]
+- [#kotools-types on Kotlin Slack][slack]
+
+See the [contributing guidelines](/CONTRIBUTING.md) for more details.
+
+[slack]: https://kotlinlang.slack.com/archives/C05H0L1LD25
+[github-discussions]: https://github.com/kotools/types/discussions
+
+## Reporting problems
+
+If you find a problem with this release, please [report a bug][bug-report] on
+GitHub.
+
+We hope you will build great things with Kotools Types, and we look forward to
+your feedback via [Slack], [Twitter] or [GitHub].
+
+[bug-report]: https://github.com/kotools/types/issues/new?assignees=&labels=bug&projects=&template=bug-template.md&title=Bug
+[github]: https://github.com/kotools
+[twitter]: https://twitter.com/KotoolsContact


### PR DESCRIPTION
This request resolves #283 by adding a template for release notes in the `documentation/release-notes` directory.
