### PR TITLE
📝 Improve docs of `Integer`, design goals and README

### DIFF
--- a/.github/workflows/api-reference.yml
+++ b/.github/workflows/api-reference.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.7.3
         with:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -11,7 +11,7 @@ jobs:
       GRADLE_CACHE_CLEANUP: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Setup Java
         uses: actions/setup-java@v4.7.0
         with:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.1
+        uses: gradle/actions/setup-gradle@v5.0.2
       - name: Publish sources
         run: ./gradlew :publishSources
       - name: Archive distribution

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -15,6 +15,6 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4.3.1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Setup Java
         uses: actions/setup-java@v4.7.0
         with:
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Setup Java
         uses: actions/setup-java@v4.7.0
         with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Setup Java
         uses: actions/setup-java@v4.7.0
         with:
@@ -79,7 +79,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.1
       - name: Setup Java
         uses: actions/setup-java@v4.7.0
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -51,7 +51,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5.0.1
       - name: Setup Java
-        uses: actions/setup-java@v4.7.0
+        uses: actions/setup-java@v5.2.0
         with:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.1
+        uses: gradle/actions/setup-gradle@v5.0.2
       - name: Build 'plugins' project
         run: ./gradlew :plugins:build
   internal:
@@ -56,7 +56,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.1
+        uses: gradle/actions/setup-gradle@v5.0.2
       - name: Build 'types-internal' project
         run: ./gradlew :types-internal:build
   library:
@@ -71,7 +71,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.1
+        uses: gradle/actions/setup-gradle@v5.0.2
       - name: Build 'types' project
         run: ./gradlew :types:build
   kotlin-serialization:
@@ -86,6 +86,6 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
           java-version: ${{ env.JAVA_VERSION }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.1
+        uses: gradle/actions/setup-gradle@v5.0.2
       - name: Build 'types-kotlinx-serialization' project
         run: ./gradlew :types-kotlinx-serialization:build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
 
 ## 🚧 Unreleased
 
+### ♻️ Changed
+
+- Improve the vision of Kotools Types in design goals, README and `Integer`
+  type's documentation ([#913](https://github.com/kotools/types/pull/913)).
+
 ## 🔖 Releases
 
 | Version | Release date |

--- a/README.md
+++ b/README.md
@@ -99,28 +99,11 @@ implementation "org.kotools:types:$version"
 > for serializing types from the `org.kotools.types` package using the
 > [kotlinx.serialization] library. 
 
-## 🎨 Included types
-
-Explore some of the types offered by this library:
-
-- [NotBlankString][kotools.types.text.NotBlankString] ensuring that your strings
-  have at least one character excluding whitespaces.
-- [PositiveInt][kotools.types.number.PositiveInt] representing an integer number
-  of type [Int][kotlin.Int] that is greater than or equals zero.
-- [NotEmptyList][kotools.types.collection.NotEmptyList] for grouping your data
-  in a list with at least one element.
-
-See the [API reference](https://types.kotools.org) for more types!
-
-[kotlin.Int]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int
-[kotools.types.collection.NotEmptyList]: https://types.kotools.org/types/kotools.types.collection/-not-empty-list/index.html
-[kotools.types.number.PositiveInt]: https://types.kotools.org/types/kotools.types.number/-positive-int/index.html
-[kotools.types.text.NotBlankString]: https://types.kotools.org/types/kotools.types.text/-not-blank-string/index.html
-
 ## 📝 Documentation
 
 Here's additional documentation for learning more about this project:
 
+- [API reference](https://types.kotools.org)
 - [Design goals](documentation/design-goals.md)
 - [Versioning strategy](documentation/versioning-strategy.md)
 - [Dependency compatibility](documentation/dependencies.md)

--- a/README.md
+++ b/README.md
@@ -14,13 +14,6 @@
 [![macOS arm64 Platform][macos-arm64-platform-badge]][kotlin-native]
 [![MinGW x64 Platform][mingw-x64-platform-badge]][kotlin-native]
 
-> "Kool Types for Kotlin Multiplatform." -
-> [@jmfayard](https://github.com/jmfayard)
-
-Unlock the true potential of Kotlin's type system across Kotlin/JVM, Kotlin/JS,
-and Kotlin/Native platforms with Kotools Types – your comprehensive toolkit for
-explicit type handling!
-
 [ios-arm64-platform-badge]: https://img.shields.io/badge/Platform-iOS_arm64-4b4bff
 [ios-simulator-arm64-platform-badge]: https://img.shields.io/badge/Platform-iOS_Simulator_arm64-4b4bff
 [ios-x64-platform-badge]: https://img.shields.io/badge/Platform-iOS_x64-4b4bff
@@ -42,21 +35,28 @@ explicit type handling!
 
 ## 🚀 Introduction
 
-Kotools Types is not just a library; it's your gateway to seamless and
-expressive type manipulation in Kotlin projects.
-Dive into a world where types are your allies, providing clarity, safety, and
-flexibility across diverse Kotlin platforms.
+Kotools Types is a Kotlin Multiplatform library providing types that model
+real-world concepts with correct and predictable behavior.
+
+Instead of exposing the limitations of underlying platforms, these types follow
+their domain definitions. For example, the [Integer](https://types.kotools.org/types/org.kotools.types/-integer/index.html)
+type represents a mathematical integer and does not overflow.
+
+By using Kotools Types, you can build APIs that are more explicit, easier to
+reason about, and less error-prone across JVM, JS, and Native platforms.
 
 ## ⭐️ Key Features
 
-- **Unified Type Handling:** Embrace a unified approach to handling types across
-  platforms, ensuring consistency in your Kotlin/JVM, Kotlin/JS and
-  Kotlin/Native projects.
-- **Enhanced Type Safety:** Fortify your code with explicit types, catching
-  errors at compile time to create robust and reliable applications.
-- **Automatic Serialization:** Seamlessly serialize and deserialize types using
-  [kotlinx.serialization], making data interchange between platforms, APIs, 
-  databases and libraries a breeze.
+- **Correct by Design:** Types model real-world concepts and provide predictable
+  behavior, avoiding common pitfalls such as integer overflow.
+- **Explicit and Safe APIs:** Constraints and invariants are expressed directly
+  in types, helping prevent invalid states and making code easier to understand.
+- **Complete and Practical:** Each type comes with the operations needed for
+  real-world usage, not just constructors or wrappers.
+- **Multiplatform Ready:** Use the same reliable types across Kotlin/JVM,
+  Kotlin/JS, and Kotlin/Native.
+- **Seamless Serialization:** Built-in support for [kotlinx.serialization]
+  ensures smooth integration with APIs, databases, and external systems.
 
 ## 🛠️ Installation
 

--- a/documentation/design-goals.md
+++ b/documentation/design-goals.md
@@ -1,50 +1,34 @@
-# Design goals
+# 🎨 Design goals
 
-This section presents the design goals that we should keep in mind when building
-and improving Kotools Types.
+This section presents the design goals that we keep in mind when building and
+improving Kotools Types.
 
-## Less is more
+## 🌐 Model real-world concepts
 
-Kotools Types focuses primarily on what is essential for building an explicit
-and safe API: the types, their factory functions and their serializer.
+Kotools Types provides types that model real-world concepts with correct and
+predictable behavior.
 
-By having this minimalist approach, we engage to provide what users really need.
+These types are designed to follow their domain definitions, rather than the
+limitations of underlying platforms. For example, the `Integer` type represents
+a mathematical integer and does not overflow.
 
-Note that we may add other declarations if suggested by the community.
-See the [contributing guidelines](/CONTRIBUTING.md) for more details about it.
+By prioritizing correctness, Kotools Types helps developers build APIs that are
+easier to reason about and less error-prone.
 
-## Avoid useless dependencies
+## 🎯 Be explicit by design
 
-This project is very light and just ship with one direct dependency (excluding
-the [Kotlin] language): the [kotlinx.serialization] library for serializing or
-deserializing the provided types.
+This library favors explicitness over implicit behavior. Its APIs are designed
+to make constraints and invariants visible in code, reducing ambiguity and
+preventing invalid states.
 
-Like stated above, these mechanisms are essential for Kotools Types because its
-type-system should be usable in any type of application.
+## 🟢 Provide complete types
 
-See the [dependency compatibility](dependencies.md) documentation for more
-details about the compatibility of Kotools Types with its dependencies.
+Kotools Types provides complete and usable types, not just wrappers. Each type
+comes with the operations and APIs necessary to justify its use in real-world
+applications.
 
-## Error handling agnostic
+## 🧱 Avoid useless dependencies
 
-Users should be responsible for deciding how to handle errors, not this library.
-Externalizing this responsibility to consumers implies that Kotools Types should
-provide an explicit API by definition.
-This is why we are using the [Result][kotlin.Result] type from Kotlin for
-representing a result that can be a success or a failure.
-
-Here's an example of creating a `StrictlyPositiveInt` from Kotlin code:
-
-```kotlin
-val succes: Result<StrictlyPositiveInt> = 23.toStrictlyPositiveInt()
-val number: StrictlyPositiveInt = succes.getOrThrow()
-println(number) // 23
-
-val failure: Result<StrictlyPositiveInt> = 0.toStrictlyPositiveInt()
-val nullableNumber: StrictlyPositiveInt? = failure.getOrNull()
-println(nullableNumber) // null
-```
-
-[kotlin]: https://kotlinlang.org
-[kotlin.Result]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-result
-[kotlinx.serialization]: https://github.com/Kotlin/kotlinx.serialization
+This library is designed to be lightweight and depends only on what is strictly
+necessary. See the [dependency compatibility](dependencies.md) documentation for
+more details about its dependencies.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
@@ -23,6 +23,29 @@ import kotlin.jvm.JvmSynthetic
  * <br>
  * <details>
  * <summary>
+ *     <b>Integer vs Int</b>
+ * </summary>
+ *
+ * ### Integer vs Int
+ *
+ * The [Integer] type is the default integer type provided by Kotools Types,
+ * designed to replace primitive integer types where correctness matters.
+ *
+ * It models a mathematical integer and provides exact arithmetic without
+ * overflow, unlike Kotlin's built-in number types ([Byte], [Short], [Int] and
+ * [Long]).
+ *
+ * This type intentionally avoids names like `BigInteger` or `BigInt`, as its
+ * behavior is part of its contract and not an implementation detail.
+ *
+ * On JVM, this type coexists with [`java.lang.Integer`](https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html).
+ * In Kotlin, developers typically use [Int], so this rarely causes confusion in
+ * practice.
+ * </details>
+ *
+ * <br>
+ * <details>
+ * <summary>
  *     <b>Motivations</b>
  * </summary>
  *


### PR DESCRIPTION
This request resolves #889 by expressing clearly the intent of Kotools Types and its `Integer` type.

**TLDR:** The new vision of Kotools Types is to provide types that model real-world concepts with correct and predictable behavior.

Additionally, this request upgrades actions for using Node.js 24, due to the [deprecation of Node.js 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners).