### PR TITLE
✨ Add primitive conversions from/to `Integer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ All notable changes to this project will be documented in this file.
   arithmetic operators (`+`, `-`, `*`, unary `-`), comparison, and canonical
   string conversion. Division is intentionally excluded because the set of
   terminating decimals is not closed under division. ([#925])
+- `Integer.Companion.fromByte(Byte)`, `fromShort(Short)` and `fromInt(Int)`
+  **experimental** functions to `org.kotools.types.number` package, creating
+  an `Integer` from a `Byte`, `Short` or `Int` value respectively. ([#987])
+- `Integer.toByte()`, `toShort()`, `toInt()` and `toLong()` **experimental**
+  functions to `org.kotools.types.number` package, converting this integer to
+  the corresponding type and throwing an `ArithmeticException` if it's out of
+  that type's range. Each has a `toByteOrNull()`, `toShortOrNull()`,
+  `toIntOrNull()` or `toLongOrNull()` counterpart returning `null` instead of
+  throwing. ([#987])
 
 ### ♻️ Changed
 
@@ -35,8 +44,8 @@ All notable changes to this project will be documented in this file.
   `Integer.remOrNull` **experimental** functions to use Euclidean division
   semantics: the remainder is always non-negative (`0 ≤ r < |b|`). ([#952])
 - Moved `Integer` **experimental** type to `org.kotools.types.number` package,
-  and renamed some of its functions (`from` -> `of`, `fromDecimal` -> `parse`,
-  `fromDecimalOrNull` -> `parseOrNull`). ([#960])
+  and renamed some of its functions (`from` -> `fromLong`, `fromDecimal` ->
+  `parse`, `fromDecimalOrNull` -> `parseOrNull`). ([#960], [#987])
 - Reformatted error messages thrown by **experimental** declarations in
   `org.kotools.types.*` (`Decimal`, `Integer`, `EmailAddressRegex`, and the
   `kotlinx-serialization` serializers) to follow a consistent
@@ -73,6 +82,7 @@ All notable changes to this project will be documented in this file.
 [#960]: https://github.com/kotools/types/issues/960
 [#962]: https://github.com/kotools/types/issues/962
 [#966]: https://github.com/kotools/types/issues/966
+[#987]: https://github.com/kotools/types/issues/987
 [#988]: https://github.com/kotools/types/issues/988
 [#990]: https://github.com/kotools/types/issues/990
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,23 @@ merged. Enforce this by:
 - **CI wiring travels with the change it enables**, not as a follow-up
   cleanup.
 
+### Commit conventions for related API additions
+
+When an issue adds multiple related public API members (e.g. several
+`from<Type>` / `to<Type>` conversions), follow these conventions:
+
+- **One commit per public API member.** Each commit that adds or changes a
+  public API member ships its KDoc, Kotlin/Java samples, tests, and ABI dump
+  update together.
+- **Split closely-related pairs into separate commits.** A conversion and its
+  `OrNull` counterpart (e.g. `toLong()` and `toLongOrNull()`) are each their
+  own public API addition and get their own commit, even though they're
+  conceptually paired.
+- **Separate ADR documentation from changelog updates.** When an issue
+  requires both an Architecture Decision Record (ADR) and an unreleased
+  `CHANGELOG.md` update, these are two separate commits, with the ADR landing
+  first, followed by the changelog update.
+
 ## Git & Version Control
 
 - **Never commit or push in interactive/local sessions.** Do not run

--- a/documentation/decisions/ADR-012-integer-conversion-range-errors.md
+++ b/documentation/decisions/ADR-012-integer-conversion-range-errors.md
@@ -1,0 +1,65 @@
+# 🏷️ ADR-012: Out-of-range error handling for `Integer` conversions
+
+This document records how [`Integer`][Integer] reports out-of-range values
+when converting to [`Byte`], [`Short`], [`Int`] or [`Long`].
+
+## 🤔 Context
+
+[`Integer`][Integer] (`org.kotools.types`) has arbitrary precision: its value
+isn't bounded by [`Byte`], [`Short`], [`Int`] or [`Long`]'s ranges. Converting
+an [`Integer`][Integer] to one of these fixed-size types
+(`toByte`/`toShort`/`toInt`/`toLong`) can therefore fail when the
+[`Integer`][Integer]'s value falls outside the target type's range.
+
+The library already has two established patterns for this kind of failure:
+
+- [`Integer.div`][Integer] and [`Integer.rem`][Integer] throw
+  [`ArithmeticException`] for an invalid arithmetic operation (division by
+  zero), each with a Kotlin-only `OrNull` counterpart
+  ([`divOrNull`][Integer], [`remOrNull`][Integer]) that returns `null` instead
+  of throwing.
+- [ADR-010] and [ADR-011] define the `<description>: <value>` format for
+  `org.kotools.types.*` error messages.
+
+A consistent choice was needed for the new conversion functions.
+
+## ✅ Decision
+
+`toByte`, `toShort`, `toInt` and `toLong` throw an [`ArithmeticException`] when
+this [`Integer`][Integer]'s value is outside the target type's range
+(`<Type>.MIN_VALUE..<Type>.MAX_VALUE`). [`ArithmeticException`] is reused from
+the [`div`][Integer]/[`rem`][Integer] convention above instead of introducing
+a new exception type.
+
+The exception message follows the [ADR-010] format, with this
+[`Integer`][Integer] as the (unquoted, numeric) offending value:
+
+```
+Integer out of range for <Type>: <value>
+```
+
+Each function has a Kotlin-only `toByteOrNull`/`toShortOrNull`/`toIntOrNull`/
+`toLongOrNull` counterpart that returns `null` instead of throwing, mirroring
+[`divOrNull`][Integer]/[`remOrNull`][Integer]. Like these, the `OrNull`
+variants are annotated `@JvmSynthetic` and hidden from Java, because
+nullability isn't explicit in Java's type system.
+
+## 🔗 Consequences
+
+- [`Integer`][Integer] gains `toByte`/`toShort`/`toInt`/`toLong` and their
+  `OrNull` counterparts, all following this shared range-check and error
+  format.
+- Any future `Integer` conversion that can fail due to a range constraint
+  should follow this same `ArithmeticException` / `OrNull` pairing and the
+  [ADR-010] message format.
+
+<!----------------------------------- Links ----------------------------------->
+
+[ADR-010]: ADR-010-error-message-format.md
+[ADR-011]: ADR-011-error-message-quote-escaping.md
+[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+[ArithmeticException]: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-arithmetic-exception/
+[Byte]: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-byte/
+[Short]: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-short/
+[Int]: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-int/
+[Long]: https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-long/

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -19,6 +19,7 @@ rationale behind it, and its consequences.
 | [ADR-009](ADR-009-default-serializer-serial-names.md)     | Explicit serial names for default serializers       | ✅ Accepted               |
 | [ADR-010](ADR-010-error-message-format.md)                | Error message format for `org.kotools.types`        | ✅ Accepted               |
 | [ADR-011](ADR-011-error-message-quote-escaping.md)        | String value quote escaping for `org.kotools.types` | ✅ Accepted               |
+| [ADR-012](ADR-012-integer-conversion-range-errors.md)     | Out-of-range error handling for `Integer` conversions | ✅ Accepted             |
 
 ## 🔄 Superseding records
 

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -15,8 +15,12 @@ public expect fun PlatformInteger(value: String): PlatformInteger
  */
 @InternalKotoolsTypesApi
 public interface PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
     /** Compares this integer with the [other] one for order. */
     public operator fun compareTo(other: PlatformInteger): Int
+
+    // ------------------------- Arithmetic operations -------------------------
 
     /** Returns the negative of this integer. */
     public operator fun unaryMinus(): PlatformInteger

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -36,9 +36,11 @@ public interface PlatformInteger {
     /** Returns the remainder of dividing this integer by the [other] one. */
     public operator fun rem(other: PlatformInteger): PlatformInteger
 
+    // ------------------------------ Conversions ------------------------------
+
     /**
      * Returns the [Long] representation of this integer, or returns `null` if
      * this integer is out of the [Long] range.
      */
-    public fun toLongOrNull(): Long? = this.toString().toLongOrNull()
+    public fun toLongOrNull(): Long?
 }

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
@@ -35,4 +35,10 @@ public interface PlatformInteger {
 
     /** Returns the remainder of dividing this integer by the [other] one. */
     public operator fun rem(other: PlatformInteger): PlatformInteger
+
+    /**
+     * Returns the [Long] representation of this integer, or returns `null` if
+     * this integer is out of the [Long] range.
+     */
+    public fun toLongOrNull(): Long? = this.toString().toLongOrNull()
 }

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -78,6 +78,11 @@ private value class JsInteger(private val delegate: BigInt) : PlatformInteger {
         return JsInteger(remainder)
     }
 
+    // ------------------------------ Conversions ------------------------------
+
+    override fun toLongOrNull(): Long? = this.toString()
+        .toLongOrNull()
+
     override fun toString(): String = this.delegate.toString()
 }
 

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -80,8 +80,13 @@ private value class JsInteger(private val delegate: BigInt) : PlatformInteger {
 
     // ------------------------------ Conversions ------------------------------
 
-    override fun toLongOrNull(): Long? = this.toString()
-        .toLongOrNull()
+    override fun toLongOrNull(): Long? {
+        val value: dynamic = this.delegate.asDynamic()
+        val min: dynamic = LONG_MIN_VALUE.asDynamic()
+        val max: dynamic = LONG_MAX_VALUE.asDynamic()
+        return if (value < min || value > max) null
+        else this.toString().toLong()
+    }
 
     override fun toString(): String = this.delegate.toString()
 }
@@ -89,3 +94,6 @@ private value class JsInteger(private val delegate: BigInt) : PlatformInteger {
 private external object BigInt
 
 private external fun BigInt(value: String): BigInt
+
+private val LONG_MIN_VALUE: BigInt = BigInt(Long.MIN_VALUE.toString())
+private val LONG_MAX_VALUE: BigInt = BigInt(Long.MAX_VALUE.toString())

--- a/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
+++ b/subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
@@ -18,11 +18,15 @@ public actual fun PlatformInteger(value: String): PlatformInteger {
 
 @OptIn(InternalKotoolsTypesApi::class)
 private value class JsInteger(private val delegate: BigInt) : PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
     override fun compareTo(other: PlatformInteger): Int {
         val x = this.delegate.asDynamic()
         val y = (other as JsInteger).delegate.asDynamic()
         return if (x < y) -1 else if (x > y) 1 else 0
     }
+
+    // ------------------------- Arithmetic operations -------------------------
 
     override fun unaryMinus(): PlatformInteger {
         val negated: BigInt = (-this.delegate.asDynamic()).unsafeCast<BigInt>()

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -21,8 +21,12 @@ public actual fun PlatformInteger(value: String): PlatformInteger {
 @OptIn(InternalKotoolsTypesApi::class)
 private value class JvmInteger(private val delegate: BigInteger) :
     PlatformInteger {
+    // ------------------------------ Comparisons ------------------------------
+
     override fun compareTo(other: PlatformInteger): Int =
         this.delegate.compareTo((other as JvmInteger).delegate)
+
+    // ------------------------- Arithmetic operations -------------------------
 
     override fun unaryMinus(): PlatformInteger =
         JvmInteger(this.delegate.negate())

--- a/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
+++ b/subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
@@ -55,5 +55,14 @@ private value class JvmInteger(private val delegate: BigInteger) :
         return JvmInteger(remainder)
     }
 
+    // ------------------------------ Conversions ------------------------------
+
+    override fun toLongOrNull(): Long? {
+        val min: BigInteger = BigInteger.valueOf(Long.MIN_VALUE)
+        val max: BigInteger = BigInteger.valueOf(Long.MAX_VALUE)
+        return this.delegate.takeIf { it in min..max }
+            ?.toLong()
+    }
+
     override fun toString(): String = this.delegate.toString()
 }

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -176,6 +176,25 @@ private class NativeInteger private constructor(
 
     // ------------------------------ Conversions ------------------------------
 
+    override fun toLongOrNull(): Long? {
+        if (this.sign == IntegerSign.Zero) return 0L
+        if (this.magnitude.size > 2) return null
+        val low: ULong = this.magnitude.getOrElse(0) { 0u }
+            .toULong()
+        val high: ULong = this.magnitude.getOrElse(1) { 0u }
+            .toULong()
+        val unsigned: ULong = low or (high shl 32)
+        return when {
+            this.sign == IntegerSign.Positive &&
+                unsigned <= Long.MAX_VALUE.toULong() -> unsigned.toLong()
+            this.sign == IntegerSign.Negative && unsigned == 1uL shl 63 ->
+                Long.MIN_VALUE
+            this.sign == IntegerSign.Negative && unsigned < 1uL shl 63 ->
+                -unsigned.toLong()
+            else -> null
+        }
+    }
+
     override fun toString(): String {
         if (this.sign == IntegerSign.Zero) return "0"
         val builder = StringBuilder()

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
@@ -65,7 +65,7 @@ class SerializersModuleSample {
         @Serializable
         data class Account(@Contextual val balance: Integer)
 
-        val balance: Integer = Integer.of(150)
+        val balance: Integer = Integer.fromLong(150)
         val account = Account(balance)
 
         val format = Json {

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
@@ -155,7 +155,7 @@ class IntegerAsStringSerializerTest {
     fun serialize() {
         val format =
             Json { this.serializersModule = KotoolsTypesSerializersModule() }
-        val value: Integer = Integer.of(150)
+        val value: Integer = Integer.fromLong(150)
 
         val actual: String = format.encodeToString(value)
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -390,6 +390,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun divOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromByte (B)Lorg/kotools/types/number/Integer;
+	public static final fun fromShort (S)Lorg/kotools/types/number/Integer;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
@@ -404,6 +405,7 @@ public final class org/kotools/types/number/Integer {
 
 public final class org/kotools/types/number/Integer$Companion {
 	public final fun fromByte (B)Lorg/kotools/types/number/Integer;
+	public final fun fromShort (S)Lorg/kotools/types/number/Integer;
 	public final fun of (J)Lorg/kotools/types/number/Integer;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -400,6 +400,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
+	public final fun toLong ()J
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -401,6 +401,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toInt ()I
+	public final synthetic fun toIntOrNull ()Ljava/lang/Integer;
 	public final fun toLong ()J
 	public final synthetic fun toLongOrNull ()Ljava/lang/Long;
 	public final fun toString ()Ljava/lang/String;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -400,6 +400,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
+	public final fun toByte ()B
 	public final fun toInt ()I
 	public final synthetic fun toIntOrNull ()Ljava/lang/Integer;
 	public final fun toLong ()J

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -389,6 +389,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun div (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun divOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun equals (Ljava/lang/Object;)Z
+	public static final fun fromByte (B)Lorg/kotools/types/number/Integer;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public static final fun of (J)Lorg/kotools/types/number/Integer;
@@ -402,6 +403,7 @@ public final class org/kotools/types/number/Integer {
 }
 
 public final class org/kotools/types/number/Integer$Companion {
+	public final fun fromByte (B)Lorg/kotools/types/number/Integer;
 	public final fun of (J)Lorg/kotools/types/number/Integer;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -400,6 +400,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
+	public final fun toInt ()I
 	public final fun toLong ()J
 	public final synthetic fun toLongOrNull ()Ljava/lang/Long;
 	public final fun toString ()Ljava/lang/String;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -391,10 +391,10 @@ public final class org/kotools/types/number/Integer {
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromByte (B)Lorg/kotools/types/number/Integer;
 	public static final fun fromInt (I)Lorg/kotools/types/number/Integer;
+	public static final fun fromLong (J)Lorg/kotools/types/number/Integer;
 	public static final fun fromShort (S)Lorg/kotools/types/number/Integer;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
-	public static final fun of (J)Lorg/kotools/types/number/Integer;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun plus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
@@ -407,8 +407,8 @@ public final class org/kotools/types/number/Integer {
 public final class org/kotools/types/number/Integer$Companion {
 	public final fun fromByte (B)Lorg/kotools/types/number/Integer;
 	public final fun fromInt (I)Lorg/kotools/types/number/Integer;
+	public final fun fromLong (J)Lorg/kotools/types/number/Integer;
 	public final fun fromShort (S)Lorg/kotools/types/number/Integer;
-	public final fun of (J)Lorg/kotools/types/number/Integer;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -404,6 +404,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun toIntOrNull ()Ljava/lang/Integer;
 	public final fun toLong ()J
 	public final synthetic fun toLongOrNull ()Ljava/lang/Long;
+	public final fun toShort ()S
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -390,6 +390,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun divOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromByte (B)Lorg/kotools/types/number/Integer;
+	public static final fun fromInt (I)Lorg/kotools/types/number/Integer;
 	public static final fun fromShort (S)Lorg/kotools/types/number/Integer;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
@@ -405,6 +406,7 @@ public final class org/kotools/types/number/Integer {
 
 public final class org/kotools/types/number/Integer$Companion {
 	public final fun fromByte (B)Lorg/kotools/types/number/Integer;
+	public final fun fromInt (I)Lorg/kotools/types/number/Integer;
 	public final fun fromShort (S)Lorg/kotools/types/number/Integer;
 	public final fun of (J)Lorg/kotools/types/number/Integer;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -401,6 +401,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toLong ()J
+	public final synthetic fun toLongOrNull ()Ljava/lang/Long;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -405,6 +405,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun toLong ()J
 	public final synthetic fun toLongOrNull ()Ljava/lang/Long;
 	public final fun toShort ()S
+	public final synthetic fun toShortOrNull ()Ljava/lang/Short;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -401,6 +401,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toByte ()B
+	public final synthetic fun toByteOrNull ()Ljava/lang/Byte;
 	public final fun toInt ()I
 	public final synthetic fun toIntOrNull ()Ljava/lang/Integer;
 	public final fun toLong ()J

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -112,7 +112,7 @@ public class Decimal private constructor(
          */
         @JvmStatic
         public fun of(value: Long): Decimal {
-            val unscaled: Integer = Integer.of(value)
+            val unscaled: Integer = Integer.fromLong(value)
             return Decimal(unscaled, scale = 0)
         }
 
@@ -552,7 +552,7 @@ public class Decimal private constructor(
      */
     private fun scaleUpTo(targetScale: Int): Integer {
         if (this.scale == targetScale) return this.unscaledValue
-        val ten: Integer = Integer.of(10)
+        val ten: Integer = Integer.fromLong(10)
         var result: Integer = this.unscaledValue
         repeat(targetScale - this.scale) { result *= ten }
         return result
@@ -565,12 +565,13 @@ public class Decimal private constructor(
      * [Integer.rem] uses Euclidean semantics (`remainder >= 0`), which
      * correctly identifiers divisibility by 10 for negative unscaled values.
      *
-     * Example: `-30 % 10 = 0` -> strip -> `Decimal(Integer.of(-3), scale = 0)`
+     * Example: `-30 % 10 = 0` -> strip ->
+     * `Decimal(Integer.fromLong(-3), scale = 0)`
      */
     private fun normalize(): Decimal {
         if (this.scale == 0) return this
-        val zero: Integer = Integer.of(0)
-        val ten: Integer = Integer.of(10)
+        val zero: Integer = Integer.fromLong(0)
+        val ten: Integer = Integer.fromLong(10)
         var current: Decimal = this
         while (current.scale > 0) {
             if (current.unscaledValue % ten != zero) break

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -738,10 +738,9 @@ public class Integer private constructor(
     // ------------------------------ Conversions ------------------------------
 
     /**
-     * Returns the decimal string representation of this integer.
-     *
-     * The resulting string is always canonical (no leading plus sign and
-     * zeros).
+     * Returns the [Byte] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Byte] range
+     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
      *
      * <br>
      * <details>
@@ -751,7 +750,7 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Kotlin code:
      *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toStringOverride
+     * SAMPLE: org.kotools.types.number.IntegerSample.toByte
      * </details>
      *
      * <br>
@@ -762,16 +761,20 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Java code:
      *
-     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toStringOverride
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toByte
      * </details>
+     * <br>
+     *
+     * See the [toByteOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Byte] range.
      */
-    @Suppress("RedundantModalityModifier")
-    final override fun toString(): String = this.delegate.toString()
+    public fun toByte(): Byte = this.toByteOrNull()
+        ?: this.outOfRangeError<Byte>()
 
     /**
-     * Returns the [Long] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Long] range
-     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     * Returns the [Byte] representation of this integer, or returns `null`
+     * if this integer is out of the [Byte] range
+     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
      *
      * <br>
      * <details>
@@ -781,119 +784,21 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Kotlin code:
      *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toLong
-     * </details>
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Java</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Java code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toLong
-     * </details>
-     * <br>
-     *
-     * See the [toLongOrNull] function for returning `null` instead of
-     * throwing an exception if this integer is out of the [Long] range.
-     */
-    public fun toLong(): Long =
-        this.delegate.toLongOrNull() ?: this.outOfRangeError("Long")
-
-    /**
-     * Returns the [Long] representation of this integer, or returns `null`
-     * if this integer is out of the [Long] range
-     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toLongOrNull
+     * SAMPLE: org.kotools.types.number.IntegerSample.toByteOrNull
      * </details>
      * <br>
      *
      * This function is hidden from Java, because nullability is not explicit
      * in its type system.
      *
-     * See the [toLong] function for throwing an exception instead of
-     * returning `null` if this integer is out of the [Long] range.
+     * See the [toByte] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Byte] range.
      */
     @JvmSynthetic
-    public fun toLongOrNull(): Long? = this.delegate.toLongOrNull()
-
-    /**
-     * Returns the [Int] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Int] range
-     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toInt
-     * </details>
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Java</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Java code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toInt
-     * </details>
-     * <br>
-     *
-     * See the [toIntOrNull] function for returning `null` instead of
-     * throwing an exception if this integer is out of the [Int] range.
-     */
-    public fun toInt(): Int {
-        val range: LongRange = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()
-        val value: Long? = this.delegate.toLongOrNull()
-        return if (value != null && value in range) value.toInt()
-        else this.outOfRangeError("Int")
-    }
-
-    /**
-     * Returns the [Int] representation of this integer, or returns `null` if
-     * this integer is out of the [Int] range
-     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toIntOrNull
-     * </details>
-     * <br>
-     *
-     * This function is hidden from Java, because nullability is not explicit
-     * in its type system.
-     *
-     * See the [toInt] function for throwing an exception instead of
-     * returning `null` if this integer is out of the [Int] range.
-     */
-    @JvmSynthetic
-    public fun toIntOrNull(): Int? {
-        val range: LongRange = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()
-        val value: Long? = this.delegate.toLongOrNull()
-        return if (value != null && value in range) value.toInt() else null
+    public fun toByteOrNull(): Byte? {
+        val value: Long = this.delegate.toLongOrNull() ?: return null
+        val range: LongRange = Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()
+        return if (value in range) value.toByte() else null
     }
 
     /**
@@ -927,13 +832,8 @@ public class Integer private constructor(
      * See the [toShortOrNull] function for returning `null` instead of
      * throwing an exception if this integer is out of the [Short] range.
      */
-    public fun toShort(): Short {
-        val range: LongRange =
-            Short.MIN_VALUE.toLong()..Short.MAX_VALUE.toLong()
-        val value: Long? = this.delegate.toLongOrNull()
-        return if (value != null && value in range) value.toShort()
-        else this.outOfRangeError("Short")
-    }
+    public fun toShort(): Short = this.toShortOrNull()
+        ?: this.outOfRangeError<Short>()
 
     /**
      * Returns the [Short] representation of this integer, or returns `null`
@@ -960,17 +860,16 @@ public class Integer private constructor(
      */
     @JvmSynthetic
     public fun toShortOrNull(): Short? {
+        val value: Long = this.delegate.toLongOrNull() ?: return null
         val range: LongRange =
             Short.MIN_VALUE.toLong()..Short.MAX_VALUE.toLong()
-        val value: Long? = this.delegate.toLongOrNull()
-        return if (value != null && value in range) value.toShort()
-        else null
+        return if (value in range) value.toShort() else null
     }
 
     /**
-     * Returns the [Byte] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Byte] range
-     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
+     * Returns the [Int] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Int] range
+     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
      *
      * <br>
      * <details>
@@ -980,7 +879,7 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Kotlin code:
      *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toByte
+     * SAMPLE: org.kotools.types.number.IntegerSample.toInt
      * </details>
      *
      * <br>
@@ -991,25 +890,19 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Java code:
      *
-     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toByte
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toInt
      * </details>
      * <br>
      *
-     * See the [toByteOrNull] function for returning `null` instead of
-     * throwing an exception if this integer is out of the [Byte] range.
+     * See the [toIntOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Int] range.
      */
-    public fun toByte(): Byte {
-        val range: LongRange =
-            Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()
-        val value: Long? = this.delegate.toLongOrNull()
-        return if (value != null && value in range) value.toByte()
-        else this.outOfRangeError("Byte")
-    }
+    public fun toInt(): Int = this.toIntOrNull() ?: this.outOfRangeError<Int>()
 
     /**
-     * Returns the [Byte] representation of this integer, or returns `null`
-     * if this integer is out of the [Byte] range
-     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
+     * Returns the [Int] representation of this integer, or returns `null` if
+     * this integer is out of the [Int] range
+     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
      *
      * <br>
      * <details>
@@ -1019,28 +912,118 @@ public class Integer private constructor(
      *
      * Here's an example of calling this function from Kotlin code:
      *
-     * SAMPLE: org.kotools.types.number.IntegerSample.toByteOrNull
+     * SAMPLE: org.kotools.types.number.IntegerSample.toIntOrNull
      * </details>
      * <br>
      *
      * This function is hidden from Java, because nullability is not explicit
      * in its type system.
      *
-     * See the [toByte] function for throwing an exception instead of
-     * returning `null` if this integer is out of the [Byte] range.
+     * See the [toInt] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Int] range.
      */
     @JvmSynthetic
-    public fun toByteOrNull(): Byte? {
-        val range: LongRange =
-            Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()
-        val value: Long? = this.delegate.toLongOrNull()
-        return if (value != null && value in range) value.toByte()
-        else null
+    public fun toIntOrNull(): Int? {
+        val value: Long = this.delegate.toLongOrNull() ?: return null
+        val range: LongRange = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()
+        return if (value in range) value.toInt() else null
     }
 
-    private fun outOfRangeError(targetType: String): Nothing {
+    /**
+     * Returns the [Long] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Long] range
+     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toLong
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toLong
+     * </details>
+     * <br>
+     *
+     * See the [toLongOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Long] range.
+     */
+    public fun toLong(): Long = this.toLongOrNull()
+        ?: this.outOfRangeError<Long>()
+
+    /**
+     * Returns the [Long] representation of this integer, or returns `null`
+     * if this integer is out of the [Long] range
+     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toLongOrNull
+     * </details>
+     * <br>
+     *
+     * This function is hidden from Java, because nullability is not explicit
+     * in its type system.
+     *
+     * See the [toLong] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Long] range.
+     */
+    @JvmSynthetic
+    public fun toLongOrNull(): Long? = this.delegate.toLongOrNull()
+
+    private inline fun <reified T : Number> outOfRangeError(): Nothing {
+        val type: String? = T::class.simpleName
         val message: String =
-            errorMessage("Integer out of range for $targetType", this)
+            errorMessage("Integer out of range for $type", this)
         throw ArithmeticException(message)
     }
+
+    /**
+     * Returns the decimal string representation of this integer.
+     *
+     * The resulting string is always canonical (no leading plus sign and
+     * zeros).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toStringOverride
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toStringOverride
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun toString(): String = this.delegate.toString()
 }

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -213,6 +213,37 @@ public class Integer private constructor(
         public fun fromShort(value: Short): Integer = of(value.toLong())
 
         /**
+         * Returns an [Integer] representing the specified [value].
+         *
+         * This function preserves the canonical representation of [value], and
+         * never fails since every [Int] value is within the range of [Integer].
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.fromInt
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromInt
+         * </details>
+         */
+        @JvmStatic
+        public fun fromInt(value: Int): Integer = of(value.toLong())
+
+        /**
          * Returns an [Integer] representing the number described by [value],
          * or throws [NumberFormatException] if the [value] doesn't represent an
          * integer.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -143,6 +143,8 @@ public class Integer private constructor(
          *
          * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromByte
          * </details>
+         *
+         * @since 5.2.0
          */
         @JvmStatic
         public fun fromByte(value: Byte): Integer {
@@ -178,6 +180,8 @@ public class Integer private constructor(
          *
          * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromShort
          * </details>
+         *
+         * @since 5.2.0
          */
         @JvmStatic
         public fun fromShort(value: Short): Integer {
@@ -212,6 +216,8 @@ public class Integer private constructor(
          *
          * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromInt
          * </details>
+         *
+         * @since 5.2.0
          */
         @JvmStatic
         public fun fromInt(value: Int): Integer {
@@ -247,6 +253,8 @@ public class Integer private constructor(
          *
          * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromLong
          * </details>
+         *
+         * @since 5.2.0
          */
         @JvmStatic
         public fun fromLong(value: Long): Integer {
@@ -299,6 +307,8 @@ public class Integer private constructor(
          *
          * See the [parseOrNull] function for returning `null` instead of
          * throwing an exception in case of invalid [value].
+         *
+         * @since 5.2.0
          */
         @JvmStatic
         public fun parse(value: String): Integer {
@@ -348,6 +358,8 @@ public class Integer private constructor(
          *
          * See the [parse] function for throwing an exception instead of
          * returning `null` in case of invalid [value].
+         *
+         * @since 5.2.0
          */
         @JvmSynthetic
         public fun parseOrNull(value: String): Integer? {
@@ -767,6 +779,8 @@ public class Integer private constructor(
      *
      * See the [toByteOrNull] function for returning `null` instead of
      * throwing an exception if this integer is out of the [Byte] range.
+     *
+     * @since 5.2.0
      */
     public fun toByte(): Byte = this.toByteOrNull()
         ?: this.outOfRangeError<Byte>()
@@ -793,6 +807,8 @@ public class Integer private constructor(
      *
      * See the [toByte] function for throwing an exception instead of
      * returning `null` if this integer is out of the [Byte] range.
+     *
+     * @since 5.2.0
      */
     @JvmSynthetic
     public fun toByteOrNull(): Byte? {
@@ -831,6 +847,8 @@ public class Integer private constructor(
      *
      * See the [toShortOrNull] function for returning `null` instead of
      * throwing an exception if this integer is out of the [Short] range.
+     *
+     * @since 5.2.0
      */
     public fun toShort(): Short = this.toShortOrNull()
         ?: this.outOfRangeError<Short>()
@@ -857,6 +875,8 @@ public class Integer private constructor(
      *
      * See the [toShort] function for throwing an exception instead of
      * returning `null` if this integer is out of the [Short] range.
+     *
+     * @since 5.2.0
      */
     @JvmSynthetic
     public fun toShortOrNull(): Short? {
@@ -896,6 +916,8 @@ public class Integer private constructor(
      *
      * See the [toIntOrNull] function for returning `null` instead of
      * throwing an exception if this integer is out of the [Int] range.
+     *
+     * @since 5.2.0
      */
     public fun toInt(): Int = this.toIntOrNull() ?: this.outOfRangeError<Int>()
 
@@ -919,8 +941,10 @@ public class Integer private constructor(
      * This function is hidden from Java, because nullability is not explicit
      * in its type system.
      *
-     * See the [toInt] function for throwing an exception instead of
-     * returning `null` if this integer is out of the [Int] range.
+     * See the [toInt] function for throwing an exception instead of returning
+     * `null` if this integer is out of the [Int] range.
+     *
+     * @since 5.2.0
      */
     @JvmSynthetic
     public fun toIntOrNull(): Int? {
@@ -957,8 +981,10 @@ public class Integer private constructor(
      * </details>
      * <br>
      *
-     * See the [toLongOrNull] function for returning `null` instead of
-     * throwing an exception if this integer is out of the [Long] range.
+     * See the [toLongOrNull] function for returning `null` instead of throwing
+     * an exception if this integer is out of the [Long] range.
+     *
+     * @since 5.2.0
      */
     public fun toLong(): Long = this.toLongOrNull()
         ?: this.outOfRangeError<Long>()
@@ -983,8 +1009,10 @@ public class Integer private constructor(
      * This function is hidden from Java, because nullability is not explicit
      * in its type system.
      *
-     * See the [toLong] function for throwing an exception instead of
-     * returning `null` if this integer is out of the [Long] range.
+     * See the [toLong] function for throwing an exception instead of returning
+     * `null` if this integer is out of the [Long] range.
+     *
+     * @since 5.2.0
      */
     @JvmSynthetic
     public fun toLongOrNull(): Long? = this.delegate.toLongOrNull()

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -111,43 +111,10 @@ import kotlin.jvm.JvmSynthetic
 public class Integer private constructor(
     private val delegate: PlatformInteger
 ) {
-    // ------------------------------- Creations -------------------------------
+    // --------------------------- Factory functions ---------------------------
 
     /** Contains class-level declarations for the [Integer] type. */
     public companion object {
-        /**
-         * Returns an [Integer] representing the specified [value].
-         *
-         * This function preserves the canonical representation of [value].
-         *
-         * <br>
-         * <details>
-         * <summary>
-         *     <b>Calling from Kotlin</b>
-         * </summary>
-         *
-         * Here's an example of calling this function from Kotlin code:
-         *
-         * SAMPLE: org.kotools.types.number.IntegerSample.fromLong
-         * </details>
-         *
-         * <br>
-         * <details>
-         * <summary>
-         *     <b>Calling from Java</b>
-         * </summary>
-         *
-         * Here's an example of calling this function from Java code:
-         *
-         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromLong
-         * </details>
-         */
-        @JvmStatic
-        public fun fromLong(value: Long): Integer {
-            val delegate = PlatformInteger(value)
-            return Integer(delegate)
-        }
-
         /**
          * Returns an [Integer] representing the specified [value].
          *
@@ -178,7 +145,10 @@ public class Integer private constructor(
          * </details>
          */
         @JvmStatic
-        public fun fromByte(value: Byte): Integer = fromLong(value.toLong())
+        public fun fromByte(value: Byte): Integer {
+            val number: Long = value.toLong()
+            return this.fromLong(number)
+        }
 
         /**
          * Returns an [Integer] representing the specified [value].
@@ -210,7 +180,10 @@ public class Integer private constructor(
          * </details>
          */
         @JvmStatic
-        public fun fromShort(value: Short): Integer = fromLong(value.toLong())
+        public fun fromShort(value: Short): Integer {
+            val number = value.toLong()
+            return this.fromLong(number)
+        }
 
         /**
          * Returns an [Integer] representing the specified [value].
@@ -241,7 +214,45 @@ public class Integer private constructor(
          * </details>
          */
         @JvmStatic
-        public fun fromInt(value: Int): Integer = fromLong(value.toLong())
+        public fun fromInt(value: Int): Integer {
+            val number: Long = value.toLong()
+            return this.fromLong(number)
+        }
+
+        /**
+         * Returns an [Integer] representing the specified [value].
+         *
+         * This function preserves the canonical representation of [value], and
+         * never fails since every [Long] value is within the range of
+         * [Integer].
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.fromLong
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromLong
+         * </details>
+         */
+        @JvmStatic
+        public fun fromLong(value: Long): Integer {
+            val delegate = PlatformInteger(value)
+            return Integer(delegate)
+        }
 
         /**
          * Returns an [Integer] representing the number described by [value],

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -911,6 +911,10 @@ public class Integer private constructor(
      *
      * SAMPLE: org.kotools.types.number.IntegerJavaSample.toShort
      * </details>
+     * <br>
+     *
+     * See the [toShortOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Short] range.
      */
     public fun toShort(): Short {
         val range: LongRange =
@@ -918,6 +922,38 @@ public class Integer private constructor(
         val value: Long? = this.delegate.toLongOrNull()
         return if (value != null && value in range) value.toShort()
         else this.outOfRangeError("Short")
+    }
+
+    /**
+     * Returns the [Short] representation of this integer, or returns `null`
+     * if this integer is out of the [Short] range
+     * (`Short.MIN_VALUE..Short.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toShortOrNull
+     * </details>
+     * <br>
+     *
+     * This function is hidden from Java, because nullability is not explicit
+     * in its type system.
+     *
+     * See the [toShort] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Short] range.
+     */
+    @JvmSynthetic
+    public fun toShortOrNull(): Short? {
+        val range: LongRange =
+            Short.MIN_VALUE.toLong()..Short.MAX_VALUE.toLong()
+        val value: Long? = this.delegate.toLongOrNull()
+        return if (value != null && value in range) value.toShort()
+        else null
     }
 
     private fun outOfRangeError(targetType: String): Nothing {

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -982,6 +982,10 @@ public class Integer private constructor(
      *
      * SAMPLE: org.kotools.types.number.IntegerJavaSample.toByte
      * </details>
+     * <br>
+     *
+     * See the [toByteOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Byte] range.
      */
     public fun toByte(): Byte {
         val range: LongRange =
@@ -989,6 +993,38 @@ public class Integer private constructor(
         val value: Long? = this.delegate.toLongOrNull()
         return if (value != null && value in range) value.toByte()
         else this.outOfRangeError("Byte")
+    }
+
+    /**
+     * Returns the [Byte] representation of this integer, or returns `null`
+     * if this integer is out of the [Byte] range
+     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toByteOrNull
+     * </details>
+     * <br>
+     *
+     * This function is hidden from Java, because nullability is not explicit
+     * in its type system.
+     *
+     * See the [toByte] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Byte] range.
+     */
+    @JvmSynthetic
+    public fun toByteOrNull(): Byte? {
+        val range: LongRange =
+            Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()
+        val value: Long? = this.delegate.toLongOrNull()
+        return if (value != null && value in range) value.toByte()
+        else null
     }
 
     private fun outOfRangeError(targetType: String): Nothing {

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -756,4 +756,40 @@ public class Integer private constructor(
      */
     @Suppress("RedundantModalityModifier")
     final override fun toString(): String = this.delegate.toString()
+
+    /**
+     * Returns the [Long] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Long] range
+     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toLong
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toLong
+     * </details>
+     */
+    public fun toLong(): Long =
+        this.delegate.toLongOrNull() ?: this.outOfRangeError("Long")
+
+    private fun outOfRangeError(targetType: String): Nothing {
+        val message: String =
+            errorMessage("Integer out of range for $targetType", this)
+        throw ArithmeticException(message)
+    }
 }

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -817,6 +817,40 @@ public class Integer private constructor(
     @JvmSynthetic
     public fun toLongOrNull(): Long? = this.delegate.toLongOrNull()
 
+    /**
+     * Returns the [Int] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Int] range
+     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toInt
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toInt
+     * </details>
+     */
+    public fun toInt(): Int {
+        val range: LongRange = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()
+        val value: Long? = this.delegate.toLongOrNull()
+        return if (value != null && value in range) value.toInt()
+        else this.outOfRangeError("Int")
+    }
+
     private fun outOfRangeError(targetType: String): Nothing {
         val message: String =
             errorMessage("Integer out of range for $targetType", this)

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -885,6 +885,41 @@ public class Integer private constructor(
         return if (value != null && value in range) value.toInt() else null
     }
 
+    /**
+     * Returns the [Short] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Short] range
+     * (`Short.MIN_VALUE..Short.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toShort
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toShort
+     * </details>
+     */
+    public fun toShort(): Short {
+        val range: LongRange =
+            Short.MIN_VALUE.toLong()..Short.MAX_VALUE.toLong()
+        val value: Long? = this.delegate.toLongOrNull()
+        return if (value != null && value in range) value.toShort()
+        else this.outOfRangeError("Short")
+    }
+
     private fun outOfRangeError(targetType: String): Nothing {
         val message: String =
             errorMessage("Integer out of range for $targetType", this)

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -783,9 +783,39 @@ public class Integer private constructor(
      *
      * SAMPLE: org.kotools.types.number.IntegerJavaSample.toLong
      * </details>
+     * <br>
+     *
+     * See the [toLongOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Long] range.
      */
     public fun toLong(): Long =
         this.delegate.toLongOrNull() ?: this.outOfRangeError("Long")
+
+    /**
+     * Returns the [Long] representation of this integer, or returns `null`
+     * if this integer is out of the [Long] range
+     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toLongOrNull
+     * </details>
+     * <br>
+     *
+     * This function is hidden from Java, because nullability is not explicit
+     * in its type system.
+     *
+     * See the [toLong] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Long] range.
+     */
+    @JvmSynthetic
+    public fun toLongOrNull(): Long? = this.delegate.toLongOrNull()
 
     private fun outOfRangeError(targetType: String): Nothing {
         val message: String =

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -4,7 +4,10 @@ import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.internal.number.PlatformInteger
+import org.kotools.types.number.Integer.Companion.fromByte
+import org.kotools.types.number.Integer.Companion.fromInt
 import org.kotools.types.number.Integer.Companion.fromLong
+import org.kotools.types.number.Integer.Companion.fromShort
 import org.kotools.types.number.Integer.Companion.parse
 import org.kotools.types.number.Integer.Companion.parseOrNull
 import kotlin.jvm.JvmStatic
@@ -93,7 +96,7 @@ import kotlin.jvm.JvmSynthetic
  * ### Key features
  *
  * - **Creations:** Create from Kotlin integer types or decimal string (see
- * [fromLong] and [parse]).
+ * [fromByte], [fromShort], [fromInt], [fromLong] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][Integer.equals] (`x == y`, `x != y`) and
  * [ordering operators][compareTo] (`x < y`, `x <= y`, `x > y`, `x >= y`).
@@ -101,7 +104,8 @@ import kotlin.jvm.JvmSynthetic
  * (`x - y`), [multiply][times] (`x * y`), [divide][div] (`x / y`), compute
  * [remainders][rem] (`x % y`), and [negate][unaryMinus] (`-x`) integers without
  * overflow.
- * - **Conversions:** Convert to its decimal string representation (see
+ * - **Conversions:** Convert to Kotlin integer types or its decimal string
+ * representation (see [toByte], [toShort], [toInt], [toLong] and
  * [Integer.toString]).
  * </details>
  *

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -181,6 +181,38 @@ public class Integer private constructor(
         public fun fromByte(value: Byte): Integer = of(value.toLong())
 
         /**
+         * Returns an [Integer] representing the specified [value].
+         *
+         * This function preserves the canonical representation of [value], and
+         * never fails since every [Short] value is within the range of
+         * [Integer].
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.fromShort
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromShort
+         * </details>
+         */
+        @JvmStatic
+        public fun fromShort(value: Short): Integer = of(value.toLong())
+
+        /**
          * Returns an [Integer] representing the number described by [value],
          * or throws [NumberFormatException] if the [value] doesn't represent an
          * integer.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -843,12 +843,46 @@ public class Integer private constructor(
      *
      * SAMPLE: org.kotools.types.number.IntegerJavaSample.toInt
      * </details>
+     * <br>
+     *
+     * See the [toIntOrNull] function for returning `null` instead of
+     * throwing an exception if this integer is out of the [Int] range.
      */
     public fun toInt(): Int {
         val range: LongRange = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()
         val value: Long? = this.delegate.toLongOrNull()
         return if (value != null && value in range) value.toInt()
         else this.outOfRangeError("Int")
+    }
+
+    /**
+     * Returns the [Int] representation of this integer, or returns `null` if
+     * this integer is out of the [Int] range
+     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toIntOrNull
+     * </details>
+     * <br>
+     *
+     * This function is hidden from Java, because nullability is not explicit
+     * in its type system.
+     *
+     * See the [toInt] function for throwing an exception instead of
+     * returning `null` if this integer is out of the [Int] range.
+     */
+    @JvmSynthetic
+    public fun toIntOrNull(): Int? {
+        val range: LongRange = Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()
+        val value: Long? = this.delegate.toLongOrNull()
+        return if (value != null && value in range) value.toInt() else null
     }
 
     private fun outOfRangeError(targetType: String): Nothing {

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -149,6 +149,38 @@ public class Integer private constructor(
         }
 
         /**
+         * Returns an [Integer] representing the specified [value].
+         *
+         * This function preserves the canonical representation of [value], and
+         * never fails since every [Byte] value is within the range of
+         * [Integer].
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerSample.fromByte
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromByte
+         * </details>
+         */
+        @JvmStatic
+        public fun fromByte(value: Byte): Integer = of(value.toLong())
+
+        /**
          * Returns an [Integer] representing the number described by [value],
          * or throws [NumberFormatException] if the [value] doesn't represent an
          * integer.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -4,7 +4,7 @@ import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.internal.number.PlatformInteger
-import org.kotools.types.number.Integer.Companion.of
+import org.kotools.types.number.Integer.Companion.fromLong
 import org.kotools.types.number.Integer.Companion.parse
 import org.kotools.types.number.Integer.Companion.parseOrNull
 import kotlin.jvm.JvmStatic
@@ -92,8 +92,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from Kotlin integer types or decimal string (see [of]
- * and [parse]).
+ * - **Creations:** Create from Kotlin integer types or decimal string (see
+ * [fromLong] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][Integer.equals] (`x == y`, `x != y`) and
  * [ordering operators][compareTo] (`x < y`, `x <= y`, `x > y`, `x >= y`).
@@ -128,7 +128,7 @@ public class Integer private constructor(
          *
          * Here's an example of calling this function from Kotlin code:
          *
-         * SAMPLE: org.kotools.types.number.IntegerSample.of
+         * SAMPLE: org.kotools.types.number.IntegerSample.fromLong
          * </details>
          *
          * <br>
@@ -139,11 +139,11 @@ public class Integer private constructor(
          *
          * Here's an example of calling this function from Java code:
          *
-         * SAMPLE: org.kotools.types.number.IntegerJavaSample.of
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromLong
          * </details>
          */
         @JvmStatic
-        public fun of(value: Long): Integer {
+        public fun fromLong(value: Long): Integer {
             val delegate = PlatformInteger(value)
             return Integer(delegate)
         }
@@ -178,7 +178,7 @@ public class Integer private constructor(
          * </details>
          */
         @JvmStatic
-        public fun fromByte(value: Byte): Integer = of(value.toLong())
+        public fun fromByte(value: Byte): Integer = fromLong(value.toLong())
 
         /**
          * Returns an [Integer] representing the specified [value].
@@ -210,7 +210,7 @@ public class Integer private constructor(
          * </details>
          */
         @JvmStatic
-        public fun fromShort(value: Short): Integer = of(value.toLong())
+        public fun fromShort(value: Short): Integer = fromLong(value.toLong())
 
         /**
          * Returns an [Integer] representing the specified [value].
@@ -241,7 +241,7 @@ public class Integer private constructor(
          * </details>
          */
         @JvmStatic
-        public fun fromInt(value: Int): Integer = of(value.toLong())
+        public fun fromInt(value: Int): Integer = fromLong(value.toLong())
 
         /**
          * Returns an [Integer] representing the number described by [value],
@@ -614,7 +614,7 @@ public class Integer private constructor(
      * - [rem] or [remOrNull] for returning Euclidean remainder
      */
     public operator fun div(other: Integer): Integer =
-        if (other == of(0)) this.divisionByZeroError()
+        if (other == fromLong(0)) this.divisionByZeroError()
         else Integer(this.delegate / other.delegate)
 
     /**
@@ -645,7 +645,7 @@ public class Integer private constructor(
      */
     @JvmSynthetic
     public fun divOrNull(other: Integer): Integer? =
-        if (other == of(0)) null
+        if (other == fromLong(0)) null
         else Integer(this.delegate / other.delegate)
 
     /**
@@ -684,7 +684,7 @@ public class Integer private constructor(
      * - [div] or [divOrNull] for returning Euclidean quotient
      */
     public operator fun rem(other: Integer): Integer =
-        if (other == of(0)) this.divisionByZeroError()
+        if (other == fromLong(0)) this.divisionByZeroError()
         else Integer(this.delegate % other.delegate)
 
     /**
@@ -716,7 +716,7 @@ public class Integer private constructor(
      */
     @JvmSynthetic
     public fun remOrNull(other: Integer): Integer? =
-        if (other == of(0)) null
+        if (other == fromLong(0)) null
         else Integer(this.delegate % other.delegate)
 
     private fun divisionByZeroError(): Nothing {

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -787,7 +787,7 @@ public class Integer private constructor(
      * @since 5.2.0
      */
     public fun toByte(): Byte = this.toByteOrNull()
-        ?: this.outOfRangeError<Byte>()
+        ?: this.outOfRangeError("Byte")
 
     /**
      * Returns the [Byte] representation of this integer, or returns `null` if
@@ -855,7 +855,7 @@ public class Integer private constructor(
      * @since 5.2.0
      */
     public fun toShort(): Short = this.toShortOrNull()
-        ?: this.outOfRangeError<Short>()
+        ?: this.outOfRangeError("Short")
 
     /**
      * Returns the [Short] representation of this integer, or returns `null` if
@@ -923,7 +923,7 @@ public class Integer private constructor(
      *
      * @since 5.2.0
      */
-    public fun toInt(): Int = this.toIntOrNull() ?: this.outOfRangeError<Int>()
+    public fun toInt(): Int = this.toIntOrNull() ?: this.outOfRangeError("Int")
 
     /**
      * Returns the [Int] representation of this integer, or returns `null` if
@@ -991,7 +991,7 @@ public class Integer private constructor(
      * @since 5.2.0
      */
     public fun toLong(): Long = this.toLongOrNull()
-        ?: this.outOfRangeError<Long>()
+        ?: this.outOfRangeError("Long")
 
     /**
      * Returns the [Long] representation of this integer, or returns `null`
@@ -1021,8 +1021,7 @@ public class Integer private constructor(
     @JvmSynthetic
     public fun toLongOrNull(): Long? = this.delegate.toLongOrNull()
 
-    private inline fun <reified T : Number> outOfRangeError(): Nothing {
-        val type: String? = T::class.simpleName
+    private fun outOfRangeError(type: String): Nothing {
         val message: String =
             errorMessage("Integer out of range for $type", this)
         throw ArithmeticException(message)

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -751,8 +751,8 @@ public class Integer private constructor(
 
     /**
      * Returns the [Byte] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Byte] range
-     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
+     * [ArithmeticException] if this integer is out of the [Byte] range, i.e.,
+     * less than [Byte.MIN_VALUE] or greater than [Byte.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -786,9 +786,9 @@ public class Integer private constructor(
         ?: this.outOfRangeError<Byte>()
 
     /**
-     * Returns the [Byte] representation of this integer, or returns `null`
-     * if this integer is out of the [Byte] range
-     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
+     * Returns the [Byte] representation of this integer, or returns `null` if
+     * this integer is out of the [Byte] range, i.e., less than [Byte.MIN_VALUE]
+     * or greater than [Byte.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -819,8 +819,8 @@ public class Integer private constructor(
 
     /**
      * Returns the [Short] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Short] range
-     * (`Short.MIN_VALUE..Short.MAX_VALUE`).
+     * [ArithmeticException] if this integer is out of the [Short] range, i.e.,
+     * less than [Short.MIN_VALUE] or greater than [Short.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -854,9 +854,9 @@ public class Integer private constructor(
         ?: this.outOfRangeError<Short>()
 
     /**
-     * Returns the [Short] representation of this integer, or returns `null`
-     * if this integer is out of the [Short] range
-     * (`Short.MIN_VALUE..Short.MAX_VALUE`).
+     * Returns the [Short] representation of this integer, or returns `null` if
+     * this integer is out of the [Short] range, i.e., less than
+     * [Short.MIN_VALUE] or greater than [Short.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -888,8 +888,8 @@ public class Integer private constructor(
 
     /**
      * Returns the [Int] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Int] range
-     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
+     * [ArithmeticException] if this integer is out of the [Int] range, i.e.,
+     * less than [Int.MIN_VALUE] or greater than [Int.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -923,8 +923,8 @@ public class Integer private constructor(
 
     /**
      * Returns the [Int] representation of this integer, or returns `null` if
-     * this integer is out of the [Int] range
-     * (`Int.MIN_VALUE..Int.MAX_VALUE`).
+     * this integer is out of the [Int] range, i.e., less than [Int.MIN_VALUE]
+     * or greater than [Int.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -955,8 +955,8 @@ public class Integer private constructor(
 
     /**
      * Returns the [Long] representation of this integer, or throws an
-     * [ArithmeticException] if this integer is out of the [Long] range
-     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     * [ArithmeticException] if this integer is out of the [Long] range, i.e.,
+     * less than [Long.MIN_VALUE] or greater than [Long.MAX_VALUE].
      *
      * <br>
      * <details>
@@ -991,8 +991,8 @@ public class Integer private constructor(
 
     /**
      * Returns the [Long] representation of this integer, or returns `null`
-     * if this integer is out of the [Long] range
-     * (`Long.MIN_VALUE..Long.MAX_VALUE`).
+     * if this integer is out of the [Long] range, i.e., less than
+     * [Long.MIN_VALUE] or greater than [Long.MAX_VALUE].
      *
      * <br>
      * <details>

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -956,6 +956,41 @@ public class Integer private constructor(
         else null
     }
 
+    /**
+     * Returns the [Byte] representation of this integer, or throws an
+     * [ArithmeticException] if this integer is out of the [Byte] range
+     * (`Byte.MIN_VALUE..Byte.MAX_VALUE`).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toByte
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toByte
+     * </details>
+     */
+    public fun toByte(): Byte {
+        val range: LongRange =
+            Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()
+        val value: Long? = this.delegate.toLongOrNull()
+        return if (value != null && value in range) value.toByte()
+        else this.outOfRangeError("Byte")
+    }
+
     private fun outOfRangeError(targetType: String): Nothing {
         val message: String =
             errorMessage("Integer out of range for $targetType", this)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -128,6 +128,20 @@ internal fun Random.integerStringOutOfLongRange(): String {
     return "$sign$builder"
 }
 
+internal fun Random.integerStringOutOfIntRange(): String {
+    val sign: String = listOf("", "+", "-").random()
+    val length: Int = this.nextInt(11..18)
+    val builder = StringBuilder(length)
+
+    builder.append((1..9).random())
+    repeat(times = length - 1) {
+        val digit: Int = (0..9).random()
+        builder.append(digit)
+    }
+
+    return "$sign$builder"
+}
+
 internal fun Random.nonZeroIntegerStringWithLeadingZeros(): String {
     val prefix: String = this.zeroString()
     val suffix: String = this.positiveIntegerString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -156,6 +156,20 @@ internal fun Random.integerStringOutOfShortRange(): String {
     return "$sign$builder"
 }
 
+internal fun Random.integerStringOutOfByteRange(): String {
+    val sign: String = listOf("", "+", "-").random()
+    val length = 4
+    val builder = StringBuilder(length)
+
+    builder.append((1..9).random())
+    repeat(times = length - 1) {
+        val digit: Int = (0..9).random()
+        builder.append(digit)
+    }
+
+    return "$sign$builder"
+}
+
 internal fun Random.nonZeroIntegerStringWithLeadingZeros(): String {
     val prefix: String = this.zeroString()
     val suffix: String = this.positiveIntegerString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -114,6 +114,20 @@ internal fun Random.positiveIntegerString(): String {
     return "$sign$digits"
 }
 
+internal fun Random.integerStringOutOfLongRange(): String {
+    val sign: String = listOf("", "+", "-").random()
+    val length: Int = this.nextInt(20..64)
+    val builder = StringBuilder(length)
+
+    builder.append((1..9).random())
+    repeat(times = length - 1) {
+        val digit: Int = (0..9).random()
+        builder.append(digit)
+    }
+
+    return "$sign$builder"
+}
+
 internal fun Random.nonZeroIntegerStringWithLeadingZeros(): String {
     val prefix: String = this.zeroString()
     val suffix: String = this.positiveIntegerString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -142,6 +142,20 @@ internal fun Random.integerStringOutOfIntRange(): String {
     return "$sign$builder"
 }
 
+internal fun Random.integerStringOutOfShortRange(): String {
+    val sign: String = listOf("", "+", "-").random()
+    val length: Int = this.nextInt(6..9)
+    val builder = StringBuilder(length)
+
+    builder.append((1..9).random())
+    repeat(times = length - 1) {
+        val digit: Int = (0..9).random()
+        builder.append(digit)
+    }
+
+    return "$sign$builder"
+}
+
 internal fun Random.nonZeroIntegerStringWithLeadingZeros(): String {
     val prefix: String = this.zeroString()
     val suffix: String = this.positiveIntegerString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -74,7 +74,7 @@ internal fun Random.integer(): Integer {
 
     builder.append(sign)
     repeat(times = capacity - sign.length) {
-        val digit: Int = (0..9).random()
+        val digit: Int = this.nextInt(0..9)
         builder.append(digit)
     }
 
@@ -84,8 +84,45 @@ internal fun Random.integer(): Integer {
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 internal fun Random.integerExcept(illegal: Integer): Integer {
-    var candidate = this.integer()
+    var candidate: Integer = this.integer()
     while (candidate == illegal) candidate = this.integer()
+    return candidate
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.integerOutOfByteRange(): Integer {
+    val min: Integer = Integer.fromByte(Byte.MIN_VALUE)
+    val max: Integer = Integer.fromByte(Byte.MAX_VALUE)
+    return this.integerOutOfRange(min, max)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.integerOutOfShortRange(): Integer {
+    val min: Integer = Integer.fromShort(Short.MIN_VALUE)
+    val max: Integer = Integer.fromShort(Short.MAX_VALUE)
+    return this.integerOutOfRange(min, max)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.integerOutOfIntRange(): Integer {
+    val min: Integer = Integer.fromInt(Int.MIN_VALUE)
+    val max: Integer = Integer.fromInt(Int.MAX_VALUE)
+    return this.integerOutOfRange(min, max)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.integerOutOfLongRange(): Integer {
+    val min: Integer = Integer.fromLong(Long.MIN_VALUE)
+    val max: Integer = Integer.fromLong(Long.MAX_VALUE)
+    return this.integerOutOfRange(min, max)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+private fun Random.integerOutOfRange(min: Integer, max: Integer): Integer {
+    var candidate: Integer
+    do {
+        candidate = this.integer()
+    } while (candidate >= min && candidate <= max)
     return candidate
 }
 
@@ -112,62 +149,6 @@ internal fun Random.positiveIntegerString(): String {
     val sign: String = listOf("", "+").random()
     val digits: Long = this.nextLong(1..Long.MAX_VALUE)
     return "$sign$digits"
-}
-
-internal fun Random.integerStringOutOfLongRange(): String {
-    val sign: String = listOf("", "+", "-").random()
-    val length: Int = this.nextInt(20..64)
-    val builder = StringBuilder(length)
-
-    builder.append((1..9).random())
-    repeat(times = length - 1) {
-        val digit: Int = (0..9).random()
-        builder.append(digit)
-    }
-
-    return "$sign$builder"
-}
-
-internal fun Random.integerStringOutOfIntRange(): String {
-    val sign: String = listOf("", "+", "-").random()
-    val length: Int = this.nextInt(11..18)
-    val builder = StringBuilder(length)
-
-    builder.append((1..9).random())
-    repeat(times = length - 1) {
-        val digit: Int = (0..9).random()
-        builder.append(digit)
-    }
-
-    return "$sign$builder"
-}
-
-internal fun Random.integerStringOutOfShortRange(): String {
-    val sign: String = listOf("", "+", "-").random()
-    val length: Int = this.nextInt(6..9)
-    val builder = StringBuilder(length)
-
-    builder.append((1..9).random())
-    repeat(times = length - 1) {
-        val digit: Int = (0..9).random()
-        builder.append(digit)
-    }
-
-    return "$sign$builder"
-}
-
-internal fun Random.integerStringOutOfByteRange(): String {
-    val sign: String = listOf("", "+", "-").random()
-    val length = 4
-    val builder = StringBuilder(length)
-
-    builder.append((1..9).random())
-    repeat(times = length - 1) {
-        val digit: Int = (0..9).random()
-        builder.append(digit)
-    }
-
-    return "$sign$builder"
 }
 
 internal fun Random.nonZeroIntegerStringWithLeadingZeros(): String {

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -42,27 +42,7 @@ class IntegerSample {
         check(-7 % 2 == -1) // instead of 1
     }
 
-    // ------------------------------- Creations -------------------------------
-
-    @Test
-    fun fromLong() {
-        fun createsFromLong(input: Long, expected: String) {
-            val result: Integer = Integer.fromLong(input)
-            check("$result" == expected)
-        }
-
-        createsFromLong(input = 0, expected = "0")
-        createsFromLong(input = 42, expected = "42")
-        createsFromLong(input = -42, expected = "-42")
-        createsFromLong(
-            input = Long.MAX_VALUE,
-            expected = "9223372036854775807"
-        )
-        createsFromLong(
-            input = Long.MIN_VALUE,
-            expected = "-9223372036854775808"
-        )
-    }
+    // --------------------------- Factory functions ---------------------------
 
     @Test
     fun fromByte() {
@@ -104,6 +84,26 @@ class IntegerSample {
         createsFromInt(input = -42, expected = "-42")
         createsFromInt(input = Int.MAX_VALUE, expected = "2147483647")
         createsFromInt(input = Int.MIN_VALUE, expected = "-2147483648")
+    }
+
+    @Test
+    fun fromLong() {
+        fun createsFromLong(input: Long, expected: String) {
+            val result: Integer = Integer.fromLong(input)
+            check("$result" == expected)
+        }
+
+        createsFromLong(input = 0, expected = "0")
+        createsFromLong(input = 42, expected = "42")
+        createsFromLong(input = -42, expected = "-42")
+        createsFromLong(
+            input = Long.MAX_VALUE,
+            expected = "9223372036854775807"
+        )
+        createsFromLong(
+            input = Long.MIN_VALUE,
+            expected = "-9223372036854775808"
+        )
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -350,4 +350,14 @@ class IntegerSample {
             .exceptionOrNull()
         check(exception is ArithmeticException)
     }
+
+    @Test
+    fun toByteOrNull() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Byte? = x.toByteOrNull()
+        check(result == 42.toByte())
+
+        val y: Integer = Integer.parse("999")
+        check(y.toByteOrNull() == null)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -65,6 +65,20 @@ class IntegerSample {
     }
 
     @Test
+    fun fromByte() {
+        fun createsFromByte(input: Byte, expected: String) {
+            val result: Integer = Integer.fromByte(input)
+            check("$result" == expected)
+        }
+
+        createsFromByte(input = 0, expected = "0")
+        createsFromByte(input = 42, expected = "42")
+        createsFromByte(input = -42, expected = "-42")
+        createsFromByte(input = Byte.MAX_VALUE, expected = "127")
+        createsFromByte(input = Byte.MIN_VALUE, expected = "-128")
+    }
+
+    @Test
     fun parsing() {
         fun parsesTo(input: String, expected: String) {
             check(Integer.parse(input).toString() == expected)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -306,4 +306,14 @@ class IntegerSample {
             .exceptionOrNull()
         check(exception is ArithmeticException)
     }
+
+    @Test
+    fun toIntOrNull() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Int? = x.toIntOrNull()
+        check(result == 42)
+
+        val y: Integer = Integer.parse("9999999999")
+        check(y.toIntOrNull() == null)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -19,8 +19,8 @@ class IntegerSample {
 
     @Test
     fun overflowSolution() {
-        val x: Integer = Integer.of(9223372036854775807)
-        val y: Integer = Integer.of(10)
+        val x: Integer = Integer.fromLong(9223372036854775807)
+        val y: Integer = Integer.fromLong(10)
         check(x + y == Integer.parse("9223372036854775817"))
         check(-x - y == Integer.parse("-9223372036854775817"))
         check(x * y == Integer.parse("92233720368547758070"))
@@ -29,8 +29,8 @@ class IntegerSample {
     @Test
     fun divisionByZeroSolution() {
         // Common code
-        val x: Integer = Integer.of(12)
-        val y: Integer = Integer.of(0)
+        val x: Integer = Integer.fromLong(12)
+        val y: Integer = Integer.fromLong(0)
         val quotient: Result<Integer> = runCatching { x / y }
         val remainder: Result<Integer> = runCatching { x % y }
         check(quotient.exceptionOrNull() is ArithmeticException)
@@ -45,9 +45,9 @@ class IntegerSample {
     // ------------------------------- Creations -------------------------------
 
     @Test
-    fun of() {
+    fun fromLong() {
         fun createsFromLong(input: Long, expected: String) {
-            val result: Integer = Integer.of(input)
+            val result: Integer = Integer.fromLong(input)
             check("$result" == expected)
         }
 
@@ -163,13 +163,22 @@ class IntegerSample {
             check(integer.hashCode() != other.hashCode())
         }
 
-        checkEquality(integer = Integer.of(0), other = Integer.parse("-000"))
-        checkEquality(integer = Integer.of(42), other = Integer.parse("+00042"))
-        checkEquality(integer = Integer.of(-42), other = Integer.parse("-0042"))
+        checkEquality(
+            integer = Integer.fromLong(0),
+            other = Integer.parse("-000")
+        )
+        checkEquality(
+            integer = Integer.fromLong(42),
+            other = Integer.parse("+00042")
+        )
+        checkEquality(
+            integer = Integer.fromLong(-42),
+            other = Integer.parse("-0042")
+        )
 
-        checkDiff(integer = Integer.of(0), other = Integer.of(1))
-        checkDiff(integer = Integer.of(42), other = 42)
-        checkDiff(integer = Integer.of(-42), other = null)
+        checkDiff(integer = Integer.fromLong(0), other = Integer.fromLong(1))
+        checkDiff(integer = Integer.fromLong(42), other = 42)
+        checkDiff(integer = Integer.fromLong(-42), other = null)
     }
 
     @Test
@@ -219,29 +228,29 @@ class IntegerSample {
 
     @Test
     fun euclideanDivision() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        check(quotient == Integer.of(-4))
-        check(remainder == Integer.of(1))
+        check(quotient == Integer.fromLong(-4))
+        check(remainder == Integer.fromLong(1))
         check(x == quotient * y + remainder)
     }
 
     @Test
     fun euclideanDivisionOrNull() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(2)
 
         val quotient: Integer? = x.divOrNull(y)
         val remainder: Integer? = x.remOrNull(y)
 
         checkNotNull(quotient)
         checkNotNull(remainder)
-        check(quotient == Integer.of(-4))
-        check(remainder == Integer.of(1))
+        check(quotient == Integer.fromLong(-4))
+        check(remainder == Integer.fromLong(1))
         check(x == quotient * y + remainder)
     }
 
@@ -254,11 +263,11 @@ class IntegerSample {
             check(result == expected)
         }
 
-        checkToString(input = Integer.of(0), expected = "0")
+        checkToString(input = Integer.fromLong(0), expected = "0")
         checkToString(input = Integer.parse("+0"), expected = "0")
         checkToString(input = Integer.parse("-0"), expected = "0")
         checkToString(input = Integer.parse("+42"), expected = "42")
-        checkToString(input = Integer.of(-42), expected = "-42")
+        checkToString(input = Integer.fromLong(-42), expected = "-42")
         checkToString(input = Integer.parse("00042"), expected = "42")
         checkToString(input = Integer.parse("+00042"), expected = "42")
         checkToString(input = Integer.parse("-00042"), expected = "-42")

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -294,4 +294,16 @@ class IntegerSample {
         val y: Integer = Integer.parse("99999999999999999999")
         check(y.toLongOrNull() == null)
     }
+
+    @Test
+    fun toInt() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Int = x.toInt()
+        check(result == 42)
+
+        val y: Integer = Integer.parse("9999999999")
+        val exception: Throwable? = runCatching { y.toInt() }
+            .exceptionOrNull()
+        check(exception is ArithmeticException)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -79,6 +79,20 @@ class IntegerSample {
     }
 
     @Test
+    fun fromShort() {
+        fun createsFromShort(input: Short, expected: String) {
+            val result: Integer = Integer.fromShort(input)
+            check("$result" == expected)
+        }
+
+        createsFromShort(input = 0, expected = "0")
+        createsFromShort(input = 42, expected = "42")
+        createsFromShort(input = -42, expected = "-42")
+        createsFromShort(input = Short.MAX_VALUE, expected = "32767")
+        createsFromShort(input = Short.MIN_VALUE, expected = "-32768")
+    }
+
+    @Test
     fun parsing() {
         fun parsesTo(input: String, expected: String) {
             check(Integer.parse(input).toString() == expected)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -328,4 +328,14 @@ class IntegerSample {
             .exceptionOrNull()
         check(exception is ArithmeticException)
     }
+
+    @Test
+    fun toShortOrNull() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Short? = x.toShortOrNull()
+        check(result == 42.toShort())
+
+        val y: Integer = Integer.parse("99999")
+        check(y.toShortOrNull() == null)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -316,4 +316,16 @@ class IntegerSample {
         val y: Integer = Integer.parse("9999999999")
         check(y.toIntOrNull() == null)
     }
+
+    @Test
+    fun toShort() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Short = x.toShort()
+        check(result == 42.toShort())
+
+        val y: Integer = Integer.parse("99999")
+        val exception: Throwable? = runCatching { y.toShort() }
+            .exceptionOrNull()
+        check(exception is ArithmeticException)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -338,4 +338,16 @@ class IntegerSample {
         val y: Integer = Integer.parse("99999")
         check(y.toShortOrNull() == null)
     }
+
+    @Test
+    fun toByte() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Byte = x.toByte()
+        check(result == 42.toByte())
+
+        val y: Integer = Integer.parse("999")
+        val exception: Throwable? = runCatching { y.toByte() }
+            .exceptionOrNull()
+        check(exception is ArithmeticException)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -93,6 +93,20 @@ class IntegerSample {
     }
 
     @Test
+    fun fromInt() {
+        fun createsFromInt(input: Int, expected: String) {
+            val result: Integer = Integer.fromInt(input)
+            check("$result" == expected)
+        }
+
+        createsFromInt(input = 0, expected = "0")
+        createsFromInt(input = 42, expected = "42")
+        createsFromInt(input = -42, expected = "-42")
+        createsFromInt(input = Int.MAX_VALUE, expected = "2147483647")
+        createsFromInt(input = Int.MIN_VALUE, expected = "-2147483648")
+    }
+
+    @Test
     fun parsing() {
         fun parsesTo(input: String, expected: String) {
             check(Integer.parse(input).toString() == expected)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -257,64 +257,25 @@ class IntegerSample {
     // ------------------------------ Conversions ------------------------------
 
     @Test
-    fun toStringOverride() {
-        fun checkToString(input: Integer, expected: String) {
-            val result: String = input.toString()
-            check(result == expected)
-        }
-
-        checkToString(input = Integer.fromLong(0), expected = "0")
-        checkToString(input = Integer.parse("+0"), expected = "0")
-        checkToString(input = Integer.parse("-0"), expected = "0")
-        checkToString(input = Integer.parse("+42"), expected = "42")
-        checkToString(input = Integer.fromLong(-42), expected = "-42")
-        checkToString(input = Integer.parse("00042"), expected = "42")
-        checkToString(input = Integer.parse("+00042"), expected = "42")
-        checkToString(input = Integer.parse("-00042"), expected = "-42")
-    }
-
-    @Test
-    fun toLong() {
+    fun toByte() {
         val x: Integer = Integer.fromLong(42)
-        val result: Long = x.toLong()
-        check(result == 42L)
+        val result: Byte = x.toByte()
+        check(result == 42.toByte())
 
-        val y: Integer = Integer.parse("99999999999999999999")
-        val exception: Throwable? = runCatching { y.toLong() }
+        val y: Integer = Integer.parse("999")
+        val exception: Throwable? = runCatching { y.toByte() }
             .exceptionOrNull()
         check(exception is ArithmeticException)
     }
 
     @Test
-    fun toLongOrNull() {
+    fun toByteOrNull() {
         val x: Integer = Integer.fromLong(42)
-        val result: Long? = x.toLongOrNull()
-        check(result == 42L)
+        val result: Byte? = x.toByteOrNull()
+        check(result == 42.toByte())
 
-        val y: Integer = Integer.parse("99999999999999999999")
-        check(y.toLongOrNull() == null)
-    }
-
-    @Test
-    fun toInt() {
-        val x: Integer = Integer.fromLong(42)
-        val result: Int = x.toInt()
-        check(result == 42)
-
-        val y: Integer = Integer.parse("9999999999")
-        val exception: Throwable? = runCatching { y.toInt() }
-            .exceptionOrNull()
-        check(exception is ArithmeticException)
-    }
-
-    @Test
-    fun toIntOrNull() {
-        val x: Integer = Integer.fromLong(42)
-        val result: Int? = x.toIntOrNull()
-        check(result == 42)
-
-        val y: Integer = Integer.parse("9999999999")
-        check(y.toIntOrNull() == null)
+        val y: Integer = Integer.parse("999")
+        check(y.toByteOrNull() == null)
     }
 
     @Test
@@ -340,24 +301,63 @@ class IntegerSample {
     }
 
     @Test
-    fun toByte() {
+    fun toInt() {
         val x: Integer = Integer.fromLong(42)
-        val result: Byte = x.toByte()
-        check(result == 42.toByte())
+        val result: Int = x.toInt()
+        check(result == 42)
 
-        val y: Integer = Integer.parse("999")
-        val exception: Throwable? = runCatching { y.toByte() }
+        val y: Integer = Integer.parse("9999999999")
+        val exception: Throwable? = runCatching { y.toInt() }
             .exceptionOrNull()
         check(exception is ArithmeticException)
     }
 
     @Test
-    fun toByteOrNull() {
+    fun toIntOrNull() {
         val x: Integer = Integer.fromLong(42)
-        val result: Byte? = x.toByteOrNull()
-        check(result == 42.toByte())
+        val result: Int? = x.toIntOrNull()
+        check(result == 42)
 
-        val y: Integer = Integer.parse("999")
-        check(y.toByteOrNull() == null)
+        val y: Integer = Integer.parse("9999999999")
+        check(y.toIntOrNull() == null)
+    }
+
+    @Test
+    fun toLong() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Long = x.toLong()
+        check(result == 42L)
+
+        val y: Integer = Integer.parse("99999999999999999999")
+        val exception: Throwable? = runCatching { y.toLong() }
+            .exceptionOrNull()
+        check(exception is ArithmeticException)
+    }
+
+    @Test
+    fun toLongOrNull() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Long? = x.toLongOrNull()
+        check(result == 42L)
+
+        val y: Integer = Integer.parse("99999999999999999999")
+        check(y.toLongOrNull() == null)
+    }
+
+    @Test
+    fun toStringOverride() {
+        fun checkToString(input: Integer, expected: String) {
+            val result: String = input.toString()
+            check(result == expected)
+        }
+
+        checkToString(input = Integer.fromLong(0), expected = "0")
+        checkToString(input = Integer.parse("+0"), expected = "0")
+        checkToString(input = Integer.parse("-0"), expected = "0")
+        checkToString(input = Integer.parse("+42"), expected = "42")
+        checkToString(input = Integer.fromLong(-42), expected = "-42")
+        checkToString(input = Integer.parse("00042"), expected = "42")
+        checkToString(input = Integer.parse("+00042"), expected = "42")
+        checkToString(input = Integer.parse("-00042"), expected = "-42")
     }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -284,4 +284,14 @@ class IntegerSample {
             .exceptionOrNull()
         check(exception is ArithmeticException)
     }
+
+    @Test
+    fun toLongOrNull() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Long? = x.toLongOrNull()
+        check(result == 42L)
+
+        val y: Integer = Integer.parse("99999999999999999999")
+        check(y.toLongOrNull() == null)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -272,4 +272,16 @@ class IntegerSample {
         checkToString(input = Integer.parse("+00042"), expected = "42")
         checkToString(input = Integer.parse("-00042"), expected = "-42")
     }
+
+    @Test
+    fun toLong() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Long = x.toLong()
+        check(result == 42L)
+
+        val y: Integer = Integer.parse("99999999999999999999")
+        val exception: Throwable? = runCatching { y.toLong() }
+            .exceptionOrNull()
+        check(exception is ArithmeticException)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -1088,4 +1088,31 @@ class IntegerTest {
 
         assertNull(actual, message = "Input: $value")
     }
+
+    @Test
+    fun toBytePreservesByteRepresentation(): Unit = repeatTest {
+        val range: IntRange = Byte.MIN_VALUE.toInt()..Byte.MAX_VALUE.toInt()
+        val value: Byte = Random.nextInt(range)
+            .toByte()
+        val integer: Integer = Integer.fromByte(value)
+
+        val actual: Byte = integer.toByte()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toByteFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfByteRange()
+        val integer: Integer = Integer.parse(value)
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toByte()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Byte", integer)
+        val message = "Input: $value"
+        assertEquals(expected, actual = exception.message, message)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -949,4 +949,29 @@ class IntegerTest {
 
         assertEquals(expected = x, actual, message = "Input: $x")
     }
+
+    @Test
+    fun toLongPreservesLongRepresentation(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+        val integer: Integer = Integer.fromLong(value)
+
+        val actual: Long = integer.toLong()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toLongFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfLongRange()
+        val integer: Integer = Integer.parse(value)
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toLong()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Long", integer)
+        val message = "Input: $value"
+        assertEquals(expected, actual = exception.message, message)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -27,18 +27,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class IntegerTest {
-    // ------------------------------- Creations -------------------------------
-
-    @Test
-    fun fromLongPreservesLongRepresentation(): Unit = repeatTest {
-        val value: Long = Random.nextLong()
-
-        val integer: Integer = Integer.fromLong(value)
-
-        val actual: String = integer.toString()
-        val expected: String = value.toString()
-        assertEquals(expected, actual, message = "Input: $value")
-    }
+    // --------------------------- Factory functions ---------------------------
 
     @Test
     fun fromBytePreservesByteRepresentation(): Unit = repeatTest {
@@ -55,7 +44,7 @@ class IntegerTest {
 
     @Test
     fun fromShortPreservesShortRepresentation(): Unit = repeatTest {
-        val range: IntRange = Short.MIN_VALUE.toInt()..Short.MAX_VALUE.toInt()
+        val range: IntRange = Short.MIN_VALUE..Short.MAX_VALUE
         val value: Short = Random.nextInt(range)
             .toShort()
 
@@ -71,6 +60,17 @@ class IntegerTest {
         val value: Int = Random.nextInt()
 
         val integer: Integer = Integer.fromInt(value)
+
+        val actual: String = integer.toString()
+        val expected: String = value.toString()
+        assertEquals(expected, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun fromLongPreservesLongRepresentation(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+
+        val integer: Integer = Integer.fromLong(value)
 
         val actual: String = integer.toString()
         val expected: String = value.toString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -25,10 +25,10 @@ class IntegerTest {
     // ------------------------------- Creations -------------------------------
 
     @Test
-    fun ofPreservesLongRepresentation(): Unit = repeatTest {
+    fun fromLongPreservesLongRepresentation(): Unit = repeatTest {
         val value: Long = Random.nextLong()
 
-        val integer: Integer = Integer.of(value)
+        val integer: Integer = Integer.fromLong(value)
 
         val actual: String = integer.toString()
         val expected: String = value.toString()
@@ -79,7 +79,7 @@ class IntegerTest {
         val integer: Integer = Integer.parse(value)
         val safeInteger: Integer? = Integer.parseOrNull(value)
 
-        val expected: Integer = Integer.of(0)
+        val expected: Integer = Integer.fromLong(0)
         val message = "Input: \"$value\""
         assertEquals(expected, actual = integer, message)
         assertEquals(expected, actual = safeInteger, message)
@@ -330,7 +330,7 @@ class IntegerTest {
     @Test
     fun unaryMinusIsAdditiveInverse(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val actual: Integer = x + (-x)
 
@@ -350,7 +350,7 @@ class IntegerTest {
 
     @Test
     fun unaryMinusInversesSign(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val x: Integer = Random.integerExcept(illegal = zero)
 
         val xSign: Int = x.compareTo(zero)
@@ -365,7 +365,7 @@ class IntegerTest {
 
     @Test
     fun unaryMinusOnZero() {
-        val x: Integer = Integer.of(0)
+        val x: Integer = Integer.fromLong(0)
         val actual: Integer = -x
         assertEquals(x, actual)
     }
@@ -397,7 +397,7 @@ class IntegerTest {
     @Test
     fun plusHasZeroAsIdentityElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Input: $x"
         assertEquals(x, x + zero, message)
         assertEquals(x, zero + x, message)
@@ -433,7 +433,7 @@ class IntegerTest {
     fun plusHasUniqueInverseElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
         val y: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val actual: Boolean = x == -y
 
@@ -479,7 +479,7 @@ class IntegerTest {
     @Test
     fun minusHasZeroAsRightIdentityElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Input: $x"
         assertEquals(x, x - zero, message)
     }
@@ -487,7 +487,7 @@ class IntegerTest {
     @Test
     fun minusOfSameIntegersIsZero(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Input: $x"
         assertEquals(zero, x - x, message)
     }
@@ -549,7 +549,7 @@ class IntegerTest {
     @Test
     fun timesHasOneAsIdentityElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
         val message = "Input: $x"
         assertEquals(x, x * one, message)
         assertEquals(x, one * x, message)
@@ -571,7 +571,7 @@ class IntegerTest {
     @Test
     fun timesHasZeroAsAbsorbingElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val message = "Input: $x"
         assertEquals(zero, x * zero, message)
@@ -620,7 +620,7 @@ class IntegerTest {
     fun timesSatisfiesCancellation(): Unit = repeatTest {
         val x: Integer = Random.integer()
         val y: Integer = Random.integer()
-        val z: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val z: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Boolean = x * z == y * z
 
@@ -664,7 +664,7 @@ class IntegerTest {
     @Test
     fun divSanityCheck() {
         val x: Integer = Integer.parse("922337203685477580700")
-        val y: Integer = Integer.of(10)
+        val y: Integer = Integer.fromLong(10)
 
         val actual: Integer = x / y
 
@@ -675,7 +675,7 @@ class IntegerTest {
     @Test
     fun divHasRightIdentity(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
 
         val actual: Integer = x / one
 
@@ -684,7 +684,7 @@ class IntegerTest {
 
     @Test
     fun divHasAbsorbingZeroDividend(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val other: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer = zero / other
@@ -694,18 +694,18 @@ class IntegerTest {
 
     @Test
     fun divOfSameIntegerIsOne(): Unit = repeatTest {
-        val x: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val x: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer = x / x
 
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
         assertEquals(expected = one, actual, message = "Input: $x")
     }
 
     @Test
     fun divSatisfiesDivisionAlgorithm(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
@@ -716,44 +716,44 @@ class IntegerTest {
 
     @Test
     fun divAndRemSanityCheckWithNegativeDividend() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        assertEquals(expected = Integer.of(-4), actual = quotient)
-        assertEquals(expected = Integer.of(1), actual = remainder)
+        assertEquals(expected = Integer.fromLong(-4), actual = quotient)
+        assertEquals(expected = Integer.fromLong(1), actual = remainder)
     }
 
     @Test
     fun divAndRemSanityCheckWithNegativeDivisor() {
-        val x: Integer = Integer.of(7)
-        val y: Integer = Integer.of(-2)
+        val x: Integer = Integer.fromLong(7)
+        val y: Integer = Integer.fromLong(-2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        assertEquals(expected = Integer.of(-3), actual = quotient)
-        assertEquals(expected = Integer.of(1), actual = remainder)
+        assertEquals(expected = Integer.fromLong(-3), actual = quotient)
+        assertEquals(expected = Integer.fromLong(1), actual = remainder)
     }
 
     @Test
     fun divAndRemSanityCheckWithNegativeOperands() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(-2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(-2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        assertEquals(expected = Integer.of(4), actual = quotient)
-        assertEquals(expected = Integer.of(1), actual = remainder)
+        assertEquals(expected = Integer.fromLong(4), actual = quotient)
+        assertEquals(expected = Integer.fromLong(1), actual = remainder)
     }
 
     @Test
     fun divIsConsistentWithTimes(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer = (x * y) / y
 
@@ -763,7 +763,7 @@ class IntegerTest {
     @Test
     fun divByZeroThrowsException(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val exception: ArithmeticException = assertFailsWith { x / zero }
 
@@ -775,7 +775,7 @@ class IntegerTest {
     @Test
     fun divOrNullSanityCheck() {
         val x: Integer = Integer.parse("922337203685477580700")
-        val y: Integer = Integer.of(10)
+        val y: Integer = Integer.fromLong(10)
 
         val actual: Integer? = x.divOrNull(y)
 
@@ -786,7 +786,7 @@ class IntegerTest {
     @Test
     fun divOrNullHasRightIdentity(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
 
         val actual: Integer? = x.divOrNull(one)
 
@@ -795,7 +795,7 @@ class IntegerTest {
 
     @Test
     fun divOrNullHasAbsorbingZeroDividend(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val other: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer? = zero.divOrNull(other)
@@ -806,7 +806,7 @@ class IntegerTest {
     @Test
     fun divOrNullIsConsistentWithDiv(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer? = x.divOrNull(y)
 
@@ -817,7 +817,7 @@ class IntegerTest {
     @Test
     fun divOrNullWithZero(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Integer.of(0)
+        val y: Integer = Integer.fromLong(0)
 
         val actual: Integer? = x.divOrNull(y)
 
@@ -826,18 +826,18 @@ class IntegerTest {
 
     @Test
     fun remSanityCheck() {
-        val x: Integer = Integer.of(42)
-        val y: Integer = Integer.of(5)
+        val x: Integer = Integer.fromLong(42)
+        val y: Integer = Integer.fromLong(5)
 
         val actual: Integer = x % y
 
-        val expected: Integer = Integer.of(2)
+        val expected: Integer = Integer.fromLong(2)
         assertEquals(expected, actual)
     }
 
     @Test
     fun remByItselfIsZero(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val x: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer = x % x
@@ -848,7 +848,7 @@ class IntegerTest {
     @Test
     fun remHasZeroForDivisibleIntegers(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val y: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer = (x * y) % y
@@ -860,7 +860,7 @@ class IntegerTest {
     @Test
     fun remIsAlwaysNonNegative(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val y: Integer = Random.integerExcept(illegal = zero)
 
         val remainder: Integer = x % y
@@ -871,7 +871,7 @@ class IntegerTest {
     @Test
     fun remIsBoundedByAbsoluteValueOfDivisor(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val y: Integer = Random.integerExcept(illegal = zero)
 
         val remainder: Integer = x % y
@@ -883,7 +883,7 @@ class IntegerTest {
     @Test
     fun remByZeroThrowsException(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Integer.of(0)
+        val y: Integer = Integer.fromLong(0)
 
         val exception: ArithmeticException = assertFailsWith { x % y }
 
@@ -894,19 +894,19 @@ class IntegerTest {
 
     @Test
     fun remOrNullSanityCheck() {
-        val x: Integer = Integer.of(42)
-        val y: Integer = Integer.of(5)
+        val x: Integer = Integer.fromLong(42)
+        val y: Integer = Integer.fromLong(5)
 
         val actual: Integer? = x.remOrNull(y)
 
-        val expected: Integer = Integer.of(2)
+        val expected: Integer = Integer.fromLong(2)
         assertEquals(expected, actual)
     }
 
     @Test
     fun remOrNullIsConsistentWithRem(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer? = x.remOrNull(y)
 
@@ -917,7 +917,7 @@ class IntegerTest {
     @Test
     fun remOrNullWithZeroReturnsNull(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Integer.of(0)
+        val y: Integer = Integer.fromLong(0)
 
         val actual: Integer? = x.remOrNull(y)
 
@@ -935,7 +935,7 @@ class IntegerTest {
         assertTrue("\"$actual\" must not have leading plus sign (+).") {
             !actual.startsWith('+')
         }
-        if (integer == Integer.of(0)) assertEquals(expected = "0", actual)
+        if (integer == Integer.fromLong(0)) assertEquals(expected = "0", actual)
         else assertTrue("\"$actual\" must not have leading zeros.") {
             actual.first(Char::isDigit) != '0'
         }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -62,6 +62,17 @@ class IntegerTest {
     }
 
     @Test
+    fun fromIntPreservesIntRepresentation(): Unit = repeatTest {
+        val value: Int = Random.nextInt()
+
+        val integer: Integer = Integer.fromInt(value)
+
+        val actual: String = integer.toString()
+        val expected: String = value.toString()
+        assertEquals(expected, actual, message = "Input: $value")
+    }
+
+    @Test
     fun parsingNormalizesZero(): Unit = repeatTest {
         val value: String = Random.zeroString()
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -36,6 +36,19 @@ class IntegerTest {
     }
 
     @Test
+    fun fromBytePreservesByteRepresentation(): Unit = repeatTest {
+        val range: IntRange = Byte.MIN_VALUE.toInt()..Byte.MAX_VALUE.toInt()
+        val value: Byte = Random.nextInt(range)
+            .toByte()
+
+        val integer: Integer = Integer.fromByte(value)
+
+        val actual: String = integer.toString()
+        val expected: String = value.toString()
+        assertEquals(expected, actual, message = "Input: $value")
+    }
+
+    @Test
     fun parsingNormalizesZero(): Unit = repeatTest {
         val value: String = Random.zeroString()
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -1039,4 +1039,31 @@ class IntegerTest {
 
         assertNull(actual, message = "Input: $value")
     }
+
+    @Test
+    fun toShortPreservesShortRepresentation(): Unit = repeatTest {
+        val range: IntRange = Short.MIN_VALUE.toInt()..Short.MAX_VALUE.toInt()
+        val value: Short = Random.nextInt(range)
+            .toShort()
+        val integer: Integer = Integer.fromShort(value)
+
+        val actual: Short = integer.toShort()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toShortFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfShortRange()
+        val integer: Integer = Integer.parse(value)
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toShort()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Short", integer)
+        val message = "Input: $value"
+        assertEquals(expected, actual = exception.message, message)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -994,4 +994,29 @@ class IntegerTest {
 
         assertNull(actual, message = "Input: $value")
     }
+
+    @Test
+    fun toIntPreservesIntRepresentation(): Unit = repeatTest {
+        val value: Int = Random.nextInt()
+        val integer: Integer = Integer.fromInt(value)
+
+        val actual: Int = integer.toInt()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toIntFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfIntRange()
+        val integer: Integer = Integer.parse(value)
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toInt()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Int", integer)
+        val message = "Input: $value"
+        assertEquals(expected, actual = exception.message, message)
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -1019,4 +1019,24 @@ class IntegerTest {
         val message = "Input: $value"
         assertEquals(expected, actual = exception.message, message)
     }
+
+    @Test
+    fun toIntOrNullPreservesIntRepresentation(): Unit = repeatTest {
+        val value: Int = Random.nextInt()
+        val integer: Integer = Integer.fromInt(value)
+
+        val actual: Int? = integer.toIntOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toIntOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfIntRange()
+        val integer: Integer = Integer.parse(value)
+
+        val actual: Int? = integer.toIntOrNull()
+
+        assertNull(actual, message = "Input: $value")
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -3,10 +3,10 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.integer
 import org.kotools.types.integerExcept
-import org.kotools.types.integerStringOutOfByteRange
-import org.kotools.types.integerStringOutOfIntRange
-import org.kotools.types.integerStringOutOfLongRange
-import org.kotools.types.integerStringOutOfShortRange
+import org.kotools.types.integerOutOfByteRange
+import org.kotools.types.integerOutOfIntRange
+import org.kotools.types.integerOutOfLongRange
+import org.kotools.types.integerOutOfShortRange
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.nonIntegerString
 import org.kotools.types.nonZeroIntegerStringWithLeadingZeros
@@ -932,6 +932,180 @@ class IntegerTest {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    fun toBytePreservesByteRepresentation(): Unit = repeatTest {
+        val value: Byte = Random.nextInt(Byte.MIN_VALUE..Byte.MAX_VALUE)
+            .toByte()
+        val integer: Integer = Integer.fromByte(value)
+
+        val actual: Byte = integer.toByte()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toByteFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfByteRange()
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toByte()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Byte", integer)
+        val message = "Input: $integer"
+        assertEquals(expected, actual = exception.message, message)
+    }
+
+    @Test
+    fun toByteOrNullPreservesByteRepresentation(): Unit = repeatTest {
+        val value: Byte = Random.nextInt(Byte.MIN_VALUE..Byte.MAX_VALUE)
+            .toByte()
+        val integer: Integer = Integer.fromByte(value)
+
+        val actual: Byte? = integer.toByteOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toByteOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfByteRange()
+
+        val actual: Byte? = integer.toByteOrNull()
+
+        assertNull(actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toShortPreservesShortRepresentation(): Unit = repeatTest {
+        val value: Short = Random.nextInt(Short.MIN_VALUE..Short.MAX_VALUE)
+            .toShort()
+        val integer: Integer = Integer.fromShort(value)
+
+        val actual: Short = integer.toShort()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toShortFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfShortRange()
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toShort()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Short", integer)
+        val message = "Input: $integer"
+        assertEquals(expected, actual = exception.message, message)
+    }
+
+    @Test
+    fun toShortOrNullPreservesShortRepresentation(): Unit = repeatTest {
+        val value: Short = Random.nextInt(Short.MIN_VALUE..Short.MAX_VALUE)
+            .toShort()
+        val integer: Integer = Integer.fromShort(value)
+
+        val actual: Short? = integer.toShortOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toShortOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfShortRange()
+
+        val actual: Short? = integer.toShortOrNull()
+
+        assertNull(actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toIntPreservesIntRepresentation(): Unit = repeatTest {
+        val value: Int = Random.nextInt()
+        val integer: Integer = Integer.fromInt(value)
+
+        val actual: Int = integer.toInt()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toIntFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfIntRange()
+
+        val exception: ArithmeticException = assertFailsWith { integer.toInt() }
+
+        val expected: String =
+            errorMessage("Integer out of range for Int", integer)
+        val message = "Input: $integer"
+        assertEquals(expected, actual = exception.message, message)
+    }
+
+    @Test
+    fun toIntOrNullPreservesIntRepresentation(): Unit = repeatTest {
+        val value: Int = Random.nextInt()
+        val integer: Integer = Integer.fromInt(value)
+
+        val actual: Int? = integer.toIntOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toIntOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfIntRange()
+
+        val actual: Int? = integer.toIntOrNull()
+
+        assertNull(actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toLongPreservesLongRepresentation(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+        val integer: Integer = Integer.fromLong(value)
+
+        val actual: Long = integer.toLong()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toLongFailsWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfLongRange()
+
+        val exception: ArithmeticException = assertFailsWith {
+            integer.toLong()
+        }
+
+        val expected: String =
+            errorMessage("Integer out of range for Long", integer)
+        val message = "Input: $integer"
+        assertEquals(expected, actual = exception.message, message)
+    }
+
+    @Test
+    fun toLongOrNullPreservesLongRepresentation(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+        val integer: Integer = Integer.fromLong(value)
+
+        val actual: Long? = integer.toLongOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $integer")
+    }
+
+    @Test
+    fun toLongOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerOutOfLongRange()
+
+        val actual: Long? = integer.toLongOrNull()
+
+        assertNull(actual, message = "Input: $integer")
+    }
+
+    @Test
     fun toStringReturnsCanonicalDecimalString(): Unit = repeatTest {
         val integer: Integer = Random.integer()
 
@@ -953,193 +1127,5 @@ class IntegerTest {
         val actual: Integer = Integer.parse(x.toString())
 
         assertEquals(expected = x, actual, message = "Input: $x")
-    }
-
-    @Test
-    fun toLongPreservesLongRepresentation(): Unit = repeatTest {
-        val value: Long = Random.nextLong()
-        val integer: Integer = Integer.fromLong(value)
-
-        val actual: Long = integer.toLong()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toLongFailsWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfLongRange()
-        val integer: Integer = Integer.parse(value)
-
-        val exception: ArithmeticException = assertFailsWith {
-            integer.toLong()
-        }
-
-        val expected: String =
-            errorMessage("Integer out of range for Long", integer)
-        val message = "Input: $value"
-        assertEquals(expected, actual = exception.message, message)
-    }
-
-    @Test
-    fun toLongOrNullPreservesLongRepresentation(): Unit = repeatTest {
-        val value: Long = Random.nextLong()
-        val integer: Integer = Integer.fromLong(value)
-
-        val actual: Long? = integer.toLongOrNull()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toLongOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfLongRange()
-        val integer: Integer = Integer.parse(value)
-
-        val actual: Long? = integer.toLongOrNull()
-
-        assertNull(actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toIntPreservesIntRepresentation(): Unit = repeatTest {
-        val value: Int = Random.nextInt()
-        val integer: Integer = Integer.fromInt(value)
-
-        val actual: Int = integer.toInt()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toIntFailsWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfIntRange()
-        val integer: Integer = Integer.parse(value)
-
-        val exception: ArithmeticException = assertFailsWith {
-            integer.toInt()
-        }
-
-        val expected: String =
-            errorMessage("Integer out of range for Int", integer)
-        val message = "Input: $value"
-        assertEquals(expected, actual = exception.message, message)
-    }
-
-    @Test
-    fun toIntOrNullPreservesIntRepresentation(): Unit = repeatTest {
-        val value: Int = Random.nextInt()
-        val integer: Integer = Integer.fromInt(value)
-
-        val actual: Int? = integer.toIntOrNull()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toIntOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfIntRange()
-        val integer: Integer = Integer.parse(value)
-
-        val actual: Int? = integer.toIntOrNull()
-
-        assertNull(actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toShortPreservesShortRepresentation(): Unit = repeatTest {
-        val range: IntRange = Short.MIN_VALUE.toInt()..Short.MAX_VALUE.toInt()
-        val value: Short = Random.nextInt(range)
-            .toShort()
-        val integer: Integer = Integer.fromShort(value)
-
-        val actual: Short = integer.toShort()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toShortFailsWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfShortRange()
-        val integer: Integer = Integer.parse(value)
-
-        val exception: ArithmeticException = assertFailsWith {
-            integer.toShort()
-        }
-
-        val expected: String =
-            errorMessage("Integer out of range for Short", integer)
-        val message = "Input: $value"
-        assertEquals(expected, actual = exception.message, message)
-    }
-
-    @Test
-    fun toShortOrNullPreservesShortRepresentation(): Unit = repeatTest {
-        val range: IntRange = Short.MIN_VALUE.toInt()..Short.MAX_VALUE.toInt()
-        val value: Short = Random.nextInt(range)
-            .toShort()
-        val integer: Integer = Integer.fromShort(value)
-
-        val actual: Short? = integer.toShortOrNull()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toShortOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfShortRange()
-        val integer: Integer = Integer.parse(value)
-
-        val actual: Short? = integer.toShortOrNull()
-
-        assertNull(actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toBytePreservesByteRepresentation(): Unit = repeatTest {
-        val range: IntRange = Byte.MIN_VALUE.toInt()..Byte.MAX_VALUE.toInt()
-        val value: Byte = Random.nextInt(range)
-            .toByte()
-        val integer: Integer = Integer.fromByte(value)
-
-        val actual: Byte = integer.toByte()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toByteFailsWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfByteRange()
-        val integer: Integer = Integer.parse(value)
-
-        val exception: ArithmeticException = assertFailsWith {
-            integer.toByte()
-        }
-
-        val expected: String =
-            errorMessage("Integer out of range for Byte", integer)
-        val message = "Input: $value"
-        assertEquals(expected, actual = exception.message, message)
-    }
-
-    @Test
-    fun toByteOrNullPreservesByteRepresentation(): Unit = repeatTest {
-        val range: IntRange = Byte.MIN_VALUE.toInt()..Byte.MAX_VALUE.toInt()
-        val value: Byte = Random.nextInt(range)
-            .toByte()
-        val integer: Integer = Integer.fromByte(value)
-
-        val actual: Byte? = integer.toByteOrNull()
-
-        assertEquals(expected = value, actual, message = "Input: $value")
-    }
-
-    @Test
-    fun toByteOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
-        val value: String = Random.integerStringOutOfByteRange()
-        val integer: Integer = Integer.parse(value)
-
-        val actual: Byte? = integer.toByteOrNull()
-
-        assertNull(actual, message = "Input: $value")
     }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -1066,4 +1066,26 @@ class IntegerTest {
         val message = "Input: $value"
         assertEquals(expected, actual = exception.message, message)
     }
+
+    @Test
+    fun toShortOrNullPreservesShortRepresentation(): Unit = repeatTest {
+        val range: IntRange = Short.MIN_VALUE.toInt()..Short.MAX_VALUE.toInt()
+        val value: Short = Random.nextInt(range)
+            .toShort()
+        val integer: Integer = Integer.fromShort(value)
+
+        val actual: Short? = integer.toShortOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toShortOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfShortRange()
+        val integer: Integer = Integer.parse(value)
+
+        val actual: Short? = integer.toShortOrNull()
+
+        assertNull(actual, message = "Input: $value")
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -1115,4 +1115,26 @@ class IntegerTest {
         val message = "Input: $value"
         assertEquals(expected, actual = exception.message, message)
     }
+
+    @Test
+    fun toByteOrNullPreservesByteRepresentation(): Unit = repeatTest {
+        val range: IntRange = Byte.MIN_VALUE.toInt()..Byte.MAX_VALUE.toInt()
+        val value: Byte = Random.nextInt(range)
+            .toByte()
+        val integer: Integer = Integer.fromByte(value)
+
+        val actual: Byte? = integer.toByteOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toByteOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfByteRange()
+        val integer: Integer = Integer.parse(value)
+
+        val actual: Byte? = integer.toByteOrNull()
+
+        assertNull(actual, message = "Input: $value")
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -3,6 +3,10 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.integer
 import org.kotools.types.integerExcept
+import org.kotools.types.integerStringOutOfByteRange
+import org.kotools.types.integerStringOutOfIntRange
+import org.kotools.types.integerStringOutOfLongRange
+import org.kotools.types.integerStringOutOfShortRange
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.nonIntegerString
 import org.kotools.types.nonZeroIntegerStringWithLeadingZeros
@@ -11,6 +15,7 @@ import org.kotools.types.positiveIntegerString
 import org.kotools.types.repeatTest
 import org.kotools.types.zeroString
 import kotlin.random.Random
+import kotlin.random.nextInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -37,7 +42,7 @@ class IntegerTest {
 
     @Test
     fun fromBytePreservesByteRepresentation(): Unit = repeatTest {
-        val range: IntRange = Byte.MIN_VALUE.toInt()..Byte.MAX_VALUE.toInt()
+        val range: IntRange = Byte.MIN_VALUE..Byte.MAX_VALUE
         val value: Byte = Random.nextInt(range)
             .toByte()
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -974,4 +974,24 @@ class IntegerTest {
         val message = "Input: $value"
         assertEquals(expected, actual = exception.message, message)
     }
+
+    @Test
+    fun toLongOrNullPreservesLongRepresentation(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+        val integer: Integer = Integer.fromLong(value)
+
+        val actual: Long? = integer.toLongOrNull()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toLongOrNullReturnsNullWithOutOfRangeInteger(): Unit = repeatTest {
+        val value: String = Random.integerStringOutOfLongRange()
+        val integer: Integer = Integer.parse(value)
+
+        val actual: Long? = integer.toLongOrNull()
+
+        assertNull(actual, message = "Input: $value")
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -49,6 +49,19 @@ class IntegerTest {
     }
 
     @Test
+    fun fromShortPreservesShortRepresentation(): Unit = repeatTest {
+        val range: IntRange = Short.MIN_VALUE.toInt()..Short.MAX_VALUE.toInt()
+        val value: Short = Random.nextInt(range)
+            .toShort()
+
+        val integer: Integer = Integer.fromShort(value)
+
+        val actual: String = integer.toString()
+        val expected: String = value.toString()
+        assertEquals(expected, actual, message = "Input: $value")
+    }
+
+    @Test
     fun parsingNormalizesZero(): Unit = repeatTest {
         val value: String = Random.zeroString()
 

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -56,6 +56,23 @@ public class IntegerJavaSample {
     }
 
     @Test
+    void fromInt() {
+        final BiConsumer<java.lang.Integer, String> createsFromInt =
+                (input, expected) -> {
+                    final Integer result = Integer.fromInt(input);
+                    final boolean check =
+                            String.valueOf(result).equals(expected);
+                    if (!check) throw new IllegalStateException("Check failed.");
+                };
+
+        createsFromInt.accept(0, "0");
+        createsFromInt.accept(42, "42");
+        createsFromInt.accept(-42, "-42");
+        createsFromInt.accept(java.lang.Integer.MAX_VALUE, "2147483647");
+        createsFromInt.accept(java.lang.Integer.MIN_VALUE, "-2147483648");
+    }
+
+    @Test
     void parsing() {
         final BiConsumer<String, String> parsesTo = (input, expected) -> {
             final boolean check = String.valueOf(Integer.parse(input))

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -225,4 +225,18 @@ public class IntegerJavaSample {
         checkToString.accept(Integer.parse("+00042"), "42");
         checkToString.accept(Integer.parse("-00042"), "-42");
     }
+
+    @Test
+    void toLong() {
+        final Integer x = Integer.fromLong(42);
+        final long result = x.toLong();
+        if (result != 42L) throw new IllegalStateException("Check failed.");
+
+        final Integer y = Integer.parse("99999999999999999999");
+        try {
+            y.toLong();
+            throw new IllegalStateException("Check failed.");
+        } catch (ArithmeticException ignored) {
+        }
+    }
 }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -239,4 +239,18 @@ public class IntegerJavaSample {
         } catch (ArithmeticException ignored) {
         }
     }
+
+    @Test
+    void toInt() {
+        final Integer x = Integer.fromLong(42);
+        final int result = x.toInt();
+        if (result != 42) throw new IllegalStateException("Check failed.");
+
+        final Integer y = Integer.parse("9999999999");
+        try {
+            y.toInt();
+            throw new IllegalStateException("Check failed.");
+        } catch (ArithmeticException ignored) {
+        }
+    }
 }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -210,45 +210,14 @@ public class IntegerJavaSample {
     // ------------------------------ Conversions ------------------------------
 
     @Test
-    void toStringOverride() {
-        final BiConsumer<Integer, String> checkToString = (input, expected) -> {
-            final boolean check = String.valueOf(input).equals(expected);
-            if (!check) throw new IllegalStateException("Check failed.");
-        };
-
-        checkToString.accept(Integer.fromLong(0), "0");
-        checkToString.accept(Integer.parse("+0"), "0");
-        checkToString.accept(Integer.parse("-0"), "0");
-        checkToString.accept(Integer.parse("+42"), "42");
-        checkToString.accept(Integer.fromLong(-42), "-42");
-        checkToString.accept(Integer.parse("00042"), "42");
-        checkToString.accept(Integer.parse("+00042"), "42");
-        checkToString.accept(Integer.parse("-00042"), "-42");
-    }
-
-    @Test
-    void toLong() {
+    void toByte() {
         final Integer x = Integer.fromLong(42);
-        final long result = x.toLong();
-        if (result != 42L) throw new IllegalStateException("Check failed.");
-
-        final Integer y = Integer.parse("99999999999999999999");
-        try {
-            y.toLong();
-            throw new IllegalStateException("Check failed.");
-        } catch (ArithmeticException ignored) {
-        }
-    }
-
-    @Test
-    void toInt() {
-        final Integer x = Integer.fromLong(42);
-        final int result = x.toInt();
+        final byte result = x.toByte();
         if (result != 42) throw new IllegalStateException("Check failed.");
 
-        final Integer y = Integer.parse("9999999999");
+        final Integer y = Integer.parse("999");
         try {
-            y.toInt();
+            y.toByte();
             throw new IllegalStateException("Check failed.");
         } catch (ArithmeticException ignored) {
         }
@@ -269,16 +238,47 @@ public class IntegerJavaSample {
     }
 
     @Test
-    void toByte() {
+    void toInt() {
         final Integer x = Integer.fromLong(42);
-        final byte result = x.toByte();
+        final int result = x.toInt();
         if (result != 42) throw new IllegalStateException("Check failed.");
 
-        final Integer y = Integer.parse("999");
+        final Integer y = Integer.parse("9999999999");
         try {
-            y.toByte();
+            y.toInt();
             throw new IllegalStateException("Check failed.");
         } catch (ArithmeticException ignored) {
         }
+    }
+
+    @Test
+    void toLong() {
+        final Integer x = Integer.fromLong(42);
+        final long result = x.toLong();
+        if (result != 42L) throw new IllegalStateException("Check failed.");
+
+        final Integer y = Integer.parse("99999999999999999999");
+        try {
+            y.toLong();
+            throw new IllegalStateException("Check failed.");
+        } catch (ArithmeticException ignored) {
+        }
+    }
+
+    @Test
+    void toStringOverride() {
+        final BiConsumer<Integer, String> checkToString = (input, expected) -> {
+            final boolean check = String.valueOf(input).equals(expected);
+            if (!check) throw new IllegalStateException("Check failed.");
+        };
+
+        checkToString.accept(Integer.fromLong(0), "0");
+        checkToString.accept(Integer.parse("+0"), "0");
+        checkToString.accept(Integer.parse("-0"), "0");
+        checkToString.accept(Integer.parse("+42"), "42");
+        checkToString.accept(Integer.fromLong(-42), "-42");
+        checkToString.accept(Integer.parse("00042"), "42");
+        checkToString.accept(Integer.parse("+00042"), "42");
+        checkToString.accept(Integer.parse("-00042"), "-42");
     }
 }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -253,4 +253,18 @@ public class IntegerJavaSample {
         } catch (ArithmeticException ignored) {
         }
     }
+
+    @Test
+    void toShort() {
+        final Integer x = Integer.fromLong(42);
+        final short result = x.toShort();
+        if (result != 42) throw new IllegalStateException("Check failed.");
+
+        final Integer y = Integer.parse("99999");
+        try {
+            y.toShort();
+            throw new IllegalStateException("Check failed.");
+        } catch (ArithmeticException ignored) {
+        }
+    }
 }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -41,6 +41,21 @@ public class IntegerJavaSample {
     }
 
     @Test
+    void fromShort() {
+        final BiConsumer<Short, String> createsFromShort = (input, expected) -> {
+            final Integer result = Integer.fromShort(input);
+            final boolean check = String.valueOf(result).equals(expected);
+            if (!check) throw new IllegalStateException("Check failed.");
+        };
+
+        createsFromShort.accept((short) 0, "0");
+        createsFromShort.accept((short) 42, "42");
+        createsFromShort.accept((short) -42, "-42");
+        createsFromShort.accept(Short.MAX_VALUE, "32767");
+        createsFromShort.accept(Short.MIN_VALUE, "-32768");
+    }
+
+    @Test
     void parsing() {
         final BiConsumer<String, String> parsesTo = (input, expected) -> {
             final boolean check = String.valueOf(Integer.parse(input))

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -8,22 +8,7 @@ import java.util.function.Consumer;
 
 @SuppressWarnings("NewClassNamingConvention")
 public class IntegerJavaSample {
-    // ------------------------------- Creations -------------------------------
-
-    @Test
-    void fromLong() {
-        final BiConsumer<Long, String> createsFromLong = (input, expected) -> {
-            final Integer result = Integer.fromLong(input);
-            final boolean check = String.valueOf(result).equals(expected);
-            if (!check) throw new IllegalStateException("Check failed.");
-        };
-
-        createsFromLong.accept(0L, "0");
-        createsFromLong.accept(42L, "42");
-        createsFromLong.accept(-42L, "-42");
-        createsFromLong.accept(Long.MAX_VALUE, "9223372036854775807");
-        createsFromLong.accept(Long.MIN_VALUE, "-9223372036854775808");
-    }
+    // --------------------------- Factory functions ---------------------------
 
     @Test
     void fromByte() {
@@ -70,6 +55,21 @@ public class IntegerJavaSample {
         createsFromInt.accept(-42, "-42");
         createsFromInt.accept(java.lang.Integer.MAX_VALUE, "2147483647");
         createsFromInt.accept(java.lang.Integer.MIN_VALUE, "-2147483648");
+    }
+
+    @Test
+    void fromLong() {
+        final BiConsumer<Long, String> createsFromLong = (input, expected) -> {
+            final Integer result = Integer.fromLong(input);
+            final boolean check = String.valueOf(result).equals(expected);
+            if (!check) throw new IllegalStateException("Check failed.");
+        };
+
+        createsFromLong.accept(0L, "0");
+        createsFromLong.accept(42L, "42");
+        createsFromLong.accept(-42L, "-42");
+        createsFromLong.accept(Long.MAX_VALUE, "9223372036854775807");
+        createsFromLong.accept(Long.MIN_VALUE, "-9223372036854775808");
     }
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -267,4 +267,18 @@ public class IntegerJavaSample {
         } catch (ArithmeticException ignored) {
         }
     }
+
+    @Test
+    void toByte() {
+        final Integer x = Integer.fromLong(42);
+        final byte result = x.toByte();
+        if (result != 42) throw new IllegalStateException("Check failed.");
+
+        final Integer y = Integer.parse("999");
+        try {
+            y.toByte();
+            throw new IllegalStateException("Check failed.");
+        } catch (ArithmeticException ignored) {
+        }
+    }
 }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -11,9 +11,9 @@ public class IntegerJavaSample {
     // ------------------------------- Creations -------------------------------
 
     @Test
-    void of() {
+    void fromLong() {
         final BiConsumer<Long, String> createsFromLong = (input, expected) -> {
-            final Integer result = Integer.of(input);
+            final Integer result = Integer.fromLong(input);
             final boolean check = String.valueOf(result).equals(expected);
             if (!check) throw new IllegalStateException("Check failed.");
         };
@@ -136,13 +136,13 @@ public class IntegerJavaSample {
             if (!check) throw new IllegalStateException("Check failed.");
         };
 
-        checkEquality.accept(Integer.of(0), Integer.parse("-000"));
-        checkEquality.accept(Integer.of(42), Integer.parse("+00042"));
-        checkEquality.accept(Integer.of(-42), Integer.parse("-0042"));
+        checkEquality.accept(Integer.fromLong(0), Integer.parse("-000"));
+        checkEquality.accept(Integer.fromLong(42), Integer.parse("+00042"));
+        checkEquality.accept(Integer.fromLong(-42), Integer.parse("-0042"));
 
-        checkDiff.accept(Integer.of(0), Integer.of(1));
-        checkDiff.accept(Integer.of(42), 42);
-        checkDiff.accept(Integer.of(-42), null);
+        checkDiff.accept(Integer.fromLong(0), Integer.fromLong(1));
+        checkDiff.accept(Integer.fromLong(42), 42);
+        checkDiff.accept(Integer.fromLong(-42), null);
     }
 
     @Test
@@ -196,14 +196,14 @@ public class IntegerJavaSample {
 
     @Test
     void euclideanDivision() {
-        final Integer x = Integer.of(-7);
-        final Integer y = Integer.of(2);
+        final Integer x = Integer.fromLong(-7);
+        final Integer y = Integer.fromLong(2);
 
         final Integer quotient = x.div(y);
         final Integer remainder = x.rem(y);
 
-        final boolean check = quotient.equals(Integer.of(-4))
-                && remainder.equals(Integer.of(1));
+        final boolean check = quotient.equals(Integer.fromLong(-4))
+                && remainder.equals(Integer.fromLong(1));
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
@@ -216,11 +216,11 @@ public class IntegerJavaSample {
             if (!check) throw new IllegalStateException("Check failed.");
         };
 
-        checkToString.accept(Integer.of(0), "0");
+        checkToString.accept(Integer.fromLong(0), "0");
         checkToString.accept(Integer.parse("+0"), "0");
         checkToString.accept(Integer.parse("-0"), "0");
         checkToString.accept(Integer.parse("+42"), "42");
-        checkToString.accept(Integer.of(-42), "-42");
+        checkToString.accept(Integer.fromLong(-42), "-42");
         checkToString.accept(Integer.parse("00042"), "42");
         checkToString.accept(Integer.parse("+00042"), "42");
         checkToString.accept(Integer.parse("-00042"), "-42");

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -26,6 +26,21 @@ public class IntegerJavaSample {
     }
 
     @Test
+    void fromByte() {
+        final BiConsumer<Byte, String> createsFromByte = (input, expected) -> {
+            final Integer result = Integer.fromByte(input);
+            final boolean check = String.valueOf(result).equals(expected);
+            if (!check) throw new IllegalStateException("Check failed.");
+        };
+
+        createsFromByte.accept((byte) 0, "0");
+        createsFromByte.accept((byte) 42, "42");
+        createsFromByte.accept((byte) -42, "-42");
+        createsFromByte.accept(Byte.MAX_VALUE, "127");
+        createsFromByte.accept(Byte.MIN_VALUE, "-128");
+    }
+
+    @Test
     void parsing() {
         final BiConsumer<String, String> parsesTo = (input, expected) -> {
             final boolean check = String.valueOf(Integer.parse(input))


### PR DESCRIPTION
Implements #987: adds `Integer.Companion.fromByte/fromShort/fromInt/fromLong`, renames `of(Long)` to `fromLong(Long)`, and adds `toByte/toShort/toInt/toLong` + their `OrNull` counterparts, each with KDoc, Kotlin/Java samples, tests, and ABI dump updates. Also adds ADR-012 documenting the `ArithmeticException` choice for out-of-range conversions, updates the unreleased changelog, and documents new commit conventions in CLAUDE.md.

Closes #987.

Generated with [Claude Code](https://claude.ai/code)