### PR TITLE
🏷️ Add `Integer` type

### DIFF
--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/KotoolsTypesVersion.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/KotoolsTypesVersion.kt
@@ -3,6 +3,8 @@ package org.kotools.types.internal
 /** Represents a version of Kotools Types. */
 @InternalKotoolsTypesApi
 public enum class KotoolsTypesVersion {
+    Unreleased,
+
     /** Version 1.0.0. */
     V1_1_0,
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -373,3 +373,7 @@ public abstract interface annotation class org/kotools/types/ExperimentalKotools
 public abstract interface class org/kotools/types/Integer {
 }
 
+public final class org/kotools/types/Integers {
+	public static final fun from (J)Lorg/kotools/types/Integer;
+}
+

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -370,3 +370,6 @@ public final class org/kotools/types/EmailAddressRegex$Companion {
 public abstract interface annotation class org/kotools/types/ExperimentalKotoolsTypesApi : java/lang/annotation/Annotation {
 }
 
+public abstract interface class org/kotools/types/Integer {
+}
+

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
@@ -1,5 +1,8 @@
 package org.kotools.types
 
+import org.kotools.types.internal.ExperimentalSince
+import org.kotools.types.internal.KotoolsTypesVersion
+
 /**
  * Represents an integer.
  *
@@ -8,5 +11,5 @@ package org.kotools.types
  * [Long.MAX_VALUE] and lesser values than [Long.MIN_VALUE].
  */
 @ExperimentalKotoolsTypesApi
-// TODO: @ExperimentalSince(KotoolsTypesVersion.Unreleased)
+@ExperimentalSince(KotoolsTypesVersion.Unreleased)
 public interface Integer

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
@@ -1,0 +1,12 @@
+package org.kotools.types
+
+/**
+ * Represents an integer.
+ *
+ * Contrarily to the Kotlin integer types ([Byte], [Short], [Int] and [Long]),
+ * this type has no maximum and minimum values. It can hold greater values than
+ * [Long.MAX_VALUE] and lesser values than [Long.MIN_VALUE].
+ */
+@ExperimentalKotoolsTypesApi
+// TODO: @ExperimentalSince(KotoolsTypesVersion.Unreleased)
+public interface Integer

--- a/subprojects/library/src/jsJvmTest/kotlin/org/kotools/types/IntegerJsJvmSample.kt
+++ b/subprojects/library/src/jsJvmTest/kotlin/org/kotools/types/IntegerJsJvmSample.kt
@@ -1,0 +1,13 @@
+package org.kotools.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class IntegerJsJvmSample {
+    @Test
+    fun constructorLong() {
+        val integer = Integer(Long.MAX_VALUE)
+        assertEquals(expected = "9223372036854775807", "$integer")
+    }
+}

--- a/subprojects/library/src/jsJvmTest/kotlin/org/kotools/types/IntegerJsJvmTest.kt
+++ b/subprojects/library/src/jsJvmTest/kotlin/org/kotools/types/IntegerJsJvmTest.kt
@@ -1,0 +1,21 @@
+package org.kotools.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class IntegerJsJvmTest {
+    @Test
+    fun constructorPassesWithMaximumLong() {
+        val number: Long = Long.MAX_VALUE
+        val integer = Integer(number)
+        assertEquals(expected = "$number", actual = "$integer")
+    }
+
+    @Test
+    fun constructorPassesWithMinimumLong() {
+        val number: Long = Long.MIN_VALUE
+        val integer = Integer(number)
+        assertEquals(expected = "$number", actual = "$integer")
+    }
+}

--- a/subprojects/library/src/jsMain/kotlin/org/kotools/types/Integer.js.kt
+++ b/subprojects/library/src/jsMain/kotlin/org/kotools/types/Integer.js.kt
@@ -16,21 +16,19 @@ import org.kotools.types.internal.KotoolsTypesVersion
  *
  * SAMPLE: [org.kotools.types.IntegerJsJvmSample.constructorLong]
  * </details>
- * <br>
- *
- * This function is not yet supported on Kotlin/Native.
  */
 @ExperimentalKotoolsTypesApi
 @ExperimentalSince(KotoolsTypesVersion.Unreleased)
-public expect fun Integer(number: Long): Integer
+public actual fun Integer(number: Long): Integer {
+    val integer = BigInt("$number")
+    return JsInteger(integer)
+}
 
-/**
- * Represents an integer.
- *
- * Contrarily to the Kotlin integer types ([Byte], [Short], [Int] and [Long]),
- * this type has no maximum and minimum values. It can hold greater values than
- * [Long.MAX_VALUE] and lesser values than [Long.MIN_VALUE].
- */
-@ExperimentalKotoolsTypesApi
-@ExperimentalSince(KotoolsTypesVersion.Unreleased)
-public interface Integer
+@OptIn(ExperimentalKotoolsTypesApi::class)
+private class JsInteger(private val integer: BigInt) : Integer {
+    override fun toString(): String = this.integer.toString()
+}
+
+private external fun BigInt(value: String): BigInt
+
+private external object BigInt

--- a/subprojects/library/src/jvmMain/kotlin/org/kotools/types/Integer.jvm.kt
+++ b/subprojects/library/src/jvmMain/kotlin/org/kotools/types/Integer.jvm.kt
@@ -1,0 +1,48 @@
+@file:JvmName("Integers")
+
+package org.kotools.types
+
+import org.kotools.types.internal.ExperimentalSince
+import org.kotools.types.internal.KotoolsTypesVersion
+import java.math.BigInteger
+
+/**
+ * Creates an instance of [Integer] from the specified [number].
+ *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Calling from Kotlin</b>
+ * </summary>
+ *
+ * Here's an example of calling this function from Kotlin code:
+ *
+ * SAMPLE: [org.kotools.types.IntegerJsJvmSample.constructorLong]
+ * </details>
+ *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Calling from Java</b>
+ * </summary>
+ *
+ * The Java static method generated from this function is named `from` and
+ * callable on the `Integers` generated class.
+ *
+ * Here's an example of calling this function from Java code:
+ *
+ * SAMPLE: [org.kotools.types.IntegerJavaSample.constructorLong]
+ * </details>
+ */
+@ExperimentalKotoolsTypesApi
+@ExperimentalSince(KotoolsTypesVersion.Unreleased)
+@JvmName("from")
+public actual fun Integer(number: Long): Integer {
+    val integer: BigInteger = BigInteger.valueOf(number)
+    return JvmInteger(integer)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+private class JvmInteger(private val integer: BigInteger) : Integer {
+    override fun toString(): String = this.integer.toString()
+}

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/IntegerJavaSample.java
@@ -1,0 +1,16 @@
+package org.kotools.types;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.kotools.types.internal.Warning;
+
+@SuppressWarnings(Warning.TEST_JAVA_CLASS_NAME)
+public class IntegerJavaSample {
+    @Test
+    void constructorLong() {
+        final String result = Integers.from(Long.MAX_VALUE)
+                .toString();
+        final String expected = "9223372036854775807";
+        Assertions.assertEquals(expected, result);
+    }
+}

--- a/subprojects/library/src/nativeMain/kotlin/org/kotools/types/Integer.native.kt
+++ b/subprojects/library/src/nativeMain/kotlin/org/kotools/types/Integer.native.kt
@@ -1,0 +1,13 @@
+package org.kotools.types
+
+import org.kotools.types.internal.ExperimentalSince
+import org.kotools.types.internal.KotoolsTypesVersion
+
+/**
+ * Throws a [NotImplementedError] indicating that this function is not yet
+ * supported on Kotlin/Native.
+ */
+@ExperimentalKotoolsTypesApi
+@ExperimentalSince(KotoolsTypesVersion.Unreleased)
+public actual fun Integer(number: Long): Integer =
+    throw NotImplementedError("Not yet supported on Kotlin/Native.")

--- a/subprojects/library/src/nativeTest/kotlin/org/kotools/types/IntegerNativeTest.kt
+++ b/subprojects/library/src/nativeTest/kotlin/org/kotools/types/IntegerNativeTest.kt
@@ -1,0 +1,17 @@
+package org.kotools.types
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class IntegerNativeTest {
+    @Test
+    fun constructorLongFails() {
+        val number: Long = Long.MAX_VALUE
+        val error: NotImplementedError = assertFailsWith { Integer(number) }
+        val actual: String? = error.message
+        val expected = "Not yet supported on Kotlin/Native."
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
## 📝 Description

This request adds the `Integer` type, in the `org.kotools.types` package, for Common, JVM and JS platforms.

```kotlin
fun Integer(number: Long): Integer = TODO()
fun Integer(text: String): Integer = TODO()

interface Integer : Comparable<Integer> {
    override fun equals(other: Any?): Boolean
    override fun hashCode(): Int

    operator fun compareTo(other: Long): Int
    override fun compareTo(other: Integer): Int

    operator fun unaryMinus(): Integer

    operator fun plus(other: Long): Integer
    operator fun plus(other: Integer): Integer

    operator fun minus(other: Long): Integer
    operator fun minus(other: Integer): Integer

    operator fun times(other: Long): Integer
    operator fun times(other: Integer): Integer

    override fun toString(): String
}
```

## ✅ Checklist

- [x] 🏷️ Add `Integer` type.
- [x] ✨ Add `Integer(Long)` function.
- [ ] ✨ Override `Integer.toString()` function.
- [ ] ✨ Override `Integer.equals(Any?)` function.
- [ ] ✨ Override `Integer.hashCode()` function.
- [ ] ✨ Add `Integer(String)` function.
- [ ] ✨ Make `Integer` implementing `Comparable<Integer>`.
- [ ] ✨ Add `Integer.compareTo(Long)` function.
- [ ] ✨ Add `Integer.unaryMinus()` function.
- [ ] ✨ Add `Integer.plus(Integer)` function.
- [ ] ...
- [ ] 📝 Update unreleased changelog.