### PR TITLE
💥 Changes signature of `NotBlankString.Companion.create*` functions

### DIFF
--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -124,7 +124,7 @@ public value class NotBlankString private constructor(
         @ExperimentalKotoolsTypesApi
         @ExperimentalSince(KotoolsTypesVersion.V4_5_0)
         @JvmSynthetic
-        public fun createOrNull(value: Any?): NotBlankString? {
+        public fun createOrNull(value: Any): NotBlankString? {
             val text: String = value.toString()
             val isValid: Boolean = text.isNotBlank()
             return if (isValid) NotBlankString(text)

--- a/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
+++ b/src/commonMain/kotlin/kotools/types/text/NotBlankString.kt
@@ -93,7 +93,7 @@ public value class NotBlankString private constructor(
         @ExperimentalKotoolsTypesApi
         @ExperimentalSince(KotoolsTypesVersion.V4_5_0)
         @JvmSynthetic
-        public fun create(value: Any?): NotBlankString {
+        public fun create(value: Any): NotBlankString {
             val text: String = value.toString()
             val isValid: Boolean = text.isNotBlank()
             require(isValid) { ErrorMessage.blankString }

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -30,10 +30,6 @@ private object StringExample {
 
 @ExperimentalKotoolsTypesApi
 class NotBlankStringCompanionTest {
-    @Test
-    fun create_should_pass_with_null() {
-        NotBlankString.create(null)
-    }
 
     @Test
     fun create_should_pass_with_an_object_having_a_not_blank_string_representation() {

--- a/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
+++ b/src/commonTest/kotlin/kotools/types/text/NotBlankStringTest.kt
@@ -50,12 +50,6 @@ class NotBlankStringCompanionTest {
     }
 
     @Test
-    fun createOrNull_should_pass_with_null() {
-        val actual: NotBlankString? = NotBlankString.createOrNull(null)
-        assertNotNull(actual)
-    }
-
-    @Test
     fun createOrNull_should_pass_with_an_object_having_a_not_blank_string_representation() {
         val value: Any = StringExample.NOT_BLANK
         val actual: NotBlankString? = NotBlankString.createOrNull(value)


### PR DESCRIPTION
> Close #541.

Following the guidelines of issue #541, accepting a nullable object may be confusing for users:

- Updated the signatures of the _NotBlankString.Companion.create()_ and _NotBlankString.Companion.createOrNull()_
- Tests related to the function invocation using passing a 'null' argument seem irrelevant now and are being deleted, however this may need further review by the repository maintainers, please keep an eye on this!
- API Binaries update wasn't required

