### PR TITLE
✨ Add `Integer-Long` conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
   arithmetic operators (`+`, `-`, `*`, unary `-`), comparison, and canonical
   string conversion. Division is intentionally excluded because the set of
   terminating decimals is not closed under division. ([#925])
+- `Integer.toLong` and `Integer.toLongOrNull` **experimental** functions,
+  returning the `Long` representation of an `Integer`, or throwing an
+  `IllegalArgumentException` (`toLong`) or returning `null`
+  (`toLongOrNull`) if it's out of range for `Long`. ([#1010])
 
 ### ♻️ Changed
 
@@ -35,8 +39,8 @@ All notable changes to this project will be documented in this file.
   `Integer.remOrNull` **experimental** functions to use Euclidean division
   semantics: the remainder is always non-negative (`0 ≤ r < |b|`). ([#952])
 - Moved `Integer` **experimental** type to `org.kotools.types.number` package,
-  and renamed some of its functions (`from` -> `of`, `fromDecimal` -> `parse`,
-  `fromDecimalOrNull` -> `parseOrNull`). ([#960])
+  and renamed some of its functions (`from` -> `fromLong`, `fromDecimal` ->
+  `parse`, `fromDecimalOrNull` -> `parseOrNull`). ([#960], [#1010])
 - Reformatted error messages thrown by **experimental** declarations in
   `org.kotools.types.*` (`Decimal`, `Integer`, `EmailAddressRegex`, and the
   `kotlinx-serialization` serializers) to follow a consistent
@@ -80,6 +84,7 @@ All notable changes to this project will be documented in this file.
 [#988]: https://github.com/kotools/types/issues/988
 [#989]: https://github.com/kotools/types/issues/989
 [#990]: https://github.com/kotools/types/issues/990
+[#1010]: https://github.com/kotools/types/issues/1010
 
 ## 🔖 Releases
 

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleSample.kt
@@ -65,7 +65,7 @@ class SerializersModuleSample {
         @Serializable
         data class Account(@Contextual val balance: Integer)
 
-        val balance: Integer = Integer.of(150)
+        val balance: Integer = Integer.fromLong(150)
         val account = Account(balance)
 
         val format = Json {

--- a/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
+++ b/subprojects/kotlinx-serialization/src/commonTest/kotlin/org/kotools/types/kotlinx/serialization/SerializersModuleTest.kt
@@ -155,7 +155,7 @@ class IntegerAsStringSerializerTest {
     fun serialize() {
         val format =
             Json { this.serializersModule = KotoolsTypesSerializersModule() }
-        val value: Integer = Integer.of(150)
+        val value: Integer = Integer.fromLong(150)
 
         val actual: String = format.encodeToString(value)
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -389,9 +389,9 @@ public final class org/kotools/types/number/Integer {
 	public final fun div (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun divOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun equals (Ljava/lang/Object;)Z
+	public static final fun fromLong (J)Lorg/kotools/types/number/Integer;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
-	public static final fun of (J)Lorg/kotools/types/number/Integer;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun plus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
@@ -402,7 +402,7 @@ public final class org/kotools/types/number/Integer {
 }
 
 public final class org/kotools/types/number/Integer$Companion {
-	public final fun of (J)Lorg/kotools/types/number/Integer;
+	public final fun fromLong (J)Lorg/kotools/types/number/Integer;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -397,6 +397,7 @@ public final class org/kotools/types/number/Integer {
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
+	public final fun toLong ()J
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -398,6 +398,7 @@ public final class org/kotools/types/number/Integer {
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toLong ()J
+	public final synthetic fun toLongOrNull ()Ljava/lang/Long;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -565,8 +565,7 @@ public class Decimal private constructor(
      * [Integer.rem] uses Euclidean semantics (`remainder >= 0`), which
      * correctly identifiers divisibility by 10 for negative unscaled values.
      *
-     * Example: `-30 % 10 = 0` -> strip -> `Decimal(Integer.fromLong(-3),
-     * scale = 0)`
+     * `-30 % 10 = 0` -> strip -> `Decimal(Integer.fromLong(-3), scale = 0)`
      */
     private fun normalize(): Decimal {
         if (this.scale == 0) return this

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -112,7 +112,7 @@ public class Decimal private constructor(
          */
         @JvmStatic
         public fun of(value: Long): Decimal {
-            val unscaled: Integer = Integer.of(value)
+            val unscaled: Integer = Integer.fromLong(value)
             return Decimal(unscaled, scale = 0)
         }
 
@@ -552,7 +552,7 @@ public class Decimal private constructor(
      */
     private fun scaleUpTo(targetScale: Int): Integer {
         if (this.scale == targetScale) return this.unscaledValue
-        val ten: Integer = Integer.of(10)
+        val ten: Integer = Integer.fromLong(10)
         var result: Integer = this.unscaledValue
         repeat(targetScale - this.scale) { result *= ten }
         return result
@@ -565,12 +565,13 @@ public class Decimal private constructor(
      * [Integer.rem] uses Euclidean semantics (`remainder >= 0`), which
      * correctly identifiers divisibility by 10 for negative unscaled values.
      *
-     * Example: `-30 % 10 = 0` -> strip -> `Decimal(Integer.of(-3), scale = 0)`
+     * Example: `-30 % 10 = 0` -> strip -> `Decimal(Integer.fromLong(-3),
+     * scale = 0)`
      */
     private fun normalize(): Decimal {
         if (this.scale == 0) return this
-        val zero: Integer = Integer.of(0)
-        val ten: Integer = Integer.of(10)
+        val zero: Integer = Integer.fromLong(0)
+        val ten: Integer = Integer.fromLong(10)
         var current: Decimal = this
         while (current.scale > 0) {
             if (current.unscaledValue % ten != zero) break

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -565,7 +565,8 @@ public class Decimal private constructor(
      * [Integer.rem] uses Euclidean semantics (`remainder >= 0`), which
      * correctly identifiers divisibility by 10 for negative unscaled values.
      *
-     * `-30 % 10 = 0` -> strip -> `Decimal(Integer.fromLong(-3), scale = 0)`
+     * Example: `-30 % 10 = 0` -> strip -> `Decimal(Integer.fromLong(-3),
+     * scale = 0)`
      */
     private fun normalize(): Decimal {
         if (this.scale == 0) return this

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -102,7 +102,7 @@ import kotlin.jvm.JvmSynthetic
  * [remainders][rem] (`x % y`), and [negate][unaryMinus] (`-x`) integers without
  * overflow.
  * - **Conversions:** Convert to its decimal string representation (see
- * [Integer.toString]).
+ * [Integer.toString]) or to a [Long] (see [toLong]).
  * </details>
  *
  * @since 5.1.0
@@ -630,6 +630,46 @@ public class Integer private constructor(
     }
 
     // ------------------------------ Conversions ------------------------------
+
+    /**
+     * Returns the [Long] representation of this integer, or throws an
+     * [IllegalArgumentException] if this integer is out of range for [Long]
+     * (less than [Long.MIN_VALUE] or greater than [Long.MAX_VALUE]).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toLong
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.toLong
+     * </details>
+     * <br>
+     *
+     * See the [toLongOrNull] function for returning `null` instead of
+     * throwing an exception when this integer is out of range for [Long].
+     */
+    public fun toLong(): Long {
+        if (this < fromLong(Long.MIN_VALUE) || this > fromLong(Long.MAX_VALUE)) {
+            val message: String =
+                errorMessage("Integer out of range for Long", this)
+            throw IllegalArgumentException(message)
+        }
+        return this.toString().toLong()
+    }
 
     /**
      * Returns the decimal string representation of this integer.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -102,7 +102,7 @@ import kotlin.jvm.JvmSynthetic
  * [remainders][rem] (`x % y`), and [negate][unaryMinus] (`-x`) integers without
  * overflow.
  * - **Conversions:** Convert to its decimal string representation (see
- * [Integer.toString]) or to a [Long] (see [toLong]).
+ * [Integer.toString]) or to a [Long] (see [toLong] and [toLongOrNull]).
  * </details>
  *
  * @since 5.1.0
@@ -669,6 +669,36 @@ public class Integer private constructor(
             throw IllegalArgumentException(message)
         }
         return this.toString().toLong()
+    }
+
+    /**
+     * Returns the [Long] representation of this integer, or returns `null`
+     * if this integer is out of range for [Long] (less than
+     * [Long.MIN_VALUE] or greater than [Long.MAX_VALUE]).
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.toLongOrNull
+     * </details>
+     * <br>
+     *
+     * This function is hidden from Java, because nullability is not explicit
+     * in its type system.
+     *
+     * See the [toLong] function for throwing an exception instead of
+     * returning `null` when this integer is out of range for [Long].
+     */
+    @JvmSynthetic
+    public fun toLongOrNull(): Long? {
+        val outOfRange: Boolean = this < fromLong(Long.MIN_VALUE) ||
+            this > fromLong(Long.MAX_VALUE)
+        return if (outOfRange) null else this.toString().toLong()
     }
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -4,7 +4,7 @@ import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.internal.number.PlatformInteger
-import org.kotools.types.number.Integer.Companion.of
+import org.kotools.types.number.Integer.Companion.fromLong
 import org.kotools.types.number.Integer.Companion.parse
 import org.kotools.types.number.Integer.Companion.parseOrNull
 import kotlin.jvm.JvmStatic
@@ -92,8 +92,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from Kotlin integer types or decimal string (see [of]
- * and [parse]).
+ * - **Creations:** Create from Kotlin integer types or decimal string (see
+ * [fromLong] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][Integer.equals] (`x == y`, `x != y`) and
  * [ordering operators][compareTo] (`x < y`, `x <= y`, `x > y`, `x >= y`).
@@ -128,7 +128,7 @@ public class Integer private constructor(
          *
          * Here's an example of calling this function from Kotlin code:
          *
-         * SAMPLE: org.kotools.types.number.IntegerSample.of
+         * SAMPLE: org.kotools.types.number.IntegerSample.fromLong
          * </details>
          *
          * <br>
@@ -139,11 +139,11 @@ public class Integer private constructor(
          *
          * Here's an example of calling this function from Java code:
          *
-         * SAMPLE: org.kotools.types.number.IntegerJavaSample.of
+         * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromLong
          * </details>
          */
         @JvmStatic
-        public fun of(value: Long): Integer {
+        public fun fromLong(value: Long): Integer {
             val delegate = PlatformInteger(value)
             return Integer(delegate)
         }
@@ -519,7 +519,7 @@ public class Integer private constructor(
      * - [rem] or [remOrNull] for returning Euclidean remainder
      */
     public operator fun div(other: Integer): Integer =
-        if (other == of(0)) this.divisionByZeroError()
+        if (other == fromLong(0)) this.divisionByZeroError()
         else Integer(this.delegate / other.delegate)
 
     /**
@@ -550,7 +550,7 @@ public class Integer private constructor(
      */
     @JvmSynthetic
     public fun divOrNull(other: Integer): Integer? =
-        if (other == of(0)) null
+        if (other == fromLong(0)) null
         else Integer(this.delegate / other.delegate)
 
     /**
@@ -589,7 +589,7 @@ public class Integer private constructor(
      * - [div] or [divOrNull] for returning Euclidean quotient
      */
     public operator fun rem(other: Integer): Integer =
-        if (other == of(0)) this.divisionByZeroError()
+        if (other == fromLong(0)) this.divisionByZeroError()
         else Integer(this.delegate % other.delegate)
 
     /**
@@ -621,7 +621,7 @@ public class Integer private constructor(
      */
     @JvmSynthetic
     public fun remOrNull(other: Integer): Integer? =
-        if (other == of(0)) null
+        if (other == fromLong(0)) null
         else Integer(this.delegate % other.delegate)
 
     private fun divisionByZeroError(): Nothing {

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -102,7 +102,7 @@ import kotlin.jvm.JvmSynthetic
  * [remainders][rem] (`x % y`), and [negate][unaryMinus] (`-x`) integers without
  * overflow.
  * - **Conversions:** Convert to its decimal string representation (see
- * [Integer.toString]) or to a [Long] (see [toLong] and [toLongOrNull]).
+ * [Integer.toString]) or to a [Long] (see [toLong]).
  * </details>
  *
  * @since 5.1.0
@@ -141,6 +141,8 @@ public class Integer private constructor(
          *
          * SAMPLE: org.kotools.types.number.IntegerJavaSample.fromLong
          * </details>
+         *
+         * @since 5.2.0
          */
         @JvmStatic
         public fun fromLong(value: Long): Integer {
@@ -661,6 +663,8 @@ public class Integer private constructor(
      *
      * See the [toLongOrNull] function for returning `null` instead of
      * throwing an exception when this integer is out of range for [Long].
+     *
+     * @since 5.2.0
      */
     public fun toLong(): Long {
         if (this < fromLong(Long.MIN_VALUE) || this > fromLong(Long.MAX_VALUE)) {
@@ -693,6 +697,8 @@ public class Integer private constructor(
      *
      * See the [toLong] function for throwing an exception instead of
      * returning `null` when this integer is out of range for [Long].
+     *
+     * @since 5.2.0
      */
     @JvmSynthetic
     public fun toLongOrNull(): Long? {

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -19,8 +19,8 @@ class IntegerSample {
 
     @Test
     fun overflowSolution() {
-        val x: Integer = Integer.of(9223372036854775807)
-        val y: Integer = Integer.of(10)
+        val x: Integer = Integer.fromLong(9223372036854775807)
+        val y: Integer = Integer.fromLong(10)
         check(x + y == Integer.parse("9223372036854775817"))
         check(-x - y == Integer.parse("-9223372036854775817"))
         check(x * y == Integer.parse("92233720368547758070"))
@@ -29,8 +29,8 @@ class IntegerSample {
     @Test
     fun divisionByZeroSolution() {
         // Common code
-        val x: Integer = Integer.of(12)
-        val y: Integer = Integer.of(0)
+        val x: Integer = Integer.fromLong(12)
+        val y: Integer = Integer.fromLong(0)
         val quotient: Result<Integer> = runCatching { x / y }
         val remainder: Result<Integer> = runCatching { x % y }
         check(quotient.exceptionOrNull() is ArithmeticException)
@@ -45,9 +45,9 @@ class IntegerSample {
     // ------------------------------- Creations -------------------------------
 
     @Test
-    fun of() {
+    fun fromLong() {
         fun createsFromLong(input: Long, expected: String) {
-            val result: Integer = Integer.of(input)
+            val result: Integer = Integer.fromLong(input)
             check("$result" == expected)
         }
 
@@ -121,13 +121,13 @@ class IntegerSample {
             check(integer.hashCode() != other.hashCode())
         }
 
-        checkEquality(integer = Integer.of(0), other = Integer.parse("-000"))
-        checkEquality(integer = Integer.of(42), other = Integer.parse("+00042"))
-        checkEquality(integer = Integer.of(-42), other = Integer.parse("-0042"))
+        checkEquality(integer = Integer.fromLong(0), other = Integer.parse("-000"))
+        checkEquality(integer = Integer.fromLong(42), other = Integer.parse("+00042"))
+        checkEquality(integer = Integer.fromLong(-42), other = Integer.parse("-0042"))
 
-        checkDiff(integer = Integer.of(0), other = Integer.of(1))
-        checkDiff(integer = Integer.of(42), other = 42)
-        checkDiff(integer = Integer.of(-42), other = null)
+        checkDiff(integer = Integer.fromLong(0), other = Integer.fromLong(1))
+        checkDiff(integer = Integer.fromLong(42), other = 42)
+        checkDiff(integer = Integer.fromLong(-42), other = null)
     }
 
     @Test
@@ -177,29 +177,29 @@ class IntegerSample {
 
     @Test
     fun euclideanDivision() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        check(quotient == Integer.of(-4))
-        check(remainder == Integer.of(1))
+        check(quotient == Integer.fromLong(-4))
+        check(remainder == Integer.fromLong(1))
         check(x == quotient * y + remainder)
     }
 
     @Test
     fun euclideanDivisionOrNull() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(2)
 
         val quotient: Integer? = x.divOrNull(y)
         val remainder: Integer? = x.remOrNull(y)
 
         checkNotNull(quotient)
         checkNotNull(remainder)
-        check(quotient == Integer.of(-4))
-        check(remainder == Integer.of(1))
+        check(quotient == Integer.fromLong(-4))
+        check(remainder == Integer.fromLong(1))
         check(x == quotient * y + remainder)
     }
 
@@ -212,11 +212,11 @@ class IntegerSample {
             check(result == expected)
         }
 
-        checkToString(input = Integer.of(0), expected = "0")
+        checkToString(input = Integer.fromLong(0), expected = "0")
         checkToString(input = Integer.parse("+0"), expected = "0")
         checkToString(input = Integer.parse("-0"), expected = "0")
         checkToString(input = Integer.parse("+42"), expected = "42")
-        checkToString(input = Integer.of(-42), expected = "-42")
+        checkToString(input = Integer.fromLong(-42), expected = "-42")
         checkToString(input = Integer.parse("00042"), expected = "42")
         checkToString(input = Integer.parse("+00042"), expected = "42")
         checkToString(input = Integer.parse("-00042"), expected = "-42")

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -206,6 +206,19 @@ class IntegerSample {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    fun toLong() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Long = x.toLong()
+        check(result == 42L)
+
+        val outOfRange: Integer =
+            Integer.fromLong(Long.MAX_VALUE) + Integer.fromLong(1)
+        val exception: Throwable? =
+            runCatching(outOfRange::toLong).exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
     fun toStringOverride() {
         fun checkToString(input: Integer, expected: String) {
             val result: String = input.toString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -219,6 +219,17 @@ class IntegerSample {
     }
 
     @Test
+    fun toLongOrNull() {
+        val x: Integer = Integer.fromLong(42)
+        val result: Long? = x.toLongOrNull()
+        check(result == 42L)
+
+        val outOfRange: Integer =
+            Integer.fromLong(Long.MAX_VALUE) + Integer.fromLong(1)
+        check(outOfRange.toLongOrNull() == null)
+    }
+
+    @Test
     fun toStringOverride() {
         fun checkToString(input: Integer, expected: String) {
             val result: String = input.toString()

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -917,6 +917,29 @@ class IntegerTest {
     }
 
     @Test
+    fun toLongOrNullIsConsistentWithToLong(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+        val integer: Integer = Integer.fromLong(value)
+
+        val actual: Long? = integer.toLongOrNull()
+
+        val expected: Long = integer.toLong()
+        assertEquals(expected, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toLongOrNullReturnsNullWhenOutOfRange() {
+        val aboveMax: Integer =
+            Integer.fromLong(Long.MAX_VALUE) + Integer.fromLong(1)
+        val belowMin: Integer =
+            Integer.fromLong(Long.MIN_VALUE) - Integer.fromLong(1)
+        listOf(aboveMax, belowMin).forEach { integer: Integer ->
+            val actual: Long? = integer.toLongOrNull()
+            assertNull(actual, message = "Input: $integer")
+        }
+    }
+
+    @Test
     fun toStringReturnsCanonicalDecimalString(): Unit = repeatTest {
         val integer: Integer = Random.integer()
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -25,10 +25,10 @@ class IntegerTest {
     // ------------------------------- Creations -------------------------------
 
     @Test
-    fun ofPreservesLongRepresentation(): Unit = repeatTest {
+    fun fromLongPreservesLongRepresentation(): Unit = repeatTest {
         val value: Long = Random.nextLong()
 
-        val integer: Integer = Integer.of(value)
+        val integer: Integer = Integer.fromLong(value)
 
         val actual: String = integer.toString()
         val expected: String = value.toString()
@@ -42,7 +42,7 @@ class IntegerTest {
         val integer: Integer = Integer.parse(value)
         val safeInteger: Integer? = Integer.parseOrNull(value)
 
-        val expected: Integer = Integer.of(0)
+        val expected: Integer = Integer.fromLong(0)
         val message = "Input: \"$value\""
         assertEquals(expected, actual = integer, message)
         assertEquals(expected, actual = safeInteger, message)
@@ -293,7 +293,7 @@ class IntegerTest {
     @Test
     fun unaryMinusIsAdditiveInverse(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val actual: Integer = x + (-x)
 
@@ -313,7 +313,7 @@ class IntegerTest {
 
     @Test
     fun unaryMinusInversesSign(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val x: Integer = Random.integerExcept(illegal = zero)
 
         val xSign: Int = x.compareTo(zero)
@@ -328,7 +328,7 @@ class IntegerTest {
 
     @Test
     fun unaryMinusOnZero() {
-        val x: Integer = Integer.of(0)
+        val x: Integer = Integer.fromLong(0)
         val actual: Integer = -x
         assertEquals(x, actual)
     }
@@ -360,7 +360,7 @@ class IntegerTest {
     @Test
     fun plusHasZeroAsIdentityElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Input: $x"
         assertEquals(x, x + zero, message)
         assertEquals(x, zero + x, message)
@@ -396,7 +396,7 @@ class IntegerTest {
     fun plusHasUniqueInverseElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
         val y: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val actual: Boolean = x == -y
 
@@ -442,7 +442,7 @@ class IntegerTest {
     @Test
     fun minusHasZeroAsRightIdentityElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Input: $x"
         assertEquals(x, x - zero, message)
     }
@@ -450,7 +450,7 @@ class IntegerTest {
     @Test
     fun minusOfSameIntegersIsZero(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Input: $x"
         assertEquals(zero, x - x, message)
     }
@@ -512,7 +512,7 @@ class IntegerTest {
     @Test
     fun timesHasOneAsIdentityElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
         val message = "Input: $x"
         assertEquals(x, x * one, message)
         assertEquals(x, one * x, message)
@@ -534,7 +534,7 @@ class IntegerTest {
     @Test
     fun timesHasZeroAsAbsorbingElement(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val message = "Input: $x"
         assertEquals(zero, x * zero, message)
@@ -583,7 +583,7 @@ class IntegerTest {
     fun timesSatisfiesCancellation(): Unit = repeatTest {
         val x: Integer = Random.integer()
         val y: Integer = Random.integer()
-        val z: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val z: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Boolean = x * z == y * z
 
@@ -627,7 +627,7 @@ class IntegerTest {
     @Test
     fun divSanityCheck() {
         val x: Integer = Integer.parse("922337203685477580700")
-        val y: Integer = Integer.of(10)
+        val y: Integer = Integer.fromLong(10)
 
         val actual: Integer = x / y
 
@@ -638,7 +638,7 @@ class IntegerTest {
     @Test
     fun divHasRightIdentity(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
 
         val actual: Integer = x / one
 
@@ -647,7 +647,7 @@ class IntegerTest {
 
     @Test
     fun divHasAbsorbingZeroDividend(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val other: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer = zero / other
@@ -657,18 +657,18 @@ class IntegerTest {
 
     @Test
     fun divOfSameIntegerIsOne(): Unit = repeatTest {
-        val x: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val x: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer = x / x
 
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
         assertEquals(expected = one, actual, message = "Input: $x")
     }
 
     @Test
     fun divSatisfiesDivisionAlgorithm(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
@@ -679,44 +679,44 @@ class IntegerTest {
 
     @Test
     fun divAndRemSanityCheckWithNegativeDividend() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        assertEquals(expected = Integer.of(-4), actual = quotient)
-        assertEquals(expected = Integer.of(1), actual = remainder)
+        assertEquals(expected = Integer.fromLong(-4), actual = quotient)
+        assertEquals(expected = Integer.fromLong(1), actual = remainder)
     }
 
     @Test
     fun divAndRemSanityCheckWithNegativeDivisor() {
-        val x: Integer = Integer.of(7)
-        val y: Integer = Integer.of(-2)
+        val x: Integer = Integer.fromLong(7)
+        val y: Integer = Integer.fromLong(-2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        assertEquals(expected = Integer.of(-3), actual = quotient)
-        assertEquals(expected = Integer.of(1), actual = remainder)
+        assertEquals(expected = Integer.fromLong(-3), actual = quotient)
+        assertEquals(expected = Integer.fromLong(1), actual = remainder)
     }
 
     @Test
     fun divAndRemSanityCheckWithNegativeOperands() {
-        val x: Integer = Integer.of(-7)
-        val y: Integer = Integer.of(-2)
+        val x: Integer = Integer.fromLong(-7)
+        val y: Integer = Integer.fromLong(-2)
 
         val quotient: Integer = x / y
         val remainder: Integer = x % y
 
-        assertEquals(expected = Integer.of(4), actual = quotient)
-        assertEquals(expected = Integer.of(1), actual = remainder)
+        assertEquals(expected = Integer.fromLong(4), actual = quotient)
+        assertEquals(expected = Integer.fromLong(1), actual = remainder)
     }
 
     @Test
     fun divIsConsistentWithTimes(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer = (x * y) / y
 
@@ -726,7 +726,7 @@ class IntegerTest {
     @Test
     fun divByZeroThrowsException(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val exception: ArithmeticException = assertFailsWith { x / zero }
 
@@ -738,7 +738,7 @@ class IntegerTest {
     @Test
     fun divOrNullSanityCheck() {
         val x: Integer = Integer.parse("922337203685477580700")
-        val y: Integer = Integer.of(10)
+        val y: Integer = Integer.fromLong(10)
 
         val actual: Integer? = x.divOrNull(y)
 
@@ -749,7 +749,7 @@ class IntegerTest {
     @Test
     fun divOrNullHasRightIdentity(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val one: Integer = Integer.of(1)
+        val one: Integer = Integer.fromLong(1)
 
         val actual: Integer? = x.divOrNull(one)
 
@@ -758,7 +758,7 @@ class IntegerTest {
 
     @Test
     fun divOrNullHasAbsorbingZeroDividend(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val other: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer? = zero.divOrNull(other)
@@ -769,7 +769,7 @@ class IntegerTest {
     @Test
     fun divOrNullIsConsistentWithDiv(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer? = x.divOrNull(y)
 
@@ -780,7 +780,7 @@ class IntegerTest {
     @Test
     fun divOrNullWithZero(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Integer.of(0)
+        val y: Integer = Integer.fromLong(0)
 
         val actual: Integer? = x.divOrNull(y)
 
@@ -789,18 +789,18 @@ class IntegerTest {
 
     @Test
     fun remSanityCheck() {
-        val x: Integer = Integer.of(42)
-        val y: Integer = Integer.of(5)
+        val x: Integer = Integer.fromLong(42)
+        val y: Integer = Integer.fromLong(5)
 
         val actual: Integer = x % y
 
-        val expected: Integer = Integer.of(2)
+        val expected: Integer = Integer.fromLong(2)
         assertEquals(expected, actual)
     }
 
     @Test
     fun remByItselfIsZero(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val x: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer = x % x
@@ -811,7 +811,7 @@ class IntegerTest {
     @Test
     fun remHasZeroForDivisibleIntegers(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val y: Integer = Random.integerExcept(illegal = zero)
 
         val actual: Integer = (x * y) % y
@@ -823,7 +823,7 @@ class IntegerTest {
     @Test
     fun remIsAlwaysNonNegative(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val y: Integer = Random.integerExcept(illegal = zero)
 
         val remainder: Integer = x % y
@@ -834,7 +834,7 @@ class IntegerTest {
     @Test
     fun remIsBoundedByAbsoluteValueOfDivisor(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val y: Integer = Random.integerExcept(illegal = zero)
 
         val remainder: Integer = x % y
@@ -846,7 +846,7 @@ class IntegerTest {
     @Test
     fun remByZeroThrowsException(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Integer.of(0)
+        val y: Integer = Integer.fromLong(0)
 
         val exception: ArithmeticException = assertFailsWith { x % y }
 
@@ -857,19 +857,19 @@ class IntegerTest {
 
     @Test
     fun remOrNullSanityCheck() {
-        val x: Integer = Integer.of(42)
-        val y: Integer = Integer.of(5)
+        val x: Integer = Integer.fromLong(42)
+        val y: Integer = Integer.fromLong(5)
 
         val actual: Integer? = x.remOrNull(y)
 
-        val expected: Integer = Integer.of(2)
+        val expected: Integer = Integer.fromLong(2)
         assertEquals(expected, actual)
     }
 
     @Test
     fun remOrNullIsConsistentWithRem(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val y: Integer = Random.integerExcept(illegal = Integer.fromLong(0))
 
         val actual: Integer? = x.remOrNull(y)
 
@@ -880,7 +880,7 @@ class IntegerTest {
     @Test
     fun remOrNullWithZeroReturnsNull(): Unit = repeatTest {
         val x: Integer = Random.integer()
-        val y: Integer = Integer.of(0)
+        val y: Integer = Integer.fromLong(0)
 
         val actual: Integer? = x.remOrNull(y)
 
@@ -898,7 +898,7 @@ class IntegerTest {
         assertTrue("\"$actual\" must not have leading plus sign (+).") {
             !actual.startsWith('+')
         }
-        if (integer == Integer.of(0)) assertEquals(expected = "0", actual)
+        if (integer == Integer.fromLong(0)) assertEquals(expected = "0", actual)
         else assertTrue("\"$actual\" must not have leading zeros.") {
             actual.first(Char::isDigit) != '0'
         }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -896,7 +896,7 @@ class IntegerTest {
 
         val actual: Long = integer.toLong()
 
-        assertEquals(expected = value, actual, message = "Input: $value")
+        assertEquals(expected = value, actual, message = "Input: $integer")
     }
 
     @Test
@@ -924,7 +924,7 @@ class IntegerTest {
         val actual: Long? = integer.toLongOrNull()
 
         val expected: Long = integer.toLong()
-        assertEquals(expected, actual, message = "Input: $value")
+        assertEquals(expected, actual, message = "Input: $integer")
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -890,6 +890,33 @@ class IntegerTest {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    fun toLongIsConsistentWithFromLong(): Unit = repeatTest {
+        val value: Long = Random.nextLong()
+        val integer: Integer = Integer.fromLong(value)
+
+        val actual: Long = integer.toLong()
+
+        assertEquals(expected = value, actual, message = "Input: $value")
+    }
+
+    @Test
+    fun toLongThrowsExceptionWhenOutOfRange() {
+        val aboveMax: Integer =
+            Integer.fromLong(Long.MAX_VALUE) + Integer.fromLong(1)
+        val belowMin: Integer =
+            Integer.fromLong(Long.MIN_VALUE) - Integer.fromLong(1)
+        listOf(aboveMax, belowMin).forEach { integer: Integer ->
+            val exception: IllegalArgumentException = assertFailsWith {
+                integer.toLong()
+            }
+            val expected: String =
+                errorMessage("Integer out of range for Long", integer)
+            val message = "Input: $integer"
+            assertEquals(expected, actual = exception.message, message)
+        }
+    }
+
+    @Test
     fun toStringReturnsCanonicalDecimalString(): Unit = repeatTest {
         val integer: Integer = Random.integer()
 

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -11,9 +11,9 @@ public class IntegerJavaSample {
     // ------------------------------- Creations -------------------------------
 
     @Test
-    void of() {
+    void fromLong() {
         final BiConsumer<Long, String> createsFromLong = (input, expected) -> {
-            final Integer result = Integer.of(input);
+            final Integer result = Integer.fromLong(input);
             final boolean check = String.valueOf(result).equals(expected);
             if (!check) throw new IllegalStateException("Check failed.");
         };
@@ -89,13 +89,13 @@ public class IntegerJavaSample {
             if (!check) throw new IllegalStateException("Check failed.");
         };
 
-        checkEquality.accept(Integer.of(0), Integer.parse("-000"));
-        checkEquality.accept(Integer.of(42), Integer.parse("+00042"));
-        checkEquality.accept(Integer.of(-42), Integer.parse("-0042"));
+        checkEquality.accept(Integer.fromLong(0), Integer.parse("-000"));
+        checkEquality.accept(Integer.fromLong(42), Integer.parse("+00042"));
+        checkEquality.accept(Integer.fromLong(-42), Integer.parse("-0042"));
 
-        checkDiff.accept(Integer.of(0), Integer.of(1));
-        checkDiff.accept(Integer.of(42), 42);
-        checkDiff.accept(Integer.of(-42), null);
+        checkDiff.accept(Integer.fromLong(0), Integer.fromLong(1));
+        checkDiff.accept(Integer.fromLong(42), 42);
+        checkDiff.accept(Integer.fromLong(-42), null);
     }
 
     @Test
@@ -149,14 +149,14 @@ public class IntegerJavaSample {
 
     @Test
     void euclideanDivision() {
-        final Integer x = Integer.of(-7);
-        final Integer y = Integer.of(2);
+        final Integer x = Integer.fromLong(-7);
+        final Integer y = Integer.fromLong(2);
 
         final Integer quotient = x.div(y);
         final Integer remainder = x.rem(y);
 
-        final boolean check = quotient.equals(Integer.of(-4))
-                && remainder.equals(Integer.of(1));
+        final boolean check = quotient.equals(Integer.fromLong(-4))
+                && remainder.equals(Integer.fromLong(1));
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
@@ -169,11 +169,11 @@ public class IntegerJavaSample {
             if (!check) throw new IllegalStateException("Check failed.");
         };
 
-        checkToString.accept(Integer.of(0), "0");
+        checkToString.accept(Integer.fromLong(0), "0");
         checkToString.accept(Integer.parse("+0"), "0");
         checkToString.accept(Integer.parse("-0"), "0");
         checkToString.accept(Integer.parse("+42"), "42");
-        checkToString.accept(Integer.of(-42), "-42");
+        checkToString.accept(Integer.fromLong(-42), "-42");
         checkToString.accept(Integer.parse("00042"), "42");
         checkToString.accept(Integer.parse("+00042"), "42");
         checkToString.accept(Integer.parse("-00042"), "-42");

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -163,6 +163,21 @@ public class IntegerJavaSample {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    void toLong() {
+        final Integer x = Integer.fromLong(42);
+        final long result = x.toLong();
+        if (result != 42L) throw new IllegalStateException("Check failed.");
+
+        final Integer outOfRange =
+                Integer.fromLong(Long.MAX_VALUE).plus(Integer.fromLong(1));
+        try {
+            outOfRange.toLong();
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
     void toStringOverride() {
         final BiConsumer<Integer, String> checkToString = (input, expected) -> {
             final boolean check = String.valueOf(input).equals(expected);


### PR DESCRIPTION
## Summary
- Renamed `Integer.Companion.of` to `fromLong`
- Added `Integer.toLong()` and `Integer.toLongOrNull()` experimental conversions
- Updated changelog

Closes #1010

Generated with [Claude Code](https://claude.ai/code)