### PR TITLE
✨ `Integer` - New API and location

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+bignum = "0.3.9"
 dokka = "1.9.20"
 java = "17"
 kotlin = "1.9.25"
@@ -6,6 +7,7 @@ kotlinx-bcv = "0.16.3"
 kotlinx-serialization = "1.6.3"
 
 [libraries]
+bignum = { module = "com.ionspin.kotlin:bignum", version.ref = "bignum" }
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 dokka-gradle-plugin = { module = "org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin", version.ref = "dokka" }
 dokka-versioning = { module = "org.jetbrains.dokka:versioning-plugin", version.ref = "dokka" }

--- a/gradle/plugins/src/main/kotlin/convention/kotlin/multiplatform.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/convention/kotlin/multiplatform.gradle.kts
@@ -3,6 +3,7 @@ package convention.kotlin
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrLink
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
 import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
@@ -54,6 +55,12 @@ kotlin.targets.configureEach {
 kotlin.applyDefaultHierarchyTemplate()
 kotlin.sourceSets {
     configureEach { languageSettings.optIn("kotlin.RequiresOptIn") }
+    val commonTest: KotlinSourceSet by this.getting
+    val jvmNativeTest: KotlinSourceSet by this.creating {
+        this.dependsOn(commonTest)
+    }
+    this.getByName("jvmTest").dependsOn(jvmNativeTest)
+    this.getByName("nativeTest").dependsOn(jvmNativeTest)
 }
 
 // ----------------------------------- Tasks -----------------------------------

--- a/subprojects/internal/build.gradle.kts
+++ b/subprojects/internal/build.gradle.kts
@@ -17,4 +17,8 @@ compatibility {
 
 documentation.excludeFromParentApiReference = true
 
-dependencies.commonMainImplementation(libs.kotlinx.serialization.core)
+dependencies {
+    commonMainImplementation(libs.kotlinx.serialization.core)
+
+    nativeMainImplementation(libs.bignum)
+}

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -72,4 +72,9 @@ public interface PlatformInteger {
      * less than, equal to, or greater than the [other] one.
      */
     public operator fun compareTo(other: PlatformInteger): Int
+
+    // ------------------------- Arithmetic operations -------------------------
+
+    /** Returns the negative of this integer. */
+    public operator fun unaryMinus(): PlatformInteger
 }

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -6,9 +6,47 @@ import org.kotools.types.internal.InternalKotoolsTypesApi
 @InternalKotoolsTypesApi
 public expect fun PlatformInteger(value: Long): PlatformInteger
 
+@OptIn(InternalKotoolsTypesApi::class)
+internal expect fun PlatformInteger(value: String): PlatformInteger
+
 /** Implementations of this interface represent a platform-specific integer. */
 @InternalKotoolsTypesApi
 public interface PlatformInteger {
+    // ------------------------------- Creations -------------------------------
+
+    /** Contains type-level declarations for [PlatformInteger]. */
+    public companion object {
+        /**
+         * Returns a [PlatformInteger] representing exactly the number described
+         * by [value], or throws [NumberFormatException] if the [value] doesn't
+         * represent an integer.
+         */
+        public fun parse(value: String): PlatformInteger {
+            if (!this.isValidInteger(value)) throw NumberFormatException(
+                "\"$value\" is not a valid integer."
+            )
+            val sign: String = value.first()
+                .takeIf { it == '-' }
+                ?.toString()
+                ?: ""
+            val digits: String = value.removePrefix(sign)
+                .trimStart('0')
+                .ifEmpty { "0" }
+            return PlatformInteger("$sign$digits")
+        }
+
+        private fun isValidInteger(value: String): Boolean {
+            if (value.isEmpty()) return false
+            val firstCharacter: Char = value.first()
+            val start: Int =
+                if (firstCharacter == '+' || firstCharacter == '-') 1
+                else 0
+            if (start == value.length) return false
+            return value.substring(start)
+                .all(Char::isDigit)
+        }
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     /**

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -8,4 +8,14 @@ public expect fun PlatformInteger(value: Long): PlatformInteger
 
 /** Implementations of this interface represent a platform-specific integer. */
 @InternalKotoolsTypesApi
-public interface PlatformInteger
+public interface PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
+    /**
+     * Compares this integer with the [other] one for order.
+     *
+     * Returns a negative number, zero, or a positive number as this integer is
+     * less than, equal to, or greater than the [other] one.
+     */
+    public operator fun compareTo(other: PlatformInteger): Int
+}

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -25,14 +25,19 @@ public interface PlatformInteger {
             if (!this.isValidInteger(value)) throw NumberFormatException(
                 "\"$value\" is not a valid integer."
             )
-            val sign: String = value.first()
-                .takeIf { it == '-' }
-                ?.toString()
-                ?: ""
-            val digits: String = value.removePrefix(sign)
-                .trimStart('0')
-                .ifEmpty { "0" }
-            return PlatformInteger("$sign$digits")
+            val normalizedValue: String = this.normalize(value)
+            return PlatformInteger(normalizedValue)
+        }
+
+        /**
+         * Returns a [PlatformInteger] representing exactly the number described
+         * by [value], or returns `null` if the [value] doesn't represent an
+         * integer.
+         */
+        public fun parseOrNull(value: String): PlatformInteger? {
+            if (!this.isValidInteger(value)) return null
+            val normalizedValue: String = this.normalize(value)
+            return PlatformInteger(normalizedValue)
         }
 
         private fun isValidInteger(value: String): Boolean {
@@ -44,6 +49,17 @@ public interface PlatformInteger {
             if (start == value.length) return false
             return value.substring(start)
                 .all(Char::isDigit)
+        }
+
+        private fun normalize(value: String): String {
+            val sign: String = value.first()
+                .takeIf { it == '-' }
+                ?.toString()
+                ?: ""
+            val digits: String = value.removePrefix(sign)
+                .trimStart('0')
+                .ifEmpty { "0" }
+            return "$sign$digits"
         }
     }
 

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -77,4 +77,9 @@ public interface PlatformInteger {
 
     /** Returns the negative of this integer. */
     public operator fun unaryMinus(): PlatformInteger
+
+    /**
+     * Returns the sum of this integer with the [other] one (`this + other`).
+     */
+    public operator fun plus(other: PlatformInteger): PlatformInteger
 }

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -1,0 +1,11 @@
+package org.kotools.types.internal.number
+
+import org.kotools.types.internal.InternalKotoolsTypesApi
+
+/** Returns a [PlatformInteger] representing exactly the specified [value]. */
+@InternalKotoolsTypesApi
+public expect fun PlatformInteger(value: Long): PlatformInteger
+
+/** Implementations of this interface represent a platform-specific integer. */
+@InternalKotoolsTypesApi
+public interface PlatformInteger

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -37,6 +37,16 @@ private class JsInteger(private val delegate: BigInt) : PlatformInteger {
         return x.compareTo(y) * sign
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Suppress("UNUSED_VARIABLE", "unused")
+    override fun unaryMinus(): PlatformInteger {
+        val x: BigInt = this.delegate
+        val negative: dynamic = js("-x")
+        val delegate = BigInt("$negative")
+        return JsInteger(delegate)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -11,6 +11,13 @@ public actual fun PlatformInteger(value: Long): PlatformInteger {
 
 @OptIn(InternalKotoolsTypesApi::class)
 private class JsInteger(private val delegate: BigInt) : PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
+    override fun equals(other: Any?): Boolean =
+        other is JsInteger && this.delegate == other.delegate
+
+    override fun hashCode(): Int = this.delegate.hashCode()
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -10,6 +10,12 @@ public actual fun PlatformInteger(value: Long): PlatformInteger {
 }
 
 @OptIn(InternalKotoolsTypesApi::class)
+internal actual fun PlatformInteger(value: String): PlatformInteger {
+    val delegate = BigInt(value)
+    return JsInteger(delegate)
+}
+
+@OptIn(InternalKotoolsTypesApi::class)
 private class JsInteger(private val delegate: BigInt) : PlatformInteger {
     // ------------------------------ Comparisons ------------------------------
 

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -43,8 +43,7 @@ private class JsInteger(private val delegate: BigInt) : PlatformInteger {
     override fun unaryMinus(): PlatformInteger {
         val x: BigInt = this.delegate
         val negative: dynamic = js("-x")
-        val delegate = BigInt("$negative")
-        return JsInteger(delegate)
+        return PlatformInteger.parse("$negative")
     }
 
     @Suppress("UNUSED_VARIABLE", "unused")

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -47,6 +47,15 @@ private class JsInteger(private val delegate: BigInt) : PlatformInteger {
         return JsInteger(delegate)
     }
 
+    @Suppress("UNUSED_VARIABLE", "unused")
+    override fun plus(other: PlatformInteger): PlatformInteger {
+        check(other is JsInteger)
+        val x: BigInt = this.delegate
+        val y: BigInt = other.delegate
+        val sum: dynamic = js("x + y")
+        return PlatformInteger.parse("$sum")
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -18,6 +18,19 @@ private class JsInteger(private val delegate: BigInt) : PlatformInteger {
 
     override fun hashCode(): Int = this.delegate.hashCode()
 
+    override fun compareTo(other: PlatformInteger): Int {
+        check(other is JsInteger)
+        if (this.delegate == other.delegate) return 0
+        val x: String = this.delegate.toString()
+        val y: String = other.delegate.toString()
+        if (!x.startsWith('-') && y.startsWith('-')) return 1
+        if (x.startsWith('-') && !y.startsWith('-')) return -1
+        val sign: Int = if (x.startsWith('-') && y.startsWith('-')) -1 else 1
+        if (x.length > y.length) return 1 * sign
+        if (x.length < y.length) return -1 * sign
+        return x.compareTo(y) * sign
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -1,0 +1,21 @@
+package org.kotools.types.internal.number
+
+import org.kotools.types.internal.InternalKotoolsTypesApi
+
+/** Returns a [PlatformInteger] representing exactly the specified [value]. */
+@InternalKotoolsTypesApi
+public actual fun PlatformInteger(value: Long): PlatformInteger {
+    val delegate = BigInt("$value")
+    return JsInteger(delegate)
+}
+
+@OptIn(InternalKotoolsTypesApi::class)
+private class JsInteger(private val delegate: BigInt) : PlatformInteger {
+    // ------------------------------ Conversions ------------------------------
+
+    override fun toString(): String = this.delegate.toString()
+}
+
+private external fun BigInt(value: String): BigInt
+
+private external object BigInt

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -31,6 +31,10 @@ private class JvmInteger(private val delegate: BigInteger) : PlatformInteger {
         return this.delegate.compareTo(other.delegate)
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    override fun unaryMinus(): PlatformInteger = JvmInteger(-this.delegate)
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -35,6 +35,12 @@ private class JvmInteger(private val delegate: BigInteger) : PlatformInteger {
 
     override fun unaryMinus(): PlatformInteger = JvmInteger(-this.delegate)
 
+    override fun plus(other: PlatformInteger): PlatformInteger {
+        check(other is JvmInteger)
+        val sum: BigInteger = this.delegate.add(other.delegate)
+        return JvmInteger(sum)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -1,0 +1,18 @@
+package org.kotools.types.internal.number
+
+import org.kotools.types.internal.InternalKotoolsTypesApi
+import java.math.BigInteger
+
+/** Returns a [PlatformInteger] representing exactly the specified [value]. */
+@InternalKotoolsTypesApi
+public actual fun PlatformInteger(value: Long): PlatformInteger {
+    val delegate: BigInteger = BigInteger.valueOf(value)
+    return JvmInteger(delegate)
+}
+
+@OptIn(InternalKotoolsTypesApi::class)
+private class JvmInteger(private val delegate: BigInteger) : PlatformInteger {
+    // ------------------------------ Conversions ------------------------------
+
+    override fun toString(): String = this.delegate.toString()
+}

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -12,6 +12,13 @@ public actual fun PlatformInteger(value: Long): PlatformInteger {
 
 @OptIn(InternalKotoolsTypesApi::class)
 private class JvmInteger(private val delegate: BigInteger) : PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
+    override fun equals(other: Any?): Boolean =
+        other is JvmInteger && this.delegate == other.delegate
+
+    override fun hashCode(): Int = this.delegate.hashCode()
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -19,6 +19,11 @@ private class JvmInteger(private val delegate: BigInteger) : PlatformInteger {
 
     override fun hashCode(): Int = this.delegate.hashCode()
 
+    override fun compareTo(other: PlatformInteger): Int {
+        check(other is JvmInteger)
+        return this.delegate.compareTo(other.delegate)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -10,6 +10,13 @@ public actual fun PlatformInteger(value: Long): PlatformInteger {
     return JvmInteger(delegate)
 }
 
+@JvmSynthetic
+@OptIn(InternalKotoolsTypesApi::class)
+internal actual fun PlatformInteger(value: String): PlatformInteger {
+    val delegate = BigInteger(value)
+    return JvmInteger(delegate)
+}
+
 @OptIn(InternalKotoolsTypesApi::class)
 private class JvmInteger(private val delegate: BigInteger) : PlatformInteger {
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -14,6 +14,13 @@ public actual fun PlatformInteger(value: Long): PlatformInteger {
 private class NativeInteger(
     private val delegate: BigInteger
 ) : PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
+    override fun equals(other: Any?): Boolean =
+        other is NativeInteger && this.delegate == other.delegate
+
+    override fun hashCode(): Int = this.delegate.hashCode()
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -32,6 +32,10 @@ private class NativeInteger(
         return this.delegate.compare(other.delegate)
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    override fun unaryMinus(): PlatformInteger = NativeInteger(-this.delegate)
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -21,6 +21,11 @@ private class NativeInteger(
 
     override fun hashCode(): Int = this.delegate.hashCode()
 
+    override fun compareTo(other: PlatformInteger): Int {
+        check(other is NativeInteger)
+        return this.delegate.compare(other.delegate)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -36,6 +36,11 @@ private class NativeInteger(
 
     override fun unaryMinus(): PlatformInteger = NativeInteger(-this.delegate)
 
+    override fun plus(other: PlatformInteger): PlatformInteger {
+        check(other is NativeInteger)
+        return NativeInteger(this.delegate + other.delegate)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     override fun toString(): String = this.delegate.toString()

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -11,6 +11,12 @@ public actual fun PlatformInteger(value: Long): PlatformInteger {
 }
 
 @OptIn(InternalKotoolsTypesApi::class)
+internal actual fun PlatformInteger(value: String): PlatformInteger {
+    val delegate: BigInteger = BigInteger.parseString(value)
+    return NativeInteger(delegate)
+}
+
+@OptIn(InternalKotoolsTypesApi::class)
 private class NativeInteger(
     private val delegate: BigInteger
 ) : PlatformInteger {

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -1,0 +1,20 @@
+package org.kotools.types.internal.number
+
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import org.kotools.types.internal.InternalKotoolsTypesApi
+
+/** Returns a [PlatformInteger] representing exactly the specified [value]. */
+@InternalKotoolsTypesApi
+public actual fun PlatformInteger(value: Long): PlatformInteger {
+    val delegate: BigInteger = BigInteger.fromLong(value)
+    return NativeInteger(delegate)
+}
+
+@OptIn(InternalKotoolsTypesApi::class)
+private class NativeInteger(
+    private val delegate: BigInteger
+) : PlatformInteger {
+    // ------------------------------ Conversions ------------------------------
+
+    override fun toString(): String = this.delegate.toString()
+}

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -361,3 +361,6 @@ public final class org/kotools/types/EmailAddressRegex$Companion {
 public abstract interface annotation class org/kotools/types/ExperimentalKotoolsTypesApi : java/lang/annotation/Annotation {
 }
 
+public final class org/kotools/types/number/Integer {
+}
+

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -375,5 +375,6 @@ public final class org/kotools/types/number/Integer {
 public final class org/kotools/types/number/Integer$Companion {
 	public final fun of (J)Lorg/kotools/types/number/Integer;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
+	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -367,6 +367,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun compareTo (Lorg/kotools/types/number/Integer;)I
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
+	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun plus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -369,6 +369,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun hashCode ()I
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
+	public final fun plus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -368,10 +368,12 @@ public final class org/kotools/types/number/Integer {
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
+	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 }
 
 public final class org/kotools/types/number/Integer$Companion {
 	public final fun of (J)Lorg/kotools/types/number/Integer;
+	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -362,5 +362,13 @@ public abstract interface annotation class org/kotools/types/ExperimentalKotools
 }
 
 public final class org/kotools/types/number/Integer {
+	public static final field Companion Lorg/kotools/types/number/Integer$Companion;
+	public synthetic fun <init> (Lorg/kotools/types/internal/number/PlatformInteger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun of (J)Lorg/kotools/types/number/Integer;
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class org/kotools/types/number/Integer$Companion {
+	public final fun of (J)Lorg/kotools/types/number/Integer;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -364,6 +364,8 @@ public abstract interface annotation class org/kotools/types/ExperimentalKotools
 public final class org/kotools/types/number/Integer {
 	public static final field Companion Lorg/kotools/types/number/Integer$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/internal/number/PlatformInteger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun hashCode ()I
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -370,6 +370,7 @@ public final class org/kotools/types/number/Integer {
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
+	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }
 
 public final class org/kotools/types/number/Integer$Companion {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -364,6 +364,7 @@ public abstract interface annotation class org/kotools/types/ExperimentalKotools
 public final class org/kotools/types/number/Integer {
 	public static final field Companion Lorg/kotools/types/number/Integer$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/internal/number/PlatformInteger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun compareTo (Lorg/kotools/types/number/Integer;)I
 	public final fun equals (Ljava/lang/Object;)Z
 	public final fun hashCode ()I
 	public static final fun of (J)Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -340,6 +340,34 @@ public class Integer private constructor(
         return Integer(this.delegate + other.delegate)
     }
 
+    /**
+     * Returns the difference between this integer and the [other] one
+     * (`this - other`), without producing an overflow.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.minus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.minus
+     * </details>
+     */
+    public operator fun minus(other: Integer): Integer = this + (-other)
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -92,6 +92,50 @@ public class Integer private constructor(
             val delegate = PlatformInteger(value)
             return Integer(delegate)
         }
+
+        /**
+         * Returns an [Integer] representing exactly the number described by
+         * [value], or throws [NumberFormatException] if the [value] doesn't
+         * represent an integer.
+         *
+         * The specified [value] must be a numeric string, with an optional
+         * leading sign (`+` or `-`). Also, this function removes insignificant
+         * leading zeros from the [value]. As a result, calling this function
+         * with `123` and `+000123` produces the same result.
+         *
+         * ```
+         * integer = [sign] digit {digit}
+         * sign = "+" | "-"
+         * digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+         * ```
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.parse
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.parse
+         * </details>
+         */
+        @JvmStatic
+        public fun parse(value: String): Integer {
+            val delegate: PlatformInteger = PlatformInteger.parse(value)
+            return Integer(delegate)
+        }
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -84,7 +84,7 @@ public class Integer private constructor(
          *
          * Here's an example of calling this function from Java code:
          *
-         * SAMPLE: org.kotools.types.IntegerJavaSample.ofLong
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.ofLong
          * </details>
          */
         @JvmStatic
@@ -118,7 +118,7 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Java code:
      *
-     * SAMPLE: org.kotools.types.IntegerJavaSample.toStringOverride
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toStringOverride
      * </details>
      */
     @Suppress("RedundantModalityModifier")

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -1,0 +1,56 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+
+/**
+ * Represents a mathematical integer, with exact arithmetic.
+ *
+ * Unlike Kotlin's built-in integer types ([Byte], [Short], [Int] and [Long]),
+ * the [Integer] type provides exact arithmetic without overflow, and has
+ * consistent behavior across all platforms when dividing an integer by zero.
+ *
+ * Designed to replace primitive integer types where correctness matters, this
+ * type intentionally avoids name like `BigInteger` or `BigInt`, as its behavior
+ * is part of its contract and not an implementation detail.
+ *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Motivations</b>
+ * </summary>
+ *
+ * ### Motivations
+ *
+ * #### Integer overflow
+ *
+ * **Problem:** Adding, subtracting or multiplying Kotlin integer types can lead
+ * to an overflow, which produces unexpected behavior.
+ *
+ * SAMPLE: org.kotools.types.number.IntegerSample.overflowProblem
+ *
+ * **Solution:** The [Integer] type can add, subtract or multiply integers
+ * without producing an overflow.
+ *
+ * TODO: Add Kotlin sample
+ *
+ * #### Division by zero
+ *
+ * **Problem:** Performing division and remainder operations by zero on Kotlin
+ * integer types have different behavior per platform: throw an
+ * [ArithmeticException] on JVM and Native platforms, and return `0` on JS
+ * platform.
+ *
+ * SAMPLE: org.kotools.types.number.IntegerJvmNativeSample.divisionByZeroProblem
+ *
+ * SAMPLE: org.kotools.types.number.IntegerJsSample.divisionByZeroProblem
+ *
+ * **Solution:** Division and remainder operations by zero on [Integer] type
+ * throw an [ArithmeticException] on all platforms.
+ *
+ * TODO: Add Kotlin sample
+ * </details>
+ *
+ * @since 5.2.0
+ */
+@ExperimentalKotoolsTypesApi
+public class Integer private constructor()

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -273,6 +273,38 @@ public class Integer private constructor(
     public operator fun compareTo(other: Integer): Int =
         this.delegate.compareTo(other.delegate)
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    /**
+     * Returns the negative of this integer, or the same instance if this
+     * integer represents zero.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.unaryMinus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.unaryMinus
+     * </details>
+     */
+    public operator fun unaryMinus(): Integer =
+        if (this == of(0)) this
+        else Integer(-this.delegate)
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -307,6 +307,48 @@ public class Integer private constructor(
         if (this == of(0)) this
         else Integer(-this.delegate)
 
+    /**
+     * Returns the sum of this integer and the [other] one (`this + other`),
+     * without producing an overflow.
+     *
+     * This function satisfies the algebraic properties of integer addition:
+     * - Closure: adding two integers produces another integer.
+     * - Associativity: grouping integers preserves the result
+     * (`x + (y + z) = (x + y) + z`).
+     * - Commutativity: changing the order of integers preserves the result
+     * (`x + y = y + x`).
+     * - Identity element: adding `0` to an integer is neutral (`x + 0 = x`).
+     * - Inverse element: every integer has an opposite (`x + (-x) = 0`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.plus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.plus
+     * </details>
+     */
+    public operator fun plus(other: Integer): Integer {
+        val zero: Integer = of(0)
+        if (this == zero) return other
+        if (other == zero) return this
+        return Integer(this.delegate + other.delegate)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -3,6 +3,7 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.number.PlatformInteger
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Represents a mathematical integer, with exact arithmetic.
@@ -130,12 +131,55 @@ public class Integer private constructor(
          *
          * SAMPLE: org.kotools.types.number.IntegerJavaSample.parse
          * </details>
+         * <br>
+         *
+         * See the [Integer.Companion.parseOrNull] function for returning `null`
+         * instead of throwing an exception in case of invalid [value].
          */
         @JvmStatic
         public fun parse(value: String): Integer {
             val delegate: PlatformInteger = PlatformInteger.parse(value)
             return Integer(delegate)
         }
+
+        /**
+         * Returns an [Integer] representing exactly the number described by
+         * [value], or returns `null` if the [value] doesn't represent an
+         * integer.
+         *
+         * The specified [value] must be a numeric string, with an optional
+         * leading sign (`+` or `-`). Also, this function removes insignificant
+         * leading zeros from the [value]. As a result, calling this function
+         * with `123` and `+000123` produces the same result.
+         *
+         * ```
+         * integer = [sign] digit {digit}
+         * sign = "+" | "-"
+         * digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+         * ```
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.parseOrNull
+         * </details>
+         * <br>
+         *
+         * This function is not available from Java code, due to its
+         * non-explicit support for nullable types.
+         *
+         * See the [Integer.Companion.parse] function for throwing an exception
+         * instead of returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun parseOrNull(value: String): Integer? = PlatformInteger
+            .parseOrNull(value)
+            ?.let(::Integer)
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -311,15 +311,6 @@ public class Integer private constructor(
      * Returns the sum of this integer and the [other] one (`this + other`),
      * without producing an overflow.
      *
-     * This function satisfies the algebraic properties of integer addition:
-     * - Closure: adding two integers produces another integer.
-     * - Associativity: grouping integers preserves the result
-     * (`x + (y + z) = (x + y) + z`).
-     * - Commutativity: changing the order of integers preserves the result
-     * (`x + y = y + x`).
-     * - Identity element: adding `0` to an integer is neutral (`x + 0 = x`).
-     * - Inverse element: every integer has an opposite (`x + (-x) = 0`).
-     *
      * <br>
      * <details>
      * <summary>

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -154,6 +154,37 @@ public class Integer private constructor(
     @Suppress("RedundantModalityModifier")
     final override fun hashCode(): Int = this.delegate.hashCode()
 
+    /**
+     * Compares this integer with the [other] one for order.
+     *
+     * Returns a negative number, zero, or a positive number as this integer is
+     * less than, equal to, or greater than the [other] one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.compareTo
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.compareTo
+     * </details>
+     */
+    public operator fun compareTo(other: Integer): Int =
+        this.delegate.compareTo(other.delegate)
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -94,6 +94,66 @@ public class Integer private constructor(
         }
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    /**
+     * Returns `true` if the [other] object is an [Integer] representing the
+     * same numeric value as this one, or returns `false` otherwise.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.structuralEquality
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun equals(other: Any?): Boolean =
+        other is Integer && this.delegate == other.delegate
+
+    /**
+     * Returns a hash code value for this integer.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.structuralEquality
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun hashCode(): Int = this.delegate.hashCode()
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -2,6 +2,8 @@ package org.kotools.types.number
 
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.number.PlatformInteger
+import org.kotools.types.number.Integer.Companion.parse
+import org.kotools.types.number.Integer.Companion.parseOrNull
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -133,8 +135,8 @@ public class Integer private constructor(
          * </details>
          * <br>
          *
-         * See the [Integer.Companion.parseOrNull] function for returning `null`
-         * instead of throwing an exception in case of invalid [value].
+         * See the [parseOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
          */
         @JvmStatic
         public fun parse(value: String): Integer {
@@ -173,8 +175,8 @@ public class Integer private constructor(
          * This function is not available from Java code, due to its
          * non-explicit support for nullable types.
          *
-         * See the [Integer.Companion.parse] function for throwing an exception
-         * instead of returning `null` in case of invalid [value].
+         * See the [parse] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
          */
         @JvmSynthetic
         public fun parseOrNull(value: String): Integer? = PlatformInteger

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -308,8 +308,9 @@ public class Integer private constructor(
         else Integer(-this.delegate)
 
     /**
-     * Returns the sum of this integer and the [other] one (`this + other`),
-     * without producing an overflow.
+     * Returns the sum of this integer and the [other] one (`this + other`).
+     *
+     * This operation never overflows.
      *
      * <br>
      * <details>
@@ -342,7 +343,9 @@ public class Integer private constructor(
 
     /**
      * Returns the difference between this integer and the [other] one
-     * (`this - other`), without producing an overflow.
+     * (`this - other`).
+     *
+     * This operation never overflows.
      *
      * <br>
      * <details>

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -1,6 +1,8 @@
 package org.kotools.types.number
 
 import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.number.PlatformInteger
+import kotlin.jvm.JvmStatic
 
 /**
  * Represents a mathematical integer, with exact arithmetic.
@@ -53,4 +55,72 @@ import org.kotools.types.ExperimentalKotoolsTypesApi
  * @since 5.2.0
  */
 @ExperimentalKotoolsTypesApi
-public class Integer private constructor()
+public class Integer private constructor(
+    private val delegate: PlatformInteger
+) {
+    // ------------------------------- Creations -------------------------------
+
+    /** Contains class-level declarations for the [Integer] type. */
+    public companion object {
+        /**
+         * Returns an [Integer] representing exactly the specified [value].
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.ofLong
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.IntegerJavaSample.ofLong
+         * </details>
+         */
+        @JvmStatic
+        public fun of(value: Long): Integer {
+            val delegate = PlatformInteger(value)
+            return Integer(delegate)
+        }
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    /**
+     * Returns the string representation of this integer.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toStringOverride
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.IntegerJavaSample.toStringOverride
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun toString(): String = this.delegate.toString()
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -51,6 +51,19 @@ class IntegerSample {
         check(result == expected)
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    fun unaryMinus() {
+        // Given
+        val integer: Integer = Integer.of(42)
+        // When
+        val result: Integer = -integer
+        // Then
+        val expected: Integer = Integer.of(-42)
+        check(result == expected)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -1,0 +1,17 @@
+package org.kotools.types.number
+
+import kotlin.test.Test
+
+class IntegerSample {
+    // -------------------------- Type documentation ---------------------------
+
+    @Suppress("INTEGER_OVERFLOW")
+    @Test
+    fun overflowProblem() {
+        val x = 9223372036854775807
+        val y = 10
+        check(x + y == -9223372036854775799) // instead of 9223372036854775817
+        check(-x - y == 9223372036854775799) // instead of -9223372036854775817
+        check(x * y == -10L) // instead of 92233720368547758070
+    }
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -40,6 +40,17 @@ class IntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun parseOrNull() {
+        // Given
+        val value = "+000123"
+        // When
+        val result: Integer? = Integer.parseOrNull(value)
+        // Then
+        val expected: Integer = Integer.of(123)
+        check(result == expected)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -44,6 +44,15 @@ class IntegerSample {
         check(equality && hashConformity)
     }
 
+    @Test
+    fun compareTo() {
+        // Given
+        val x: Integer = Integer.of(Long.MIN_VALUE)
+        val y: Integer = Integer.of(Long.MAX_VALUE)
+        // When & Then
+        check(x < y)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -1,7 +1,9 @@
 package org.kotools.types.number
 
+import org.kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.test.Test
 
+@OptIn(ExperimentalKotoolsTypesApi::class)
 class IntegerSample {
     // -------------------------- Type documentation ---------------------------
 
@@ -13,5 +15,29 @@ class IntegerSample {
         check(x + y == -9223372036854775799) // instead of 9223372036854775817
         check(-x - y == 9223372036854775799) // instead of -9223372036854775817
         check(x * y == -10L) // instead of 92233720368547758070
+    }
+
+    // ------------------------------- Creations -------------------------------
+
+    @Test
+    fun ofLong() {
+        // Given
+        val value: Long = Long.MAX_VALUE
+        // When
+        val result: Integer = Integer.of(value)
+        // Then
+        check("$result" == "$value")
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toStringOverride() {
+        // Given
+        val integer: Integer = Integer.of(Long.MAX_VALUE)
+        // When
+        val result: String = integer.toString()
+        // Then
+        check(result == "9223372036854775807")
     }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -29,6 +29,17 @@ class IntegerSample {
         check("$result" == "$value")
     }
 
+    @Test
+    fun parse() {
+        // Given
+        val value = "+000123"
+        // When
+        val result: Integer = Integer.parse(value)
+        // Then
+        val expected: Integer = Integer.of(123)
+        check(result == expected)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -29,6 +29,21 @@ class IntegerSample {
         check("$result" == "$value")
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEquality() {
+        // Given
+        val value: Long = Long.MAX_VALUE
+        val x: Integer = Integer.of(value)
+        val y: Integer = Integer.of(value)
+        // When
+        val equality: Boolean = x == y
+        val hashConformity: Boolean = x.hashCode() == y.hashCode()
+        // Then
+        check(equality && hashConformity)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -76,6 +76,18 @@ class IntegerSample {
         check(sum == expected)
     }
 
+    @Test
+    fun minus() {
+        // Given
+        val x: Integer = Integer.of(-9223372036854775807)
+        val y: Integer = Integer.of(10)
+        // When
+        val difference: Integer = x - y
+        // Then
+        val expected: Integer = Integer.parse("-9223372036854775817")
+        check(difference == expected)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -64,6 +64,18 @@ class IntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun plus() {
+        // Given
+        val x: Integer = Integer.of(9223372036854775807)
+        val y: Integer = Integer.of(10)
+        // When
+        val sum: Integer = x + y
+        // Then
+        val expected: Integer = Integer.parse("9223372036854775817")
+        check(sum == expected)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
@@ -512,6 +513,42 @@ class IntegerTest {
         val expected: Int = xValue.compareTo(yValue)
         val message = "Integer must align with Long comparisons."
         assertEquals(expected, actual, message)
+    }
+
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    fun unaryMinusReturnsSameInstanceOnZero() {
+        // Given
+        val x: Integer = Integer.of(0)
+        // When
+        val actual: Integer = -x
+        // Then
+        assertSame(expected = x, actual)
+    }
+
+    @Test
+    fun unaryMinusReturnsNegativeIntegerOnPositiveInteger(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong(1..Long.MAX_VALUE)
+        val x: Integer = Integer.of(value)
+        // When
+        val actual: Integer = -x
+        // Then
+        val expected: Integer = Integer.of(-value)
+        assertEquals(expected, actual, "Input: $value")
+    }
+
+    @Test
+    fun unaryMinusReturnsPositiveIntegerOnNegativeInteger(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong((Long.MIN_VALUE + 1)..-1)
+        val x: Integer = Integer.of(value)
+        // When
+        val actual: Integer = -x
+        // Then
+        val expected: Integer = Integer.of(-value)
+        assertEquals(expected, actual, "Input: $value")
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -2,9 +2,11 @@ package org.kotools.types.number
 
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import kotlin.random.Random
+import kotlin.random.nextInt
 import kotlin.random.nextLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -51,6 +53,187 @@ class IntegerTest {
         // Then
         assertEquals(expected = "$value", "$actual")
     }
+
+    @Test
+    fun parseHasUniqueRepresentationOfZero(): Unit = repeatTest {
+        // Given
+        val sign: String = listOf("", "+", "-").random()
+        val digits: String = buildString {
+            val times: Int = Random.nextInt(1..2_000)
+            repeat(times) { this.append(0) }
+        }
+        val value = "$sign$digits"
+        // When
+        val actual: Integer = Integer.parse(value)
+        // Then
+        val expected: Integer = Integer.of(0)
+        assertEquals(expected, actual, "Input: $value")
+    }
+
+    @Test
+    fun parseRemovesPlusSignFromPositiveInteger(): Unit = repeatTest {
+        // Given
+        val digits: String = buildString {
+            val firstDigit: Int = Random.nextInt(1..9)
+            this.append(firstDigit)
+            val times: Int = Random.nextInt(1..32)
+            repeat(times) {
+                val otherDigit: Int = Random.nextInt(0..9)
+                this.append(otherDigit)
+            }
+        }
+        val value = "+$digits"
+        // When
+        val actual: Integer = Integer.parse(value)
+        // Then
+        assertEquals(expected = digits, "$actual", "Input: $value")
+    }
+
+    @Test
+    fun parsePreservesRepresentationOfNegativeInteger(): Unit = repeatTest {
+        // Given
+        val digits: String = buildString {
+            val firstDigit: Int = Random.nextInt(1..9)
+            this.append(firstDigit)
+            val times: Int = Random.nextInt(1..32)
+            repeat(times) {
+                val otherDigit: Int = Random.nextInt(0..9)
+                this.append(otherDigit)
+            }
+        }
+        val value = "-$digits"
+        // When
+        val actual: Integer = Integer.parse(value)
+        // Then
+        assertEquals(expected = value, "$actual", "Input: $value")
+    }
+
+    @Test
+    fun parseRemovesInsignificantLeadingZerosFromInteger(): Unit = repeatTest {
+        // Given
+        val sign: String = listOf("", "+", "-").random()
+        val zeros: String = buildString {
+            val times: Int = Random.nextInt(1..16)
+            repeat(times) { this.append(0) }
+        }
+        val digits: String = buildString {
+            val firstDigit: Int = Random.nextInt(1..9)
+            this.append(firstDigit)
+            val times: Int = Random.nextInt(1..16)
+            repeat(times) {
+                val otherDigit: Int = Random.nextInt(0..9)
+                this.append(otherDigit)
+            }
+        }
+        val value = "$sign$zeros$digits"
+        // When
+        val actual: Integer = Integer.parse(value)
+        // Then
+        val expected: String = buildString {
+            if (sign != "+") this.append(sign)
+            this.append(digits)
+        }
+        assertEquals(expected, "$actual", "Input: $value")
+    }
+
+    @Test
+    fun parseThrowsWithEmptyString() {
+        // Given
+        val value = ""
+        // When & Then
+        val exception: NumberFormatException = assertFailsWith {
+            Integer.parse(value)
+        }
+        val actual: String? = exception.message
+        assertEquals(expected = "\"$value\" is not a valid integer.", actual)
+    }
+
+    @Test
+    fun parseThrowsNumberFormatExceptionWithSignOnly(): Unit = listOf("+", "-")
+        .forEach {
+            // Given, When & Then
+            val exception: NumberFormatException = assertFailsWith {
+                Integer.parse(it)
+            }
+            val actual: String? = exception.message
+            assertEquals(expected = "\"$it\" is not a valid integer.", actual)
+        }
+
+    @Test
+    fun parseThrowsNumberFormatExceptionWithMultipleSigns(): Unit = repeatTest {
+        // Given
+        val signs: String = buildString {
+            val signs: List<Char> = listOf('+', '-')
+            val times: Int = Random.nextInt(2..16)
+            repeat(times) {
+                val sign: Char = signs.random()
+                this.append(sign)
+            }
+        }
+        val digits: String = buildString {
+            val firstDigit: Int = Random.nextInt(1..9)
+            this.append(firstDigit)
+            val times: Int = Random.nextInt(1..16)
+            repeat(times) {
+                val otherDigit: Int = Random.nextInt(0..9)
+                this.append(otherDigit)
+            }
+        }
+        val value = "$signs$digits"
+        // When & Then
+        val exception: NumberFormatException = assertFailsWith {
+            Integer.parse(value)
+        }
+        val actual: String? = exception.message
+        assertEquals(expected = "\"$value\" is not a valid integer.", actual)
+    }
+
+    @Test
+    fun parseThrowsNumberFormatExceptionWithMalformedIntegerString(): Unit =
+        repeatTest {
+            // Given
+            val signs: List<Char> = listOf('+', '-')
+            val characters: List<Char> = ('0'..'9') + signs
+            val value: String = buildString {
+                var signCount = 0
+                while (signCount < 2) {
+                    val character: Char = characters.random()
+                    this.append(character)
+                    if (character in signs) signCount++
+                }
+            }
+            // When & Then
+            val exception: NumberFormatException = assertFailsWith {
+                Integer.parse(value)
+            }
+            val actual: String? = exception.message
+            val expected = "\"$value\" is not a valid integer."
+            assertEquals(expected, actual)
+        }
+
+    @Test
+    fun parseThrowsNumberFormatExceptionWithIllegalCharactersInString(): Unit =
+        repeatTest {
+            // Given
+            val allowedCharacters: List<Char> = ('0'..'9') + listOf('+', '-')
+            val characters: List<Char> =
+                allowedCharacters + ('a'..'z') + ('A'..'Z')
+            val value = buildString {
+                var illegalCharacterCount = 0
+                while (illegalCharacterCount == 0) {
+                    val character: Char = characters.random()
+                    this.append(character)
+                    if (character !in allowedCharacters) illegalCharacterCount++
+                }
+            }
+            // When & Then
+            val exception: NumberFormatException = assertFailsWith {
+                Integer.parse(value)
+            }
+            val actual: String? = exception.message
+            val expected = "\"$value\" is not a valid integer."
+            assertEquals(expected, actual)
+        }
 
     // ------------------------------ Comparisons ------------------------------
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -551,6 +551,80 @@ class IntegerTest {
         assertEquals(expected, actual, "Input: $value")
     }
 
+    @Test
+    fun plusDoesNotOverflowWithPositiveIntegers(): Unit = repeatTest {
+        // Given
+        val range: LongRange = 1..Long.MAX_VALUE
+        val x: Integer = Integer.of(Random.nextLong(range))
+        val y: Integer = Integer.of(Random.nextLong(range))
+        // When
+        val sum: Integer = x + y
+        // Then
+        assertTrue("$sum must be greater than ${x}.") { sum > x }
+        assertTrue("$sum must be greater than ${y}.") { sum > y }
+    }
+
+    @Test
+    fun plusDoesNotOverflowWithNegativeIntegers(): Unit = repeatTest {
+        // Given
+        val range: LongRange = Long.MIN_VALUE..-1
+        val x: Integer = Integer.of(Random.nextLong(range))
+        val y: Integer = Integer.of(Random.nextLong(range))
+        // When
+        val sum: Integer = x + y
+        // Then
+        assertTrue("$sum must be less than ${x}.") { sum < x }
+        assertTrue("$sum must be less than ${y}.") { sum < y }
+    }
+
+    @Test
+    fun plusIsAssociative(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        val y: Integer = Integer.of(Random.nextLong())
+        val z: Integer = Integer.of(Random.nextLong())
+        // When
+        val sum: Integer = (x + y) + z
+        // Then
+        val expected: Integer = x + (y + z)
+        val message = "Inputs: x = $x, y = $y, z = $z"
+        assertEquals(expected, actual = sum, message)
+    }
+
+    @Test
+    fun plusIsCommutative(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        val y: Integer = Integer.of(Random.nextLong())
+        // When
+        val sum: Integer = x + y
+        // Then
+        val expected: Integer = y + x
+        assertEquals(expected, actual = sum, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun plusHasIdentityElement(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        val zero: Integer = Integer.of(0)
+        // When & Then
+        val message = "Input: $x"
+        assertSame(expected = x, actual = x + zero, message)
+        assertSame(expected = x, actual = zero + x, message)
+    }
+
+    @Test
+    fun plusHasInverseElement(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        // When
+        val actual: Integer = x + (-x)
+        // Then
+        val expected: Integer = Integer.of(0)
+        assertEquals(expected, actual, message = "Input: $x")
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -625,6 +625,82 @@ class IntegerTest {
         assertEquals(expected, actual, message = "Input: $x")
     }
 
+    @Test
+    fun minusDoesNotOverflowWithNegativeAndPositiveIntegers(): Unit =
+        repeatTest {
+            // Given
+            val x: Integer = Integer.of(Random.nextLong(Long.MIN_VALUE..-1))
+            val y: Integer = Integer.of(Random.nextLong(1..Long.MAX_VALUE))
+            // When
+            val difference: Integer = x - y
+            // Then
+            assertTrue("$difference must be less than ${x}.") { difference < x }
+            assertTrue("$difference must be less than ${y}.") { difference < y }
+        }
+
+    @Test
+    fun minusDoesNotOverflowWithPositiveAndNegativeIntegers(): Unit =
+        repeatTest {
+            // Given
+            val x: Integer = Integer.of(Random.nextLong(1..Long.MAX_VALUE))
+            val y: Integer = Integer.of(Random.nextLong(Long.MIN_VALUE..-1))
+            // When
+            val difference: Integer = x - y
+            // Then
+            assertTrue("$difference must be greater than ${x}.") {
+                difference > x
+            }
+            assertTrue("$difference must be greater than ${y}.") {
+                difference > y
+            }
+        }
+
+    @Test
+    fun minusIsAlignedWithIntegerAddition(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        val y: Integer = Integer.of(Random.nextLong())
+        // When
+        val difference: Integer = x - y
+        // Then
+        val expected: Integer = x + (-y)
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(expected, actual = difference, message)
+    }
+
+    @Test
+    fun minusReturnsZeroWithSameInteger(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        // When
+        val difference: Integer = x - x
+        // Then
+        val expected: Integer = Integer.of(0)
+        assertEquals(expected, actual = difference, message = "Input: $x")
+    }
+
+    @Test
+    fun minusIsNeutralWithZero(): Unit = repeatTest {
+        // Given
+        val x: Integer = Integer.of(Random.nextLong())
+        val zero: Integer = Integer.of(0)
+        // When
+        val difference: Integer = x - zero
+        // Then
+        assertSame(expected = x, actual = difference, message = "Input: $x")
+    }
+
+    @Test
+    fun minusNegatesOtherIntegerOnZero(): Unit = repeatTest {
+        // Given
+        val zero: Integer = Integer.of(0)
+        val x: Integer = Integer.of(Random.nextLong())
+        // When
+        val difference: Integer = zero - x
+        // Then
+        assertEquals(expected = -x, actual = difference, message = "Input: $x")
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
@@ -137,7 +138,7 @@ class IntegerTest {
     }
 
     @Test
-    fun parseThrowsWithEmptyString() {
+    fun parseThrowsNumberFormatExceptionWithEmptyString() {
         // Given
         val value = ""
         // When & Then
@@ -233,6 +234,175 @@ class IntegerTest {
             val actual: String? = exception.message
             val expected = "\"$value\" is not a valid integer."
             assertEquals(expected, actual)
+        }
+
+    @Test
+    fun parseOrNullHasUniqueRepresentationOfZero(): Unit = repeatTest {
+        // Given
+        val sign: String = listOf("", "+", "-").random()
+        val digits: String = buildString {
+            val times: Int = Random.nextInt(1..2_000)
+            repeat(times) { this.append(0) }
+        }
+        val value = "$sign$digits"
+        // When
+        val actual: Integer? = Integer.parseOrNull(value)
+        // Then
+        val expected: Integer = Integer.of(0)
+        assertEquals(expected, actual, "Input: $value")
+    }
+
+    @Test
+    fun parseOrNullRemovesPlusSignFromPositiveInteger(): Unit = repeatTest {
+        // Given
+        val digits: String = buildString {
+            val firstDigit: Int = Random.nextInt(1..9)
+            this.append(firstDigit)
+            val times: Int = Random.nextInt(1..32)
+            repeat(times) {
+                val otherDigit: Int = Random.nextInt(0..9)
+                this.append(otherDigit)
+            }
+        }
+        val value = "+$digits"
+        // When
+        val actual: Integer? = Integer.parseOrNull(value)
+        // Then
+        assertEquals(expected = digits, "$actual", "Input: $value")
+    }
+
+    @Test
+    fun parseOrNullPreservesRepresentationOfNegativeInteger(): Unit =
+        repeatTest {
+            // Given
+            val digits: String = buildString {
+                val firstDigit: Int = Random.nextInt(1..9)
+                this.append(firstDigit)
+                val times: Int = Random.nextInt(1..32)
+                repeat(times) {
+                    val otherDigit: Int = Random.nextInt(0..9)
+                    this.append(otherDigit)
+                }
+            }
+            val value = "-$digits"
+            // When
+            val actual: Integer? = Integer.parseOrNull(value)
+            // Then
+            assertEquals(expected = value, "$actual", "Input: $value")
+        }
+
+    @Test
+    fun parseOrNullRemovesInsignificantLeadingZerosFromInteger(): Unit =
+        repeatTest {
+            // Given
+            val sign: String = listOf("", "+", "-").random()
+            val zeros: String = buildString {
+                val times: Int = Random.nextInt(1..16)
+                repeat(times) { this.append(0) }
+            }
+            val digits: String = buildString {
+                val firstDigit: Int = Random.nextInt(1..9)
+                this.append(firstDigit)
+                val times: Int = Random.nextInt(1..16)
+                repeat(times) {
+                    val otherDigit: Int = Random.nextInt(0..9)
+                    this.append(otherDigit)
+                }
+            }
+            val value = "$sign$zeros$digits"
+            // When
+            val actual: Integer? = Integer.parseOrNull(value)
+            // Then
+            val expected: String = buildString {
+                if (sign != "+") this.append(sign)
+                this.append(digits)
+            }
+            assertEquals(expected, "$actual", "Input: $value")
+        }
+
+    @Test
+    fun parseOrNullReturnsNullWithEmptyString() {
+        // Given
+        val value = ""
+        // When
+        val actual: Integer? = Integer.parseOrNull(value)
+        // Then
+        assertNull(actual)
+    }
+
+    @Test
+    fun parseOrNullReturnsNullWithSignOnly(): Unit = listOf("+", "-").forEach {
+        // When
+        val actual: Integer? = Integer.parseOrNull(it)
+        // Then
+        assertNull(actual, "Input: $it")
+    }
+
+    @Test
+    fun parseOrNullReturnsNullWithMultipleSigns(): Unit = repeatTest {
+        // Given
+        val signs: String = buildString {
+            val signs: List<Char> = listOf('+', '-')
+            val times: Int = Random.nextInt(2..16)
+            repeat(times) {
+                val sign: Char = signs.random()
+                this.append(sign)
+            }
+        }
+        val digits: String = buildString {
+            val firstDigit: Int = Random.nextInt(1..9)
+            this.append(firstDigit)
+            val times: Int = Random.nextInt(1..16)
+            repeat(times) {
+                val otherDigit: Int = Random.nextInt(0..9)
+                this.append(otherDigit)
+            }
+        }
+        val value = "$signs$digits"
+        // When
+        val actual: Integer? = Integer.parseOrNull(value)
+        // Then
+        assertNull(actual, "Input: $value")
+    }
+
+    @Test
+    fun parseOrNullReturnsNullWithMalformedIntegerString(): Unit = repeatTest {
+        // Given
+        val signs: List<Char> = listOf('+', '-')
+        val characters: List<Char> = ('0'..'9') + signs
+        val value: String = buildString {
+            var signCount = 0
+            while (signCount < 2) {
+                val character: Char = characters.random()
+                this.append(character)
+                if (character in signs) signCount++
+            }
+        }
+        // When
+        val actual: Integer? = Integer.parseOrNull(value)
+        // Then
+        assertNull(actual, "Input: $value")
+    }
+
+    @Test
+    fun parseOrNullReturnsNullWithIllegalCharactersInString(): Unit =
+        repeatTest {
+            // Given
+            val allowedCharacters: List<Char> = ('0'..'9') + listOf('+', '-')
+            val characters: List<Char> =
+                allowedCharacters + ('a'..'z') + ('A'..'Z')
+            val value = buildString {
+                var illegalCharacterCount = 0
+                while (illegalCharacterCount == 0) {
+                    val character: Char = characters.random()
+                    this.append(character)
+                    if (character !in allowedCharacters) illegalCharacterCount++
+                }
+            }
+            // When
+            val actual: Integer? = Integer.parseOrNull(value)
+            // Then
+            assertNull(actual)
         }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -52,6 +52,57 @@ class IntegerTest {
         assertEquals(expected = "$value", "$actual")
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEqualityReturnsTrueWithSameIntegerValue(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong()
+        val x: Integer = Integer.of(value)
+        val y: Integer = Integer.of(value)
+        // When
+        val equality: Boolean = x == y
+        val hashConformity: Boolean = x.hashCode() == y.hashCode()
+        // Then
+        assertTrue(equality, "$x and $y must be structurally equal.")
+        assertTrue(hashConformity, "$x and $y must have the same hash code.")
+    }
+
+    @Test
+    fun structuralEqualityReturnsFalseWithAnotherTypeThanInteger(): Unit =
+        repeatTest {
+            // Given
+            val value: Long = Random.nextLong()
+            val x: Integer = Integer.of(value)
+            // When
+            val equality: Boolean = x.equals(value)
+            val hashConformity: Boolean = x.hashCode() == value.hashCode()
+            // Then
+            assertFalse(equality, "Integer can't be equal to another type.")
+            assertFalse(
+                hashConformity,
+                "Integer must produce a unique hash code."
+            )
+        }
+
+    @Test
+    fun structuralEqualityReturnsFalseWithAnotherIntegerValue(): Unit =
+        repeatTest {
+            // Given
+            val random = Random.Default
+            val x: Integer = Integer.of(random.nextLong())
+            val y: Integer = Integer.of(random.nextLong())
+            // When
+            val equality: Boolean = x == y
+            val hashConformity: Boolean = x.hashCode() == y.hashCode()
+            // Then
+            assertFalse(equality, "$x and $y must be different.")
+            assertFalse(
+                hashConformity,
+                "$x and $y must have different hash codes."
+            )
+        }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -1,0 +1,98 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import kotlin.random.Random
+import kotlin.random.nextLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class IntegerTest {
+    // ------------------------------- Creations -------------------------------
+
+    @Test
+    fun ofWithLongRepresentingZero() {
+        // Given
+        val value = 0L
+        // When
+        val actual: Integer = Integer.of(value)
+        // Then
+        assertEquals(expected = "$value", "$actual")
+    }
+
+    @Test
+    fun ofWithLongMaxValue() {
+        // Given
+        val value: Long = Long.MAX_VALUE
+        // When
+        val actual: Integer = Integer.of(value)
+        // Then
+        assertEquals(expected = "$value", "$actual")
+    }
+
+    @Test
+    fun ofWithLongMinValue() {
+        // Given
+        val value: Long = Long.MIN_VALUE
+        // When
+        val actual: Integer = Integer.of(value)
+        // Then
+        assertEquals(expected = "$value", "$actual")
+    }
+
+    @Test
+    fun ofWithRandomLong(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong()
+        // When
+        val actual: Integer = Integer.of(value)
+        // Then
+        assertEquals(expected = "$value", "$actual")
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toStringHasUniqueRepresentationOnZero() {
+        // Given
+        val zero = Integer.of(0)
+        // When
+        val actual: String = zero.toString()
+        // Then
+        assertEquals(expected = "0", actual)
+    }
+
+    @Test
+    fun toStringIgnoresPlusSignOnPositiveInteger(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong(1..Long.MAX_VALUE)
+        val integer: Integer = Integer.of(value)
+        // When
+        val actual: String = integer.toString()
+        // Then
+        assertFalse(message = "$actual must not start with '+'.") {
+            actual.startsWith('+')
+        }
+        assertEquals(expected = "$value", actual)
+    }
+
+    @Test
+    fun toStringKeepsMinusSignOnNegativeInteger(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong(Long.MIN_VALUE..-1)
+        val integer: Integer = Integer.of(value)
+        // When
+        val actual: String = integer.toString()
+        // Then
+        assertTrue(message = "$actual must start with '-'.") {
+            actual.startsWith('-')
+        }
+        assertEquals(expected = "$value", actual)
+    }
+}
+
+private inline fun repeatTest(block: () -> Unit): Unit = repeat(times = 1_000) {
+    block()
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -103,6 +103,64 @@ class IntegerTest {
             )
         }
 
+    @Test
+    fun compareToReturnsZeroWithSameIntegerValue(): Unit = repeatTest {
+        // Given
+        val value: Long = Random.nextLong()
+        val x: Integer = Integer.of(value)
+        val y: Integer = Integer.of(value)
+        // When
+        val actual: Int = x.compareTo(y)
+        // Then
+        assertEquals(expected = 0, actual, "$x and $y must be equal.")
+    }
+
+    @Test
+    fun compareToReturnsPositiveNumberWithLesserIntegerValue(): Unit =
+        repeatTest {
+            // Given
+            val value: Long = Random.nextLong(
+                (Long.MIN_VALUE + 1)..Long.MAX_VALUE
+            )
+            val x: Integer = Integer.of(value)
+            val y: Integer = Integer.of(Random.nextLong(Long.MIN_VALUE..<value))
+            // When
+            val actual: Int = x.compareTo(y)
+            // Then
+            assertTrue("$x must be greater than ${y}.") { actual > 0 }
+        }
+
+    @Test
+    fun compareToReturnsNegativeNumberWithGreaterIntegerValue(): Unit =
+        repeatTest {
+            // Given
+            val value: Long = Random.nextLong(Long.MIN_VALUE..<Long.MAX_VALUE)
+            val x: Integer = Integer.of(value)
+            val y: Integer = Integer.of(
+                Random.nextLong((value + 1)..Long.MAX_VALUE)
+            )
+            // When
+            val actual: Int = x.compareTo(y)
+            // Then
+            assertTrue("$x must be less than ${y}.") { actual < 0 }
+        }
+
+    @Test
+    fun compareToIsAlignedWithLongComparisons() {
+        // Given
+        val random = Random.Default
+        val xValue: Long = random.nextLong()
+        val x: Integer = Integer.of(xValue)
+        val yValue: Long = random.nextLong()
+        val y: Integer = Integer.of(yValue)
+        // When
+        val actual: Int = x.compareTo(y)
+        // Then
+        val expected: Int = xValue.compareTo(yValue)
+        val message = "Integer must align with Long comparisons."
+        assertEquals(expected, actual, message)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jsTest/kotlin/org/kotools/types/number/IntegerJsSample.kt
+++ b/subprojects/library/src/jsTest/kotlin/org/kotools/types/number/IntegerJsSample.kt
@@ -1,0 +1,15 @@
+package org.kotools.types.number
+
+import kotlin.test.Test
+
+class IntegerJsSample {
+    // -------------------------- Type documentation ---------------------------
+
+    @Suppress("DIVISION_BY_ZERO")
+    @Test
+    fun divisionByZeroProblem() {
+        // JS platform
+        check(12 / 0 == 0)
+        check(12 % 0 == 0)
+    }
+}

--- a/subprojects/library/src/jvmNativeTest/kotlin/org/kotools/types/number/IntegerJvmNativeSample.kt
+++ b/subprojects/library/src/jvmNativeTest/kotlin/org/kotools/types/number/IntegerJvmNativeSample.kt
@@ -1,0 +1,17 @@
+package org.kotools.types.number
+
+import kotlin.test.Test
+
+class IntegerJvmNativeSample {
+    // -------------------------- Type documentation ---------------------------
+
+    @Suppress("DIVISION_BY_ZERO")
+    @Test
+    fun divisionByZeroProblem() {
+        // JVM and Native platforms
+        val quotient: Result<Int> = kotlin.runCatching { 12 / 0 }
+        val remainder: Result<Int> = kotlin.runCatching { 12 % 0 }
+        check(quotient.exceptionOrNull() is ArithmeticException)
+        check(remainder.exceptionOrNull() is ArithmeticException)
+    }
+}

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/IntegerJavaSample.java
@@ -1,0 +1,35 @@
+package org.kotools.types;
+
+import org.junit.jupiter.api.Test;
+import org.kotools.types.number.Integer;
+
+@SuppressWarnings("NewClassNamingConvention")
+public class IntegerJavaSample {
+    // ------------------------------- Creations -------------------------------
+
+    @Test
+    void ofLong() {
+        // Given
+        final long value = Long.MAX_VALUE;
+        // When
+        final Integer result = Integer.of(value);
+        // Then
+        final String s = String.valueOf(result);
+        final String expected = String.valueOf(value);
+        final boolean check = expected.equals(s);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    void toStringOverride() {
+        // Given
+        final Integer integer = Integer.of(Long.MAX_VALUE);
+        // When
+        final String result = integer.toString();
+        // Then
+        final boolean check = result.equals("9223372036854775807");
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+}

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -45,6 +45,19 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void plus() {
+        // Given
+        final Integer x = Integer.of(9223372036854775807L);
+        final Integer y = Integer.of(10);
+        // When
+        final Integer sum = x.plus(y);
+        // Then
+        final Integer expected = Integer.parse("9223372036854775817");
+        final boolean check = sum.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -1,7 +1,6 @@
-package org.kotools.types;
+package org.kotools.types.number;
 
 import org.junit.jupiter.api.Test;
-import org.kotools.types.number.Integer;
 
 @SuppressWarnings("NewClassNamingConvention")
 public class IntegerJavaSample {

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -35,6 +35,16 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void compareTo() {
+        // Given
+        final Integer x = Integer.of(Long.MIN_VALUE);
+        final Integer y = Integer.of(Long.MAX_VALUE);
+        // When & Then
+        final boolean check = x.compareTo(y) < 0;
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -19,6 +19,18 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void parse() {
+        // Given
+        final String value = "+000123";
+        // When
+        final Integer result = Integer.parse(value);
+        // Then
+        final Integer expected = Integer.of(123);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -31,6 +31,20 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    void unaryMinus() {
+        // Given
+        final Integer integer = Integer.of(42);
+        // When
+        final Integer result = integer.unaryMinus();
+        // Then
+        final Integer expected = Integer.of(-42);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -58,6 +58,19 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void minus() {
+        // Given
+        final Integer x = Integer.of(-9223372036854775807L);
+        final Integer y = Integer.of(10);
+        // When
+        final Integer difference = x.minus(y);
+        // Then
+        final Integer expected = Integer.parse("-9223372036854775817");
+        final boolean check = difference.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -19,6 +19,22 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    void structuralEquality() {
+        // Given
+        final long value = Long.MAX_VALUE;
+        final Integer x = Integer.of(value);
+        final Integer y = Integer.of(value);
+        // When
+        final boolean equality = x.equals(y);
+        final boolean hashConformity = x.hashCode() == y.hashCode();
+        // Then
+        final boolean check = equality && hashConformity;
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test


### PR DESCRIPTION
## 📝 Description

This request reimplements the `Integer` type, but in the `org.kotools.types.number` package, and with an improved API.

```kotlin
package org.kotools.types.number

class Integer private constructor() {
    // ------------------------------- Creations -------------------------------

    companion object {
        fun of(value: Long): Integer = TODO()
        fun parse(value: String): Integer = TODO()
        fun parseOrNull(value: String): Integer? = TODO()
    }

    // ------------------------------ Comparisons ------------------------------

    override fun equals(other: Any?): Boolean = TODO()
    override fun hashCode(): Int = TODO()
    operator fun compareTo(other: Integer): Int = TODO()

    // ------------------------- Arithmetic operations -------------------------

    operator fun unaryMinus(): Integer = TODO()
    operator fun plus(other: Integer): Integer = TODO()
    operator fun minus(other: Integer): Integer = TODO()
    operator fun times(other: Integer): Integer = TODO()
    operator fun div(other: Integer): Integer = TODO()
    operator fun rem(other: Integer): Integer = TODO()

    // ------------------------------ Conversions ------------------------------

    override fun toString(): String = TODO()
}
```

## ✅ Checklist

- [ ] 📝 Document specifications for the `Integer` type.
- [ ] 🧪 Write tests aligned with specifications of `Integer`.
- [ ] ✨ Implement `Integer`.
- [ ] 📝 Document public API of `Integer`.
- [ ] 📝 Update unreleased changelog.