### PR TITLE
Update opt-in message of experimental annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,12 @@ All notable changes to this project will be documented in this file.
   [recommended by Kotlin][directory-structure-convention] (issue [#260]).
 - Align styles of version [4.2.0] with the latest ones in [API reference] (issue
   [#261]).
+- Opt-in message of experimental annotations (PR [#328]).
 
 [4.2.0]: https://github.com/kotools/types/releases/tag/4.2.0
 [#260]: https://github.com/kotools/types/issues/260
 [#261]: https://github.com/kotools/types/issues/261
+[#328]: https://github.com/kotools/types/pull/328
 [directory-structure-convention]: https://kotlinlang.org/docs/coding-conventions.html#directory-structure
 
 ### Fixed

--- a/src/commonMain/kotlin/experimental/Annotations.kt
+++ b/src/commonMain/kotlin/experimental/Annotations.kt
@@ -12,9 +12,12 @@ import kotlin.annotation.AnnotationTarget.FUNCTION
 import kotlin.annotation.AnnotationTarget.PROPERTY
 import kotlin.annotation.AnnotationTarget.TYPEALIAS
 
+private const val OPT_IN_MESSAGE: String = "This declaration is experimental" +
+        " and can be incompatibly changed in the future."
+
 /** Marks declarations that are still **experimental** in the collection API. */
 @MustBeDocumented
-@RequiresOptIn
+@RequiresOptIn(OPT_IN_MESSAGE)
 @Retention(BINARY)
 @SinceKotoolsTypes("4.3.1")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
@@ -22,7 +25,7 @@ public annotation class ExperimentalCollectionApi
 
 /** Marks declarations that are still **experimental** in the number API. */
 @MustBeDocumented
-@RequiresOptIn
+@RequiresOptIn(OPT_IN_MESSAGE)
 @Retention(BINARY)
 @SinceKotoolsTypes("4.2")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
@@ -30,7 +33,7 @@ public annotation class ExperimentalNumberApi
 
 /** Marks declarations that are still **experimental** in the range API. */
 @MustBeDocumented
-@RequiresOptIn
+@RequiresOptIn(OPT_IN_MESSAGE)
 @Retention(BINARY)
 @SinceKotoolsTypes("4.2")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
@@ -38,7 +41,7 @@ public annotation class ExperimentalRangeApi
 
 /** Marks declarations that are still **experimental** in the result API. */
 @MustBeDocumented
-@RequiresOptIn
+@RequiresOptIn(OPT_IN_MESSAGE)
 @Retention(BINARY)
 @SinceKotoolsTypes("4.2")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
@@ -46,7 +49,7 @@ public annotation class ExperimentalResultApi
 
 /** Marks declarations that are still **experimental** in the text API. */
 @MustBeDocumented
-@RequiresOptIn
+@RequiresOptIn(OPT_IN_MESSAGE)
 @Retention(BINARY)
 @SinceKotoolsTypes("4.2")
 @Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)


### PR DESCRIPTION
This request updates the opt-in message of annotations in the `kotools.types.experimental` package.