### PR TITLE
🐛 Fix exception type thrown by default serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ All notable changes to this project will be documented in this file.
   names (`org.kotools.types.EmailAddress` and
   `org.kotools.types.EmailAddressRegex`) instead of the type's simple name.
   ([#966])
+- Fixed the `EmailAddress` and `EmailAddressRegex` **experimental** default
+  serializers provided by `KotoolsTypesSerializersModule()` to throw an
+  `IllegalStateException` instead of an `IllegalArgumentException` when
+  decoding an invalid value, aligning with the exception types recommended for
+  `KSerializer` implementations. ([#990])
 
 [@daniel-rusu]: https://github.com/daniel-rusu
 [#871]: https://github.com/kotools/types/issues/871
@@ -70,6 +75,7 @@ All notable changes to this project will be documented in this file.
 [#962]: https://github.com/kotools/types/issues/962
 [#966]: https://github.com/kotools/types/issues/966
 [#988]: https://github.com/kotools/types/issues/988
+[#990]: https://github.com/kotools/types/issues/990
 
 ## 🔖 Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,8 @@ All notable changes to this project will be documented in this file.
   names (`org.kotools.types.EmailAddress` and
   `org.kotools.types.EmailAddressRegex`) instead of the type's simple name.
   ([#966])
-- Fixed the `EmailAddress` and `EmailAddressRegex` **experimental** default
-  serializers provided by `KotoolsTypesSerializersModule()` to throw an
-  `IllegalStateException` instead of an `IllegalArgumentException` when
+- Fixed default serializers provided by `KotoolsTypesSerializersModule()` to
+  throw an `IllegalStateException` instead of an `IllegalArgumentException` when
   decoding an invalid value, aligning with the exception types recommended for
   `KSerializer` implementations. ([#990])
 

--- a/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
+++ b/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
@@ -71,7 +71,7 @@ private class EmailAddressAsStringSerializer : KSerializer<EmailAddress> {
 
     override fun deserialize(decoder: Decoder): EmailAddress {
         val text: String = decoder.decodeString()
-        return requireNotNull(EmailAddress of text) {
+        return checkNotNull(EmailAddress of text) {
             errorMessage("Invalid email address", text)
         }
     }
@@ -90,7 +90,7 @@ private class EmailAddressRegexAsStringSerializer :
 
     override fun deserialize(decoder: Decoder): EmailAddressRegex {
         val text: String = decoder.decodeString()
-        return requireNotNull(EmailAddressRegex of text) {
+        return checkNotNull(EmailAddressRegex of text) {
             errorMessage("Invalid email address regex", text)
         }
     }

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
@@ -65,7 +65,7 @@ class EmailAddressAsStringSerializerTest {
             Json { this.serializersModule = KotoolsTypesSerializersModule() }
         val encoded = "\"testDomain.org\""
 
-        val actual: IllegalArgumentException = assertFailsWith {
+        val actual: IllegalStateException = assertFailsWith {
             format.decodeFromString<EmailAddress>(encoded)
         }
 
@@ -123,7 +123,7 @@ class EmailAddressRegexAsStringSerializerTest {
             Json { this.serializersModule = KotoolsTypesSerializersModule() }
         val encoded = """"^\\S+\\S+\\.\\S+$""""
 
-        val actual: IllegalArgumentException = assertFailsWith {
+        val actual: IllegalStateException = assertFailsWith {
             format.decodeFromString<EmailAddressRegex>(encoded)
         }
 


### PR DESCRIPTION
## Description

Fixes #990.

The `EmailAddress` and `EmailAddressRegex` default serializers exposed via `KotoolsTypesSerializersModule()` threw `IllegalArgumentException` when decoding an invalid value, which doesn't align with the exception types recommended for `KSerializer` implementations.

## Changes

- Replaced `requireNotNull` with `checkNotNull` in `EmailAddressAsStringSerializer.deserialize` and `EmailAddressRegexAsStringSerializer.deserialize`, so an `IllegalStateException` is now thrown for invalid decoded values.
- Updated `SerializersModuleTest` to expect `IllegalStateException`.
- Added a changelog entry linked to #990.

Generated with [Claude Code](https://claude.ai/code)