### PR TITLE
👷 Rewrite Gradle plugins

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,8 @@ convention-documentation-root = { id = "convention.documentation.root" }
 convention-kotlin-multiplatform = { id = "convention.kotlin.multiplatform" }
 convention-publication-module = { id = "convention.publication.module" }
 convention-publication-root = { id = "convention.publication.root" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinx-binary-compatibility-validator" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotools-samples-multiplatform = { id = "org.kotools.samples.multiplatform" }


### PR DESCRIPTION
## 📝 Description

This request rewrites the Gradle plugins available internally in Kotools Types, from [pre-compiled script plugins](https://docs.gradle.org/8.12.1/userguide/implementing_gradle_plugins_precompiled.html) to [binary plugins](https://docs.gradle.org/8.12.1/userguide/implementing_gradle_plugins_binary.html). It also tries to apply [these Gradle best practices](https://github.com/liutikas/gradle-best-practices) as much as possible.

<!-- TODO: Add an overview of Gradle plugins available. -->

## ✅ Checklist

- [x] ➕ Add missing plugins in version catalog.
- [ ] ...