### PR TITLE
✨ Add default serializer for `Integer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,6 @@ All notable changes to this project will be documented in this file.
   arithmetic operators (`+`, `-`, `*`, unary `-`), comparison, and canonical
   string conversion. Division is intentionally excluded because the set of
   terminating decimals is not closed under division. ([#925])
-- Default serializer for the `Integer` **experimental** type to
-  `KotoolsTypesSerializersModule()`, serializing and deserializing it as a
-  `String` using `org.kotools.types.number.Integer` as serial name. ([#929])
 
 ### ♻️ Changed
 
@@ -72,7 +69,6 @@ All notable changes to this project will be documented in this file.
 [#912]: https://github.com/kotools/types/issues/912
 [#914]: https://github.com/kotools/types/pull/914
 [#925]: https://github.com/kotools/types/issues/925
-[#929]: https://github.com/kotools/types/issues/929
 [#952]: https://github.com/kotools/types/issues/952
 [#960]: https://github.com/kotools/types/issues/960
 [#962]: https://github.com/kotools/types/issues/962

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to this project will be documented in this file.
   arithmetic operators (`+`, `-`, `*`, unary `-`), comparison, and canonical
   string conversion. Division is intentionally excluded because the set of
   terminating decimals is not closed under division. ([#925])
+- Default serializer for the `Integer` **experimental** type to
+  `KotoolsTypesSerializersModule()`, serializing and deserializing it as a
+  `String` using `org.kotools.types.number.Integer` as serial name. ([#929])
 
 ### ♻️ Changed
 
@@ -69,6 +72,7 @@ All notable changes to this project will be documented in this file.
 [#912]: https://github.com/kotools/types/issues/912
 [#914]: https://github.com/kotools/types/pull/914
 [#925]: https://github.com/kotools/types/issues/925
+[#929]: https://github.com/kotools/types/issues/929
 [#952]: https://github.com/kotools/types/issues/952
 [#960]: https://github.com/kotools/types/issues/960
 [#962]: https://github.com/kotools/types/issues/962

--- a/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
+++ b/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
@@ -121,9 +121,9 @@ private class IntegerAsStringSerializer : KSerializer<Integer> {
         encoder.encodeString("$value")
 
     override fun deserialize(decoder: Decoder): Integer {
-        val text: String = decoder.decodeString()
-        return checkNotNull(Integer.parseOrNull(text)) {
-            errorMessage("Invalid integer representation", text)
+        val decoded: String = decoder.decodeString()
+        return checkNotNull(Integer.parseOrNull(decoded)) {
+            errorMessage("Invalid integer representation", decoded)
         }
     }
 }

--- a/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
+++ b/subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt
@@ -14,6 +14,7 @@ import org.kotools.types.EmailAddress
 import org.kotools.types.EmailAddressRegex
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.errorMessage
+import org.kotools.types.number.Integer
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmSynthetic
 
@@ -48,6 +49,18 @@ import kotlin.jvm.JvmSynthetic
  * SAMPLE: org.kotools.types.kotlinx.serialization.SerializersModuleSample.emailAddressRegexAsString
  * </details>
  *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Integer</b>
+ * </summary>
+ *
+ * This function provides an object for serializing and deserializing an
+ * [Integer] as [String].
+ *
+ * SAMPLE: org.kotools.types.kotlinx.serialization.SerializersModuleSample.integerAsString
+ * </details>
+ *
  * @since 5.0.1
  */
 @ExperimentalKotoolsTypesApi
@@ -57,6 +70,7 @@ public fun KotoolsTypesSerializersModule(): SerializersModule =
     SerializersModule {
         this.contextual(EmailAddressAsStringSerializer())
         this.contextual(EmailAddressRegexAsStringSerializer())
+        this.contextual(IntegerAsStringSerializer())
     }
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
@@ -96,9 +110,28 @@ private class EmailAddressRegexAsStringSerializer :
     }
 }
 
+@OptIn(ExperimentalKotoolsTypesApi::class)
+private class IntegerAsStringSerializer : KSerializer<Integer> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor(
+        serialName = SerialName.Integer.toString(),
+        PrimitiveKind.STRING
+    )
+
+    override fun serialize(encoder: Encoder, value: Integer): Unit =
+        encoder.encodeString("$value")
+
+    override fun deserialize(decoder: Decoder): Integer {
+        val text: String = decoder.decodeString()
+        return checkNotNull(Integer.parseOrNull(text)) {
+            errorMessage("Invalid integer representation", text)
+        }
+    }
+}
+
 private enum class SerialName(private val value: String) {
     EmailAddress("org.kotools.types.EmailAddress"),
-    EmailAddressRegex("org.kotools.types.EmailAddressRegex");
+    EmailAddressRegex("org.kotools.types.EmailAddressRegex"),
+    Integer("org.kotools.types.number.Integer");
 
     override fun toString(): String = this.value
 }

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.Json
 import org.kotools.types.EmailAddress
 import org.kotools.types.EmailAddressRegex
 import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.number.Integer
 import kotlin.test.Test
 
 class SerializersModuleSample {
@@ -56,5 +57,25 @@ class SerializersModuleSample {
 
         val decoded: CustomEmailAddress = format.decodeFromString(encoded)
         check(decoded == customEmail)
+    }
+
+    @OptIn(ExperimentalKotoolsTypesApi::class)
+    @Test
+    fun integerAsString() {
+        @Serializable
+        data class Account(@Contextual val balance: Integer)
+
+        val balance: Integer = Integer.of(150)
+        val account = Account(balance)
+
+        val format = Json {
+            this.serializersModule = KotoolsTypesSerializersModule()
+        }
+
+        val encoded: String = format.encodeToString(account)
+        check(encoded == """{"balance":"150"}""")
+
+        val decoded: Account = format.decodeFromString(encoded)
+        check(decoded == account)
     }
 }

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.serializer
 import org.kotools.types.EmailAddress
 import org.kotools.types.EmailAddressRegex
 import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.number.Integer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -130,6 +131,63 @@ class EmailAddressRegexAsStringSerializerTest {
         val text: String = encoded.trim('"')
             .replace(oldValue = "\\\\", newValue = "\\")
         val expected = "Invalid email address regex: '$text'"
+        assertEquals(expected, actual.message)
+    }
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class IntegerAsStringSerializerTest {
+    @Test
+    fun descriptor() {
+        val module: SerializersModule = KotoolsTypesSerializersModule()
+        val serializer: KSerializer<Integer> = module.serializer()
+
+        val actual: SerialDescriptor = serializer.descriptor
+
+        val expected: SerialDescriptor = PrimitiveSerialDescriptor(
+            serialName = "org.kotools.types.number.Integer",
+            PrimitiveKind.STRING
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun serialize() {
+        val format =
+            Json { this.serializersModule = KotoolsTypesSerializersModule() }
+        val value: Integer = Integer.of(150)
+
+        val actual: String = format.encodeToString(value)
+
+        assertEquals(expected = "\"${value}\"", actual)
+    }
+
+    @Test
+    fun deserializeWithValidInteger() {
+        val format =
+            Json { this.serializersModule = KotoolsTypesSerializersModule() }
+        val encoded = "\"150\""
+
+        val actual: Integer = format.decodeFromString(encoded)
+
+        val text: String = encoded.trim('"')
+        val expected: Integer = Integer.parseOrNull(text)
+            ?: fail("Null integer")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun deserializeWithInvalidInteger() {
+        val format =
+            Json { this.serializersModule = KotoolsTypesSerializersModule() }
+        val encoded = "\"abc\""
+
+        val actual: IllegalStateException = assertFailsWith {
+            format.decodeFromString<Integer>(encoded)
+        }
+
+        val text: String = encoded.trim('"')
+        val expected = "Invalid integer representation: '$text'"
         assertEquals(expected, actual.message)
     }
 }

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
@@ -171,8 +171,7 @@ class IntegerAsStringSerializerTest {
         val actual: Integer = format.decodeFromString(encoded)
 
         val text: String = encoded.trim('"')
-        val expected: Integer = Integer.parseOrNull(text)
-            ?: fail("Null integer")
+        val expected: Integer = Integer.parse(text)
         assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
## Summary

Adds the default `IntegerAsStringSerializer` to `KotoolsTypesSerializersModule()`, serializing `Integer` to/from `String` using `Integer.toString()` for serialization and `Integer.Companion.parseOrNull(String)` for deserialization (via `checkNotNull`, throwing `IllegalStateException` on invalid input).

- Serial name: `org.kotools.types.number.Integer`
- Adds `integerAsString` sample and `IntegerAsStringSerializerTest`
- Adds a CHANGELOG entry

Closes #929.

✅ Verified with `./gradlew :types-kotlinx-serialization:check` (BUILD SUCCESSFUL).

Generated with [Claude Code](https://claude.ai/code)