### PR TITLE
✨ New `kotools.types.ExperimentalKotoolsTypesApi` annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,17 @@ All notable changes to this project will be documented in this file.
 
 ## 🚧 Unreleased
 
+### ✨ Added
+
+- `ExperimentalKotoolsTypesApi` annotation in `kotools.types` package, for
+  indicating that a declaration is experimental and can be incompatibly changed
+  in the future. ([#937](https://github.com/kotools/types/pull/937))
+
 ### ♻️ Changed
 
+- **Experimental** declarations are now marked with
+  `kotools.types.ExperimentalKotoolsTypesApi`.
+  ([#937](https://github.com/kotools/types/pull/937))
 - Improve the vision of Kotools Types in design goals, README and `Integer`
   type's documentation ([#913](https://github.com/kotools/types/pull/913)).
 - Convert `Integer` **experimental** type from class to interface
@@ -33,6 +42,12 @@ All notable changes to this project will be documented in this file.
 - Error message of `Integer.Companion.fromInteger(Long)` **experimental**
   function in case of invalid input
   ([9dc7b938](https://github.com/kotools/types/commit/9dc7b938)).
+
+### 🗑️ Deprecated
+
+- `org.kotools.types.ExperimentalKotoolsTypesApi` annotation with **warning**
+  level. Use `kotools.types.ExperimentalKotoolsTypesApi` instead.
+  ([#937](https://github.com/kotools/types/pull/937))
 
 ### 🔥 Removed
 

--- a/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
+++ b/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
@@ -10,9 +10,9 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
+import kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.EmailAddress
 import org.kotools.types.EmailAddressRegex
-import org.kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmSynthetic
 

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
@@ -2,9 +2,9 @@ package org.kotools.types.kotlinx.serialization
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.EmailAddress
 import org.kotools.types.EmailAddressRegex
-import org.kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 
 class SerializersModuleSample {

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
@@ -8,16 +8,16 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.serializer
+import kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.EmailAddress
 import org.kotools.types.EmailAddressRegex
-import org.kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.fail
 
+@OptIn(ExperimentalKotoolsTypesApi::class)
 class EmailAddressAsStringSerializerTest {
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun descriptor() {
         // Given
@@ -33,7 +33,6 @@ class EmailAddressAsStringSerializerTest {
         assertEquals(expected, result)
     }
 
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun serialize() {
         // Given
@@ -48,7 +47,6 @@ class EmailAddressAsStringSerializerTest {
         assertEquals(expected = "\"$text\"", result)
     }
 
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun deserializeWithValidEmailAddress() {
         // Given
@@ -64,7 +62,6 @@ class EmailAddressAsStringSerializerTest {
         assertEquals(expected, result)
     }
 
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun deserializeWithInvalidEmailAddress() {
         // Given
@@ -82,8 +79,8 @@ class EmailAddressAsStringSerializerTest {
     }
 }
 
+@OptIn(ExperimentalKotoolsTypesApi::class)
 class EmailAddressRegexAsStringSerializerTest {
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun descriptor() {
         // Given
@@ -99,7 +96,6 @@ class EmailAddressRegexAsStringSerializerTest {
         assertEquals(expected, result)
     }
 
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun serialize() {
         // Given
@@ -115,7 +111,6 @@ class EmailAddressRegexAsStringSerializerTest {
         assertEquals(expected, result)
     }
 
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun deserializeWithValidRegex() {
         // Given
@@ -129,7 +124,6 @@ class EmailAddressRegexAsStringSerializerTest {
         assertEquals(expected, result)
     }
 
-    @OptIn(ExperimentalKotoolsTypesApi::class)
     @Test
     fun deserializeWithInvalidRegex() {
         // Given

--- a/subprojects/library/packages.md
+++ b/subprojects/library/packages.md
@@ -4,6 +4,11 @@ Explicit types for [Kotlin Multiplatform].
 
 [kotlin multiplatform]: https://www.jetbrains.com/kotlin-multiplatform
 
+# Package kotools.types
+
+Core namespace of the Kotools Types library, containing public APIs intended for
+general use.
+
 # Package kotools.types.collection
 
 Contains types such as [NotEmptyList] for manipulating collections.

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -1,3 +1,6 @@
+public abstract interface annotation class kotools/types/ExperimentalKotoolsTypesApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface class kotools/types/collection/NotEmptyCollection {
 	public abstract fun getHead ()Ljava/lang/Object;
 	public abstract fun getSize-qaD5h0E ()I

--- a/subprojects/library/src/commonMain/kotlin/kotools/types/ExperimentalKotoolsTypesApi.kt
+++ b/subprojects/library/src/commonMain/kotlin/kotools/types/ExperimentalKotoolsTypesApi.kt
@@ -1,0 +1,22 @@
+package kotools.types
+
+import kotlin.annotation.AnnotationRetention.BINARY
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.annotation.AnnotationTarget.PROPERTY
+import kotlin.annotation.AnnotationTarget.TYPEALIAS
+
+/**
+ * Signals that the annotated declaration is experimental and can be
+ * incompatibly changed in the future.
+ *
+ * @since 5.2.0
+ */
+@MustBeDocumented
+@RequiresOptIn(
+    "This declaration is experimental and can be incompatibly changed in the " +
+            "future."
+)
+@Retention(BINARY)
+@Target(CLASS, FUNCTION, PROPERTY, TYPEALIAS)
+public annotation class ExperimentalKotoolsTypesApi

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/Decimal.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.Decimal.Companion.fromString
 import org.kotools.types.Decimal.Companion.fromStringOrNull
 

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/EmailAddress.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/EmailAddress.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotools.types.internal.hashCodeOf
 import org.kotools.types.internal.Warning
 import kotlin.jvm.JvmStatic

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/EmailAddressRegex.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/EmailAddressRegex.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotools.types.internal.hashCodeOf
 import org.kotools.types.internal.Warning
 import kotlin.jvm.JvmName

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/ExperimentalKotoolsTypesApi.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/ExperimentalKotoolsTypesApi.kt
@@ -14,6 +14,10 @@ private const val OPT_IN_MESSAGE: String = "This declaration is experimental" +
  *
  * @since 4.4.0
  */
+@Deprecated(
+    message = "Moved to 'kotools.types' package.",
+    ReplaceWith("kotools.types.ExperimentalKotoolsTypesApi")
+)
 @MustBeDocumented
 @RequiresOptIn(OPT_IN_MESSAGE)
 @Retention(BINARY)

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/Integer.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.Integer.Companion.from
 import org.kotools.types.Integer.Companion.fromDecimal
 import org.kotools.types.Integer.Companion.fromDecimalOrNull

--- a/subprojects/library/src/commonTest/kotlin/kotools/types/number/AnyIntTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/kotools/types/number/AnyIntTest.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import kotools.types.internal.simpleNameOf
 import kotools.types.shouldEqual
-import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.InternalKotoolsTypesApi
 import kotlin.random.Random
 import kotlin.test.Test
@@ -160,7 +159,6 @@ class AnyIntSerializerTest {
         assertEquals(expected, actual)
     }
 
-    @ExperimentalKotoolsTypesApi
     @Test
     fun deserialize_should_pass_with_an_Int() {
         val value: Int = Random.nextInt()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/DecimalSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/DecimalSample.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 
 @OptIn(ExperimentalKotoolsTypesApi::class)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/DecimalTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/DecimalTest.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressCommonSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressCommonSample.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressRegexCommonSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressRegexCommonSample.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressRegexTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressRegexTest.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotools.types.internal.hashCodeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +16,7 @@ class EmailAddressRegexTest {
     fun equalsFailsWithNull() {
         val regex: EmailAddressRegex = EmailAddressRegex.default()
         val other: Any? = null
-        val actual: Boolean = regex.equals(other)
+        val actual: Boolean = regex == other
         assertFalse(actual)
     }
 
@@ -31,7 +32,7 @@ class EmailAddressRegexTest {
     fun equalsFailsWithEmailAddressRegexHavingAnotherPattern() {
         val regex: EmailAddressRegex = EmailAddressRegex.default()
         val other: EmailAddressRegex = EmailAddressRegex.alphabetic()
-        val actual: Boolean = regex.equals(other)
+        val actual: Boolean = regex == other
         assertFalse(actual)
     }
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/EmailAddressTest.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotools.types.internal.hashCodeOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,7 +18,7 @@ class EmailAddressTest {
         val text = "contact@kotools.org"
         val first: EmailAddress = EmailAddress.of(text) ?: fail()
         val second: Any = text
-        val actual: Boolean = first.equals(second)
+        val actual: Boolean = first == second
         assertFalse(actual)
     }
 
@@ -26,7 +27,7 @@ class EmailAddressTest {
         val first: EmailAddress = EmailAddress.of("contact@kotools.org")
             ?: fail()
         val second: Any = EmailAddress.of("second@kotools.org") ?: fail()
-        val actual: Boolean = first.equals(second)
+        val actual: Boolean = first == second
         assertFalse(actual)
     }
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/IntegerSample.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 
 @OptIn(ExperimentalKotoolsTypesApi::class)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/IntegerTest.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/PropertyTesting.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/PropertyTesting.kt
@@ -1,5 +1,7 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
+
 internal inline fun repeatTest(block: () -> Unit): Unit =
     repeat(times = 1_000) { block() }
 

--- a/subprojects/library/src/jsMain/kotlin/org/kotools/types/JsInteger.kt
+++ b/subprojects/library/src/jsMain/kotlin/org/kotools/types/JsInteger.kt
@@ -1,5 +1,7 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
+
 @OptIn(ExperimentalKotoolsTypesApi::class)
 @Suppress("unused")
 internal actual fun Integer(text: String): Integer {

--- a/subprojects/library/src/jsNativeMain/kotlin/org/kotools/types/JsNativeDecimal.kt
+++ b/subprojects/library/src/jsNativeMain/kotlin/org/kotools/types/JsNativeDecimal.kt
@@ -1,6 +1,7 @@
 package org.kotools.types
 
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotools.types.ExperimentalKotoolsTypesApi
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 internal actual fun Decimal(value: Long): Decimal {

--- a/subprojects/library/src/jvmMain/kotlin/org/kotools/types/JvmDecimal.kt
+++ b/subprojects/library/src/jvmMain/kotlin/org/kotools/types/JvmDecimal.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import java.math.BigDecimal
 
 @JvmSynthetic

--- a/subprojects/library/src/jvmMain/kotlin/org/kotools/types/JvmInteger.kt
+++ b/subprojects/library/src/jvmMain/kotlin/org/kotools/types/JvmInteger.kt
@@ -1,5 +1,6 @@
 package org.kotools.types
 
+import kotools.types.ExperimentalKotoolsTypesApi
 import java.math.BigInteger
 
 @JvmSynthetic

--- a/subprojects/library/src/nativeMain/kotlin/org/kotools/types/NativeInteger.kt
+++ b/subprojects/library/src/nativeMain/kotlin/org/kotools/types/NativeInteger.kt
@@ -1,6 +1,7 @@
 package org.kotools.types
 
 import com.ionspin.kotlin.bignum.integer.BigInteger
+import kotools.types.ExperimentalKotoolsTypesApi
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 @Suppress("unused")


### PR DESCRIPTION
## 📝 Description

This request starts the migration of the `ExperimentalKotoolsTypesApi` annotation, from the `org.kotools.types` package to the `kotools.types` one.

## ✅ Checklist

- [x] ✨ Add `ExperimentalKotoolsTypesApi` annotation in `kotools.types`.
- [x] 🗑️ Deprecate `org.kotools.types.ExperimentalKotoolsTypesApi` annotation with **warning** level.
- [x] 📝 Update unreleased changelog.
- [ ] 📝 Create an issue for promoting deprecation of `org.kotools.types.ExperimentalKotoolsTypesApi` to **error** level. (**v5.3.0**)
- [ ] 📝 Create an issue for hiding `org.kotools.types.ExperimentalKotoolsTypesApi` from API. (**v5.4.0**)
- [ ] 📝 Create an issue for removing `org.kotools.types.ExperimentalKotoolsTypesApi` from API. (**v6.0.0**)