### PR TITLE
⬆️ Bump gradle-build-action from 2.12.0 to 3.0.0

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishJsPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -53,7 +53,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishJvmPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -71,7 +71,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishLinuxPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -89,7 +89,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH for macOS x64
         run: ./gradlew :types-internal:publishMacosPublicationToOSSRHRepository
       - name: Deliver 'internal' subproject to OSSRH for macOS arm64
@@ -111,7 +111,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishWindowsPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -135,7 +135,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishKotlinMultiplatformPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishJsPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -53,7 +53,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishJvmPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -71,7 +71,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishLinuxPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -89,7 +89,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH for macOS x64
         run: ./gradlew :types-internal:publishMacosPublicationToOSSRHRepository
       - name: Deliver 'internal' subproject to OSSRH for macOS arm64
@@ -111,7 +111,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishWindowsPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH
@@ -135,7 +135,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
       - name: Deliver 'internal' subproject to OSSRH
         run: ./gradlew :types-internal:publishKotlinMultiplatformPublicationToOSSRHRepository
       - name: Deliver root project to OSSRH

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,7 +69,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
           dependency-graph-continue-on-failure: false
@@ -92,7 +92,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
           dependency-graph-continue-on-failure: false
@@ -117,7 +117,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
           dependency-graph-continue-on-failure: false
@@ -140,7 +140,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
           dependency-graph-continue-on-failure: false
@@ -167,7 +167,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.0.0
+        uses: gradle/actions/setup-gradle@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
           dependency-graph-continue-on-failure: false

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -69,7 +69,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
       - name: Test 'internal' subproject
@@ -91,7 +91,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
       - name: Test 'internal' subproject
@@ -115,7 +115,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
       - name: Test 'internal' subproject
@@ -137,7 +137,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
       - name: Test 'internal' subproject on macOS x64
@@ -163,7 +163,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2.12.0
+        uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
       - name: Test 'internal' subproject

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,6 +72,7 @@ jobs:
         uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
+          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:jsTest
       - name: Test root project
@@ -94,6 +95,7 @@ jobs:
         uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
+          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:jvmTest
       - name: Test 'java-compatibility' subproject
@@ -118,6 +120,7 @@ jobs:
         uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
+          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:linuxTest
       - name: Test root project
@@ -140,6 +143,7 @@ jobs:
         uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
+          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject on macOS x64
         run: ./gradlew :types-internal:macosTest
       - name: Test 'internal' subproject on macOS arm64
@@ -166,6 +170,7 @@ jobs:
         uses: gradle/gradle-build-action@v3.0.0
         with:
           dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
+          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:windowsTest
       - name: Test root project

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,16 +24,10 @@ on:
       - yarn.lock
   workflow_dispatch:
 env:
-  GRADLE_DEPENDENCY_GRAPH: |
-    ${{
-      github.event_name == 'push' && github.ref_name == 'main'
-          && 'generate-and-submit'
-          || 'disabled'
-    }}
   JAVA_DISTRIBUTION: temurin
   JAVA_VERSION: 17
 jobs:
-  # ---------- Stage 1 ----------
+  # --------------------------------- Stage 1 ----------------------------------
   gradle-wrapper-validation:
     name: Gradle wrapper validation
     runs-on: ubuntu-latest
@@ -53,13 +47,11 @@ jobs:
         with:
           args: --fail-threshold,0
           pr-mode: false
-  # ---------- Stage 2 ----------
+  # --------------------------------- Stage 2 ----------------------------------
   js-test:
     name: Kotlin/JS tests
     needs: gradle-wrapper-validation
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.0.0
@@ -70,9 +62,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.0.0
-        with:
-          dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
-          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:jsTest
       - name: Test root project
@@ -81,8 +70,6 @@ jobs:
     name: Kotlin/JVM checks
     needs: gradle-wrapper-validation
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.0.0
@@ -93,9 +80,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.0.0
-        with:
-          dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
-          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:jvmTest
       - name: Test 'java-compatibility' subproject
@@ -106,8 +90,6 @@ jobs:
     name: Kotlin Native tests for Linux
     needs: gradle-wrapper-validation
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.0.0
@@ -118,9 +100,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.0.0
-        with:
-          dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
-          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:linuxTest
       - name: Test root project
@@ -129,8 +108,6 @@ jobs:
     name: Kotlin Native tests for macOS
     needs: gradle-wrapper-validation
     runs-on: macos-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.0.0
@@ -141,9 +118,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.0.0
-        with:
-          dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
-          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject on macOS x64
         run: ./gradlew :types-internal:macosTest
       - name: Test 'internal' subproject on macOS arm64
@@ -156,8 +130,6 @@ jobs:
     name: Kotlin Native tests for Windows
     needs: gradle-wrapper-validation
     runs-on: windows-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.0.0
@@ -168,10 +140,26 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.0.0
-        with:
-          dependency-graph: ${{ env.GRADLE_DEPENDENCY_GRAPH }}
-          dependency-graph-continue-on-failure: false
       - name: Test 'internal' subproject
         run: ./gradlew :types-internal:windowsTest
       - name: Test root project
         run: ./gradlew :windowsTest
+  # --------------------------------- Stage 3 ----------------------------------
+  dependency-submission:
+    name: Dependency submission
+    needs:
+      - js-test
+      - jvm-checks
+      - linux-test
+      - macos-test
+      - static-code-analysis
+      - windows-test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref_name == 'main'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.0.0
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3.0.0


### PR DESCRIPTION
This request bumps the [gradle-build-action](https://github.com/gradle/gradle-build-action) to [v3.0.0](https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0).

## Checklist

- [x] Bump to v3.0.0.
- [x] Force job to fail on dependency graph submission failures.
- [x] Use `gradle/actions/setup-gradle@v3` like recommended in release notes.