### PR TITLE
✨ Add `NonZeroInteger` experimental type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ Added
 
+- `NonZeroInteger` **experimental** type to `org.kotools.types.number` package,
+  representing an integer other than zero. Supports creation from an [Integer]
+  via `fromInteger`/`fromIntegerOrNull`, from `Byte`, `Short`, `Int` and `Long`
+  primitives via `fromByte`/`fromShort`/`fromInt`/`fromLong` (and their `OrNull`
+  counterparts), and from a `String` via `parse`/`parseOrNull`. Factory functions
+  throw `IllegalArgumentException` (or return `null`) when the value represents
+  zero, and `parse` additionally propagates `NumberFormatException` for
+  non-integer strings. Includes structural equality and string conversion
+  delegating to `Integer`. ([#997])
 - `Decimal` **experimental** type to `org.kotools.types.number` package,
   representing mathematical decimal numbers with exact arithmetic. Supports
   creation via `of(Long)`, `parse(String)` and `parseOrNull(String)`,
@@ -64,6 +73,7 @@ All notable changes to this project will be documented in this file.
   `KSerializer` implementations. ([#990])
 
 [@daniel-rusu]: https://github.com/daniel-rusu
+[#997]: https://github.com/kotools/types/issues/997
 [#871]: https://github.com/kotools/types/issues/871
 [#872]: https://github.com/kotools/types/issues/872
 [#912]: https://github.com/kotools/types/issues/912

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/HashSeed.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/HashSeed.kt
@@ -7,7 +7,10 @@ public enum class HashSeed {
     Decimal,
 
     /** Hash seed for the `Integer` type. */
-    Integer;
+    Integer,
+
+    /** Hash seed for the `NonZeroInteger` type. */
+    NonZeroInteger;
 
     /** Returns a hash seed for this entry. */
     public fun toInt(): Int = this.name.hashCode()

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -407,3 +407,18 @@ public final class org/kotools/types/number/Integer$Companion {
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 }
 
+public final class org/kotools/types/number/NonZeroInteger {
+	public static final field Companion Lorg/kotools/types/number/NonZeroInteger$Companion;
+	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun hashCode ()I
+	public final fun toInteger ()Lorg/kotools/types/number/Integer;
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class org/kotools/types/number/NonZeroInteger$Companion {
+	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+}
+

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -417,6 +417,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
+	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 }
@@ -432,5 +433,7 @@ public final class org/kotools/types/number/NonZeroInteger$Companion {
 	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromShortOrNull (S)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -412,6 +412,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromByte (B)Lorg/kotools/types/number/NonZeroInteger;
+	public static final fun fromInt (I)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
@@ -422,6 +423,8 @@ public final class org/kotools/types/number/NonZeroInteger {
 public final class org/kotools/types/number/NonZeroInteger$Companion {
 	public final fun fromByte (B)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromByteOrNull (B)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun fromInt (I)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromIntOrNull (I)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -413,6 +413,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromByte (B)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public static final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
@@ -423,5 +424,7 @@ public final class org/kotools/types/number/NonZeroInteger$Companion {
 	public final synthetic fun fromByteOrNull (B)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromShortOrNull (S)Lorg/kotools/types/number/NonZeroInteger;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -411,6 +411,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final field Companion Lorg/kotools/types/number/NonZeroInteger$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun equals (Ljava/lang/Object;)Z
+	public static final fun fromByte (B)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
@@ -418,6 +419,8 @@ public final class org/kotools/types/number/NonZeroInteger {
 }
 
 public final class org/kotools/types/number/NonZeroInteger$Companion {
+	public final fun fromByte (B)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromByteOrNull (B)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -414,6 +414,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final fun fromByte (B)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromInt (I)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
@@ -427,6 +428,8 @@ public final class org/kotools/types/number/NonZeroInteger$Companion {
 	public final synthetic fun fromIntOrNull (I)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromShort (S)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromShortOrNull (S)Lorg/kotools/types/number/NonZeroInteger;
 }

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -84,6 +84,57 @@ public class NonZeroInteger private constructor(private val value: Integer) {
         @JvmSynthetic
         public fun fromIntegerOrNull(value: Integer): NonZeroInteger? =
             if (value == Integer.of(0)) null else NonZeroInteger(value)
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or throws an
+         * [IllegalArgumentException] if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromByte
+         * </details>
+         * <br>
+         *
+         * See the [fromByteOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
+         */
+        @JvmStatic
+        public fun fromByte(value: Byte): NonZeroInteger =
+            fromByteOrNull(value) ?: throw IllegalArgumentException(
+                errorMessage("Value must be non-zero", value)
+            )
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or returns
+         * `null` if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromByteOrNull
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromByte] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun fromByteOrNull(value: Byte): NonZeroInteger? =
+            fromIntegerOrNull(Integer.of(value.toLong()))
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -237,6 +237,57 @@ public class NonZeroInteger private constructor(private val value: Integer) {
         @JvmSynthetic
         public fun fromIntOrNull(value: Int): NonZeroInteger? =
             fromIntegerOrNull(Integer.of(value.toLong()))
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or throws an
+         * [IllegalArgumentException] if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromLong
+         * </details>
+         * <br>
+         *
+         * See the [fromLongOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
+         */
+        @JvmStatic
+        public fun fromLong(value: Long): NonZeroInteger =
+            fromLongOrNull(value) ?: throw IllegalArgumentException(
+                errorMessage("Value must be non-zero", value)
+            )
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or returns
+         * `null` if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromLongOrNull
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromLong] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun fromLongOrNull(value: Long): NonZeroInteger? =
+            fromIntegerOrNull(Integer.of(value))
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -1,0 +1,173 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.HashSeed
+import org.kotools.types.internal.errorMessage
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Represents an integer other than zero (ℤ \ {0}).
+ *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Key features</b>
+ * </summary>
+ *
+ * ### Key features
+ *
+ * - **Creations:** Create from an [Integer], Kotlin integer types, or a string
+ * (see [fromInteger], [fromByte], [fromShort], [fromInt], [fromLong], and
+ * [parse]).
+ * - **Comparisons:** Compare integers using
+ * [structural equality][NonZeroInteger.equals] (`x == y`, `x != y`).
+ * - **Conversions:** Convert to an [Integer] (see [toInteger]) or its decimal
+ * string representation (see [NonZeroInteger.toString]).
+ * </details>
+ *
+ * @since 5.2.0
+ */
+@ExperimentalKotoolsTypesApi
+public class NonZeroInteger private constructor(private val value: Integer) {
+    // --------------------------- Factory functions ---------------------------
+
+    /** Contains class-level declarations for the [NonZeroInteger] type. */
+    public companion object {
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or throws an
+         * [IllegalArgumentException] if [value] represents zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromInteger
+         * </details>
+         * <br>
+         *
+         * See the [fromIntegerOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
+         */
+        @JvmStatic
+        public fun fromInteger(value: Integer): NonZeroInteger =
+            fromIntegerOrNull(value) ?: throw IllegalArgumentException(
+                errorMessage("Value must be non-zero", value)
+            )
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or returns
+         * `null` if [value] represents zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromIntegerOrNull
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromInteger] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun fromIntegerOrNull(value: Integer): NonZeroInteger? =
+            if (value == Integer.of(0)) null else NonZeroInteger(value)
+    }
+
+    // ------------------------------ Comparisons ------------------------------
+
+    /**
+     * Returns `true` if the [other] object is a [NonZeroInteger] representing
+     * the same numeric value as this one, or returns `false` otherwise.
+     *
+     * This function follows the contract of [Any.equals].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun equals(other: Any?): Boolean =
+        other is NonZeroInteger && this.value == other.value
+
+    /**
+     * Returns a hash code value for this integer.
+     *
+     * This function follows the contract of [Any.hashCode], with an additional
+     * property: if two instances of [NonZeroInteger] are not equal, then
+     * calling this function on these objects must produce different hash codes.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun hashCode(): Int {
+        val seed: Int = HashSeed.NonZeroInteger.toInt()
+        return 31 * seed + this.value.hashCode()
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    /**
+     * Returns the [Integer] representation of this non-zero integer.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.toInteger
+     * </details>
+     */
+    public fun toInteger(): Integer = this.value
+
+    /**
+     * Returns the decimal string representation of this non-zero integer.
+     *
+     * The resulting string is always canonical (no leading plus sign and
+     * zeros).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.toStringOverride
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun toString(): String = this.value.toString()
+}

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -135,6 +135,57 @@ public class NonZeroInteger private constructor(private val value: Integer) {
         @JvmSynthetic
         public fun fromByteOrNull(value: Byte): NonZeroInteger? =
             fromIntegerOrNull(Integer.of(value.toLong()))
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or throws an
+         * [IllegalArgumentException] if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromShort
+         * </details>
+         * <br>
+         *
+         * See the [fromShortOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
+         */
+        @JvmStatic
+        public fun fromShort(value: Short): NonZeroInteger =
+            fromShortOrNull(value) ?: throw IllegalArgumentException(
+                errorMessage("Value must be non-zero", value)
+            )
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or returns
+         * `null` if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromShortOrNull
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromShort] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun fromShortOrNull(value: Short): NonZeroInteger? =
+            fromIntegerOrNull(Integer.of(value.toLong()))
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -288,6 +288,72 @@ public class NonZeroInteger private constructor(private val value: Integer) {
         @JvmSynthetic
         public fun fromLongOrNull(value: Long): NonZeroInteger? =
             fromIntegerOrNull(Integer.of(value))
+
+        /**
+         * Returns a [NonZeroInteger] representing the number described by
+         * [value], or throws an exception if [value] is invalid.
+         *
+         * Throws [NumberFormatException] if [value] doesn't represent an
+         * integer. Throws [IllegalArgumentException] if [value] represents
+         * zero.
+         *
+         * See [Integer.parse] for the accepted integer string format.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.parsing
+         * </details>
+         * <br>
+         *
+         * See the [parseOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
+         */
+        @JvmStatic
+        public fun parse(value: String): NonZeroInteger {
+            val integer: Integer = Integer.parse(value)
+            return fromIntegerOrNull(integer) ?: throw IllegalArgumentException(
+                errorMessage("Value must be non-zero", value)
+            )
+        }
+
+        /**
+         * Returns a [NonZeroInteger] representing the number described by
+         * [value], or returns `null` if [value] is invalid.
+         *
+         * Returns `null` if [value] doesn't represent an integer, or if
+         * [value] represents zero.
+         *
+         * See [Integer.parseOrNull] for the accepted integer string format.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.parsing
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [parse] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun parseOrNull(value: String): NonZeroInteger? {
+            val integer: Integer = Integer.parseOrNull(value) ?: return null
+            return fromIntegerOrNull(integer)
+        }
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -186,6 +186,57 @@ public class NonZeroInteger private constructor(private val value: Integer) {
         @JvmSynthetic
         public fun fromShortOrNull(value: Short): NonZeroInteger? =
             fromIntegerOrNull(Integer.of(value.toLong()))
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or throws an
+         * [IllegalArgumentException] if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromInt
+         * </details>
+         * <br>
+         *
+         * See the [fromIntOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid [value].
+         */
+        @JvmStatic
+        public fun fromInt(value: Int): NonZeroInteger =
+            fromIntOrNull(value) ?: throw IllegalArgumentException(
+                errorMessage("Value must be non-zero", value)
+            )
+
+        /**
+         * Returns a [NonZeroInteger] from the specified [value], or returns
+         * `null` if [value] is zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromIntOrNull
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromInt] function for throwing an exception instead of
+         * returning `null` in case of invalid [value].
+         */
+        @JvmSynthetic
+        public fun fromIntOrNull(value: Int): NonZeroInteger? =
+            fromIntegerOrNull(Integer.of(value.toLong()))
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -101,6 +101,28 @@ class NonZeroIntegerSample {
         check(NonZeroInteger.fromIntOrNull(0) == null)
     }
 
+    @Test
+    fun fromLong() {
+        val value = 42L
+        val result: NonZeroInteger = NonZeroInteger.fromLong(value)
+        check(result.toString() == "42")
+
+        val exception: Throwable? = runCatching {
+            NonZeroInteger.fromLong(0L)
+        }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
+    fun fromLongOrNull() {
+        val value = 42L
+        val result: NonZeroInteger? = NonZeroInteger.fromLongOrNull(value)
+        checkNotNull(result)
+        check(result.toString() == "42")
+
+        check(NonZeroInteger.fromLongOrNull(0L) == null)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -123,6 +123,45 @@ class NonZeroIntegerSample {
         check(NonZeroInteger.fromLongOrNull(0L) == null)
     }
 
+    @Test
+    fun parsing() {
+        fun parsesTo(input: String, expected: String) {
+            check(NonZeroInteger.parse(input).toString() == expected)
+            check(NonZeroInteger.parseOrNull(input)?.toString() == expected)
+        }
+
+        fun failsWithIllegalArg(input: String) {
+            val exception: Throwable? = runCatching {
+                NonZeroInteger.parse(input)
+            }.exceptionOrNull()
+            check(exception is IllegalArgumentException)
+            check(NonZeroInteger.parseOrNull(input) == null)
+        }
+
+        fun failsWithNumberFormat(input: String) {
+            val exception: Throwable? = runCatching {
+                NonZeroInteger.parse(input)
+            }.exceptionOrNull()
+            check(exception is NumberFormatException)
+            check(NonZeroInteger.parseOrNull(input) == null)
+        }
+
+        parsesTo(input = "42", expected = "42")
+        parsesTo(input = "-42", expected = "-42")
+        parsesTo(input = "+00042", expected = "42")
+
+        // Fails with IllegalArgumentException for zero:
+        failsWithIllegalArg("0")
+        failsWithIllegalArg("+0")
+        failsWithIllegalArg("-0")
+        failsWithIllegalArg("000")
+
+        // Fails with NumberFormatException for non-integer strings:
+        failsWithNumberFormat("")
+        failsWithNumberFormat("12a")
+        failsWithNumberFormat("3.14")
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -31,6 +31,30 @@ class NonZeroIntegerSample {
         check(NonZeroInteger.fromIntegerOrNull(zero) == null)
     }
 
+    @Test
+    fun fromByte() {
+        val value: Byte = 42
+        val result: NonZeroInteger = NonZeroInteger.fromByte(value)
+        check(result.toString() == "42")
+
+        val zero: Byte = 0
+        val exception: Throwable? = runCatching {
+            NonZeroInteger.fromByte(zero)
+        }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
+    fun fromByteOrNull() {
+        val value: Byte = 42
+        val result: NonZeroInteger? = NonZeroInteger.fromByteOrNull(value)
+        checkNotNull(result)
+        check(result.toString() == "42")
+
+        val zero: Byte = 0
+        check(NonZeroInteger.fromByteOrNull(zero) == null)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -55,6 +55,30 @@ class NonZeroIntegerSample {
         check(NonZeroInteger.fromByteOrNull(zero) == null)
     }
 
+    @Test
+    fun fromShort() {
+        val value: Short = 42
+        val result: NonZeroInteger = NonZeroInteger.fromShort(value)
+        check(result.toString() == "42")
+
+        val zero: Short = 0
+        val exception: Throwable? = runCatching {
+            NonZeroInteger.fromShort(zero)
+        }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
+    fun fromShortOrNull() {
+        val value: Short = 42
+        val result: NonZeroInteger? = NonZeroInteger.fromShortOrNull(value)
+        checkNotNull(result)
+        check(result.toString() == "42")
+
+        val zero: Short = 0
+        check(NonZeroInteger.fromShortOrNull(zero) == null)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -79,6 +79,28 @@ class NonZeroIntegerSample {
         check(NonZeroInteger.fromShortOrNull(zero) == null)
     }
 
+    @Test
+    fun fromInt() {
+        val value = 42
+        val result: NonZeroInteger = NonZeroInteger.fromInt(value)
+        check(result.toString() == "42")
+
+        val exception: Throwable? = runCatching {
+            NonZeroInteger.fromInt(0)
+        }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
+    fun fromIntOrNull() {
+        val value = 42
+        val result: NonZeroInteger? = NonZeroInteger.fromIntOrNull(value)
+        checkNotNull(result)
+        check(result.toString() == "42")
+
+        check(NonZeroInteger.fromIntOrNull(0) == null)
+    }
+
     // ------------------------------ Comparisons ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -1,0 +1,88 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import kotlin.test.Test
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class NonZeroIntegerSample {
+    // --------------------------- Factory functions ---------------------------
+
+    @Test
+    fun fromInteger() {
+        val integer: Integer = Integer.of(42)
+        val result: NonZeroInteger = NonZeroInteger.fromInteger(integer)
+        check(result.toString() == "42")
+
+        val zero: Integer = Integer.of(0)
+        val exception: Throwable? = runCatching {
+            NonZeroInteger.fromInteger(zero)
+        }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
+    fun fromIntegerOrNull() {
+        val integer: Integer = Integer.of(42)
+        val result: NonZeroInteger? = NonZeroInteger.fromIntegerOrNull(integer)
+        checkNotNull(result)
+        check(result.toString() == "42")
+
+        val zero: Integer = Integer.of(0)
+        check(NonZeroInteger.fromIntegerOrNull(zero) == null)
+    }
+
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEquality() {
+        fun checkEquality(integer: NonZeroInteger, other: Any?) {
+            check(integer == other)
+            check(integer.hashCode() == other.hashCode())
+        }
+
+        fun checkDiff(integer: NonZeroInteger, other: Any?) {
+            check(integer != other)
+            check(integer.hashCode() != other.hashCode())
+        }
+
+        val x: NonZeroInteger = NonZeroInteger.fromInteger(Integer.of(42))
+        val y: NonZeroInteger = NonZeroInteger.fromInteger(Integer.parse("+00042"))
+        checkEquality(integer = x, other = y)
+
+        val z: NonZeroInteger = NonZeroInteger.fromInteger(Integer.of(-42))
+        checkDiff(integer = x, other = z)
+        checkDiff(integer = x, other = 42)
+        checkDiff(integer = x, other = null)
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toInteger() {
+        val integer: Integer = Integer.of(42)
+        val nonZero: NonZeroInteger = NonZeroInteger.fromInteger(integer)
+        val result: Integer = nonZero.toInteger()
+        check(result == integer)
+    }
+
+    @Test
+    fun toStringOverride() {
+        fun checkToString(input: NonZeroInteger, expected: String) {
+            val result: String = input.toString()
+            check(result == expected)
+        }
+
+        checkToString(
+            input = NonZeroInteger.fromInteger(Integer.of(42)),
+            expected = "42"
+        )
+        checkToString(
+            input = NonZeroInteger.fromInteger(Integer.of(-42)),
+            expected = "-42"
+        )
+        checkToString(
+            input = NonZeroInteger.fromInteger(Integer.parse("+00042")),
+            expected = "42"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `NonZeroInteger` experimental type to `org.kotools.types.number` package, representing an integer other than zero
- Implements all factory functions from `Integer`, `Byte`, `Short`, `Int`, `Long`, and `String` (throwing + null-returning variants)
- Includes structural equality, `toInteger()`, `toString()`, sample functions, and refreshed ABI dump

## Test plan

- [x] All `NonZeroIntegerSample` tests pass on JVM
- [x] ABI dump regenerated after each incremental commit
- [x] `apiDump` reports `BUILD SUCCESSFUL`

Closes #997

Generated with [Claude Code](https://claude.ai/code)