### PR TITLE
⚡️ Optimize decimal conversions for `Integer` on Kotlin/Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ All notable changes to this project will be documented in this file.
   `org.kotools.types.*` (`Decimal`, `Integer`, `EmailAddressRegex`, and the
   `kotlinx-serialization` serializers) to follow a consistent
   `<description>: <value>` structure. ([#988])
+- Optimized `parse` and `toString` in the Kotlin/Native implementation of
+  `Integer` **experimental** type to process decimal digits in batches of 9
+  (10⁹ per step) instead of one digit at a time, reducing iteration count
+  ~9×. ([#989])
 
 ### 🔥 Removed
 
@@ -74,6 +78,7 @@ All notable changes to this project will be documented in this file.
 [#962]: https://github.com/kotools/types/issues/962
 [#966]: https://github.com/kotools/types/issues/966
 [#988]: https://github.com/kotools/types/issues/988
+[#989]: https://github.com/kotools/types/issues/989
 [#990]: https://github.com/kotools/types/issues/990
 
 ## 🔖 Releases

--- a/documentation/decisions/ADR-012-native-decimal-io-chunking.md
+++ b/documentation/decisions/ADR-012-native-decimal-io-chunking.md
@@ -1,4 +1,4 @@
-# 🏷️ ADR-013: 10⁹-chunk decimal I/O for `NativeInteger`
+# 🏷️ ADR-012: 10⁹-chunk decimal I/O for `NativeInteger`
 
 This document records the chunk size chosen for batching decimal digit
 processing in the Kotlin/Native implementation of `Integer`.

--- a/documentation/decisions/ADR-013-native-decimal-io-chunking.md
+++ b/documentation/decisions/ADR-013-native-decimal-io-chunking.md
@@ -1,0 +1,60 @@
+# 🏷️ ADR-013: 10⁹-chunk decimal I/O for `NativeInteger`
+
+This document records the chunk size chosen for batching decimal digit
+processing in the Kotlin/Native implementation of `Integer`.
+
+## 🤔 Context
+
+`NativeInteger` (see [ADR-007]) stores its magnitude as a `UIntArray` in
+base 2³² (little-endian limbs). Before this decision, `parse()` and
+`toString()` processed one decimal digit per iteration — _d_ iterations
+for a _d_-digit number — making both operations O(_d_ × _n\_limbs_).
+
+Batching multiple digits into a single chunk reduces the number of
+iterations to ⌈_d_ / chunk\_size⌉ while keeping the per-iteration cost
+roughly the same, yielding a near-linear speed-up proportional to the
+chunk size.
+
+## ✅ Decision
+
+Batch decimal I/O in chunks of **10⁹** (one billion) — i.e., nine decimal
+digits at a time.
+
+The constraint is that every chunk value must fit in a `UInt`:
+
+```
+max chunk value = 999_999_999 (nine 9s)
+UInt max        = 4_294_967_295 (= 2³² − 1)
+999_999_999 < 4_294_967_295  ✓
+```
+
+10⁹ is the largest power of 10 that satisfies this constraint:
+
+```
+10⁹  = 1_000_000_000 < 2³² − 1  ✓  (chosen)
+10¹⁰ = 10_000_000_000 > 2³² − 1  ✗  (does not fit)
+```
+
+Using `UInt` for the chunk avoids a `Long` intermediate and keeps the
+arithmetic consistent with the rest of the magnitude helper functions.
+
+## 🔗 Consequences
+
+- A file-level `private val BILLION: UIntArray = uintArrayOf(1_000_000_000u)`
+  constant holds the base used by `parse()`.
+- `parse()` processes the digit string in groups of nine, multiplying the
+  accumulated magnitude by `BILLION` and adding each chunk — ⌈_d_/9⌉
+  iterations instead of _d_.
+- A `divideByBillion()` extension on `UIntArray` mirrors `divideByTen()`
+  but divides by 10⁹, returning a `(quotient, remainder)` pair where the
+  remainder is at most 999,999,999 and therefore fits in `Int`.
+- `toString()` collects nine-digit chunks via `divideByBillion()` and
+  formats them with `padStart(9, '0')` to preserve leading zeros in
+  interior groups — ⌈_d_/9⌉ iterations instead of _d_, with no final
+  `reversed()` call.
+- `divideByTen()` is removed as dead code.
+- Iteration count for both operations drops by ~9× for large numbers.
+
+<!----------------------------------- Links ----------------------------------->
+
+[ADR-007]: ADR-007-native-integer-sign-magnitude-repr.md

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -19,7 +19,7 @@ rationale behind it, and its consequences.
 | [ADR-009](ADR-009-default-serializer-serial-names.md)     | Explicit serial names for default serializers       | ✅ Accepted               |
 | [ADR-010](ADR-010-error-message-format.md)                | Error message format for `org.kotools.types`        | ✅ Accepted               |
 | [ADR-011](ADR-011-error-message-quote-escaping.md)        | String value quote escaping for `org.kotools.types` | ✅ Accepted               |
-| [ADR-013](ADR-013-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`           | ✅ Accepted               |
+| [ADR-012](ADR-012-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`           | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -19,6 +19,7 @@ rationale behind it, and its consequences.
 | [ADR-009](ADR-009-default-serializer-serial-names.md)     | Explicit serial names for default serializers       | ✅ Accepted               |
 | [ADR-010](ADR-010-error-message-format.md)                | Error message format for `org.kotools.types`        | ✅ Accepted               |
 | [ADR-011](ADR-011-error-message-quote-escaping.md)        | String value quote escaping for `org.kotools.types` | ✅ Accepted               |
+| [ADR-013](ADR-013-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`           | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
+++ b/subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
@@ -64,20 +64,23 @@ private class NativeInteger private constructor(
             val digits: String = if (isNegative) value.substring(1) else value
             if (digits == "0") return ZERO
 
-            var tmpMag = UIntArray(0)
-            digits.forEach {
-                val x: UIntArray = tmpMag * uintArrayOf(10u)
-                val y: UIntArray = uintArrayOf(it.digitToInt().toUInt())
-                tmpMag = x + y
+            val firstLen: Int =
+                if (digits.length % 9 == 0) 9 else digits.length % 9
+            var tmpMag: UIntArray =
+                uintArrayOf(digits.substring(0, firstLen).toUInt())
+            var i = firstLen
+            while (i < digits.length) {
+                val chunk: UInt = digits.substring(i, i + 9).toUInt()
+                tmpMag = tmpMag * BILLION + uintArrayOf(chunk)
+                i += 9
             }
-            val magnitude: UIntArray = tmpMag.trimLeadingZeros()
 
+            val magnitude: UIntArray = tmpMag.trimLeadingZeros()
             val sign: IntegerSign = when {
                 magnitude.isEmpty() -> IntegerSign.Zero
                 isNegative -> IntegerSign.Negative
                 else -> IntegerSign.Positive
             }
-
             return NativeInteger(magnitude, sign)
         }
     }
@@ -178,16 +181,22 @@ private class NativeInteger private constructor(
 
     override fun toString(): String {
         if (this.sign == IntegerSign.Zero) return "0"
-        val builder = StringBuilder()
+
+        val chunks = mutableListOf<Int>()
         var remaining: UIntArray = this.magnitude
         while (remaining.isNotEmpty()) {
-            val (quotient: UIntArray, digit: Int) = remaining.divideByTen()
-            builder.append(digit)
-            remaining = quotient.trimLeadingZeros()
+            val (quotient: UIntArray, chunk: Int) = remaining.divideByBillion()
+            chunks.add(chunk)
+            remaining = quotient
         }
+
+        val builder = StringBuilder()
         if (this.sign == IntegerSign.Negative) builder.append('-')
+        builder.append(chunks.last())
+        (chunks.size - 2 downTo 0).forEach {
+            builder.append(chunks[it].toString().padStart(9, '0'))
+        }
         return builder.toString()
-            .reversed()
     }
 }
 
@@ -315,14 +324,15 @@ private fun UIntArray.shiftRight(bits: Int): UIntArray {
     return result.trimLeadingZeros()
 }
 
-private fun UIntArray.divideByTen(): Pair<UIntArray, Int> {
+private val BILLION: UIntArray = uintArrayOf(1_000_000_000u)
+
+private fun UIntArray.divideByBillion(): Pair<UIntArray, Int> {
     val result = UIntArray(this.size)
     var remainder = 0L
-    this.indices.reversed()
-        .forEach {
-            val current: Long = (remainder shl 32) or this[it].toLong()
-            result[it] = (current / 10L).toUInt()
-            remainder = current % 10L
-        }
+    this.indices.reversed().forEach {
+        val current: Long = (remainder shl 32) or this[it].toLong()
+        result[it] = (current / 1_000_000_000L).toUInt()
+        remainder = current % 1_000_000_000L
+    }
     return result.trimLeadingZeros() to remainder.toInt()
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -912,4 +912,32 @@ class IntegerTest {
 
         assertEquals(expected = x, actual, message = "Input: $x")
     }
+
+    @Test
+    fun parseAndToStringWithNineDigitInteger() {
+        val value = "123456789"
+        val actual: String = Integer.parse(value).toString()
+        assertEquals(expected = value, actual)
+    }
+
+    @Test
+    fun parseAndToStringWithTenDigitInteger() {
+        val value = "1234567890"
+        val actual: String = Integer.parse(value).toString()
+        assertEquals(expected = value, actual)
+    }
+
+    @Test
+    fun parseAndToStringWithEighteenDigitInteger() {
+        val value = "123456789123456789"
+        val actual: String = Integer.parse(value).toString()
+        assertEquals(expected = value, actual)
+    }
+
+    @Test
+    fun parseAndToStringWithLargeNegativeInteger() {
+        val value = "-99999999999999999999"
+        val actual: String = Integer.parse(value).toString()
+        assertEquals(expected = value, actual)
+    }
 }


### PR DESCRIPTION
## Summary

- Rewrote `parse` and `toString` in `PlatformInteger.native.kt` to batch decimal digits in groups of 9 (10⁹ per step) instead of one digit at a time, reducing iteration count ~9×.
- Added file-level `BILLION` constant and `divideByBillion()` helper; removed dead `divideByTen()`.
- Added 4 boundary tests to `IntegerTest` (commonTest, cross-platform) covering the 9-, 10-, 18- and 20-digit chunk boundaries.
- Added ADR-013 documenting why 10⁹ is the optimal chunk size (largest power of 10 that fits in a `UInt`).
- Updated `CHANGELOG.md` with a `♻️ Changed` entry.

Closes #989

Generated with [Claude Code](https://claude.ai/code)