### PR TITLE
✨ Add `NonZeroInteger` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ All notable changes to this project will be documented in this file.
   returning the `Long` representation of an `Integer`, or throwing an
   `IllegalArgumentException` (`toLong`) or returning `null`
   (`toLongOrNull`) if it's out of range for `Long`. ([#1010])
+- `NonZeroInteger` **experimental** type to `org.kotools.types.number` package,
+  representing an `Integer` other than zero. Supports creation via
+  `fromLong(Long)`, `fromInteger(Integer)`, `parse(String)` and their
+  `OrNull` variants, structural equality, arithmetic operators (unary `-`
+  and `*`), and conversions back to `Integer` and to its decimal string
+  representation. Addition and subtraction are intentionally excluded
+  because the set of non-zero integers is not closed under these operations.
+  ([#1011])
 
 ### ♻️ Changed
 
@@ -85,6 +93,7 @@ All notable changes to this project will be documented in this file.
 [#989]: https://github.com/kotools/types/issues/989
 [#990]: https://github.com/kotools/types/issues/990
 [#1010]: https://github.com/kotools/types/issues/1010
+[#1011]: https://github.com/kotools/types/issues/1011
 
 ## 🔖 Releases
 

--- a/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
+++ b/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
@@ -1,0 +1,68 @@
+# ⚖️ ADR-013: Exclusion of additive operations from `NonZeroInteger` arithmetic
+
+This document records the decision to omit addition and subtraction from the
+[`NonZeroInteger`][NonZeroInteger] type's arithmetic API.
+
+## 🤔 Context
+
+`NonZeroInteger` represents an [`Integer`][Integer] that is other than zero.
+Negation (`unaryMinus`) and multiplication (`times`) both keep results within
+this set: the negation of a non-zero integer is never zero, and the product
+of two non-zero integers is never zero either.
+
+The question that arose during design was: should `NonZeroInteger` also
+provide `plus` and `minus` operators, like [`Integer`][Integer] does?
+
+## ✅ Decision: Addition and subtraction are excluded
+
+No `plus` or `minus` operators are defined on `NonZeroInteger`. The only
+arithmetic operations provided are unary minus (`-x`) and multiplication
+(`x * y`).
+
+**Rationale:**
+
+- **The set of non-zero integers is not closed under addition or
+  subtraction.** For any non-zero integer `x`, `x + (-x) = 0` and
+  `x - x = 0`. Both operations can produce zero from two non-zero operands,
+  so their result cannot always be represented as a `NonZeroInteger`.
+- **A nullable, throwing, or widened return type would break the type's
+  contract.** Returning `NonZeroInteger?` or throwing on the zero case would
+  make `plus`/`minus` behave unlike every other arithmetic operator in this
+  codebase, where operators are total functions over their declared types.
+  Widening the return type to `Integer` would also be inconsistent: callers
+  expecting closure under arithmetic operations would have to special-case
+  `plus`/`minus` among the type's operators.
+- **Consistent with `Decimal` design.** [ADR-006][ADR-006] excludes division
+  from `Decimal` for the same underlying reason: the set of terminating
+  decimals is not closed under division. `NonZeroInteger` follows the same
+  principle — only operations that keep results within the modelled set are
+  exposed.
+- **`times` and `unaryMinus` stay because closure holds.** The product of two
+  non-zero integers is always non-zero, and the negation of a non-zero
+  integer is always non-zero, so both operations are safe to expose as total
+  functions returning `NonZeroInteger`.
+- **Explicit delegation to the caller.** Users who need addition or
+  subtraction can convert to [`Integer`][Integer] via [`toInteger`][toInteger],
+  perform the operation there, and convert back with
+  [`fromInteger`][fromInteger] (or its `OrNull` variant) if they need to
+  re-establish the non-zero invariant, making the zero case an explicit
+  decision at the call site rather than a silent one inside
+  `NonZeroInteger`.
+
+## 🔗 Consequences
+
+- The KDoc of `NonZeroInteger` documents this design choice so users are not
+  left guessing why `+` and `-` are missing compared to `Integer`.
+- The two provided operations (unary minus and `*`) are both closed over the
+  set of non-zero integers.
+- Converting to `Integer` remains the documented path for any arithmetic that
+  isn't closed under "non-zero", consistent with how `Decimal` documents
+  converting to `Double`/`BigDecimal` for division.
+
+<!----------------------------------- Links ----------------------------------->
+
+[NonZeroInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+[ADR-006]: ADR-006-decimal-division-exclusion.md
+[toInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+[fromInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt

--- a/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
+++ b/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
@@ -35,7 +35,7 @@ arithmetic operations provided are unary minus (`-x`) and multiplication
 - **Consistent with `Decimal` design.** [ADR-006][ADR-006] excludes division
   from `Decimal` for the same underlying reason: the set of terminating
   decimals is not closed under division. `NonZeroInteger` follows the same
-  principle — only operations that keep results within the modelled set are
+  principle — only operations that keep results within the modeled set are
   exposed.
 - **`times` and `unaryMinus` stay because closure holds.** The product of two
   non-zero integers is always non-zero, and the negation of a non-zero

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -20,6 +20,7 @@ rationale behind it, and its consequences.
 | [ADR-010](ADR-010-error-message-format.md)                | Error message format for `org.kotools.types`        | ✅ Accepted               |
 | [ADR-011](ADR-011-error-message-quote-escaping.md)        | String value quote escaping for `org.kotools.types` | ✅ Accepted               |
 | [ADR-012](ADR-012-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`           | ✅ Accepted               |
+| [ADR-013](ADR-013-nonzerointeger-additive-exclusion.md)   | Exclusion of additive operations from `NonZeroInteger` arithmetic | ✅ Accepted |
 
 ## 🔄 Superseding records
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -6,21 +6,21 @@ rationale behind it, and its consequences.
 
 ## 📄 Index
 
-| ADR                                                       | Title                                               | Status                   |
-|-----------------------------------------------------------|-----------------------------------------------------|--------------------------|
-| [ADR-001](ADR-001-integer-euclidean-division.md)          | Euclidean division for `Integer`                    | ✅ Accepted               |
-| [ADR-002](ADR-002-integer-value-semantics.md)             | Value semantics for `Integer` arithmetic operations | ✅ Accepted               |
-| [ADR-003](ADR-003-euclidean-division-platform-impl.md)    | Platform implementation of Euclidean division       | 🔄 Superseded by ADR-008 |
-| [ADR-004](ADR-004-decimal-scaled-integer-repr.md)         | Scaled-integer representation for `Decimal`         | ✅ Accepted               |
-| [ADR-005](ADR-005-decimal-canonical-form.md)              | Canonical form for `Decimal`                        | ✅ Accepted               |
-| [ADR-006](ADR-006-decimal-division-exclusion.md)          | Exclusion of division from `Decimal` arithmetic     | ✅ Accepted               |
-| [ADR-007](ADR-007-native-integer-sign-magnitude-repr.md)  | Sign-magnitude representation for `NativeInteger`   | ✅ Accepted               |
-| [ADR-008](ADR-008-euclidean-division-platform-impl-v2.md) | Platform implementation of Euclidean division (v2)  | ✅ Accepted               |
-| [ADR-009](ADR-009-default-serializer-serial-names.md)     | Explicit serial names for default serializers       | ✅ Accepted               |
-| [ADR-010](ADR-010-error-message-format.md)                | Error message format for `org.kotools.types`        | ✅ Accepted               |
-| [ADR-011](ADR-011-error-message-quote-escaping.md)        | String value quote escaping for `org.kotools.types` | ✅ Accepted               |
-| [ADR-012](ADR-012-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`           | ✅ Accepted               |
-| [ADR-013](ADR-013-nonzerointeger-additive-exclusion.md)   | Exclusion of additive operations from `NonZeroInteger` arithmetic | ✅ Accepted |
+| ADR                                                       | Title                                                             | Status                   |
+|-----------------------------------------------------------|-------------------------------------------------------------------|--------------------------|
+| [ADR-001](ADR-001-integer-euclidean-division.md)          | Euclidean division for `Integer`                                  | ✅ Accepted               |
+| [ADR-002](ADR-002-integer-value-semantics.md)             | Value semantics for `Integer` arithmetic operations               | ✅ Accepted               |
+| [ADR-003](ADR-003-euclidean-division-platform-impl.md)    | Platform implementation of Euclidean division                     | 🔄 Superseded by ADR-008 |
+| [ADR-004](ADR-004-decimal-scaled-integer-repr.md)         | Scaled-integer representation for `Decimal`                       | ✅ Accepted               |
+| [ADR-005](ADR-005-decimal-canonical-form.md)              | Canonical form for `Decimal`                                      | ✅ Accepted               |
+| [ADR-006](ADR-006-decimal-division-exclusion.md)          | Exclusion of division from `Decimal` arithmetic                   | ✅ Accepted               |
+| [ADR-007](ADR-007-native-integer-sign-magnitude-repr.md)  | Sign-magnitude representation for `NativeInteger`                 | ✅ Accepted               |
+| [ADR-008](ADR-008-euclidean-division-platform-impl-v2.md) | Platform implementation of Euclidean division (v2)                | ✅ Accepted               |
+| [ADR-009](ADR-009-default-serializer-serial-names.md)     | Explicit serial names for default serializers                     | ✅ Accepted               |
+| [ADR-010](ADR-010-error-message-format.md)                | Error message format for `org.kotools.types`                      | ✅ Accepted               |
+| [ADR-011](ADR-011-error-message-quote-escaping.md)        | String value quote escaping for `org.kotools.types`               | ✅ Accepted               |
+| [ADR-012](ADR-012-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`                         | ✅ Accepted               |
+| [ADR-013](ADR-013-nonzerointeger-additive-exclusion.md)   | Exclusion of additive operations from `NonZeroInteger` arithmetic | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/HashSeed.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/HashSeed.kt
@@ -7,7 +7,10 @@ public enum class HashSeed {
     Decimal,
 
     /** Hash seed for the `Integer` type. */
-    Integer;
+    Integer,
+
+    /** Hash seed for the `NonZeroInteger` type. */
+    NonZeroInteger;
 
     /** Returns a hash seed for this entry. */
     public fun toInt(): Int = this.name.hashCode()

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -413,11 +413,14 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final field Companion Lorg/kotools/types/number/NonZeroInteger$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun toString ()Ljava/lang/String;
 }
 
 public final class org/kotools/types/number/NonZeroInteger$Companion {
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonZeroInteger;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -414,6 +414,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
+	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun toString ()Ljava/lang/String;
 }
 
@@ -422,5 +423,7 @@ public final class org/kotools/types/number/NonZeroInteger$Companion {
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
 	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -417,6 +417,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun times (Lorg/kotools/types/number/NonZeroInteger;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/NonZeroInteger;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -417,6 +417,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun hashCode ()I
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 }
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -412,8 +412,10 @@ public final class org/kotools/types/number/Integer$Companion {
 public final class org/kotools/types/number/NonZeroInteger {
 	public static final field Companion Lorg/kotools/types/number/NonZeroInteger$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun hashCode ()I
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun toString ()Ljava/lang/String;
 }

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -419,6 +419,7 @@ public final class org/kotools/types/number/NonZeroInteger {
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonZeroInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
+	public final fun unaryMinus ()Lorg/kotools/types/number/NonZeroInteger;
 }
 
 public final class org/kotools/types/number/NonZeroInteger$Companion {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -409,3 +409,15 @@ public final class org/kotools/types/number/Integer$Companion {
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 }
 
+public final class org/kotools/types/number/NonZeroInteger {
+	public static final field Companion Lorg/kotools/types/number/NonZeroInteger$Companion;
+	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final fun toString ()Ljava/lang/String;
+}
+
+public final class org/kotools/types/number/NonZeroInteger$Companion {
+	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonZeroInteger;
+}
+

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -3,6 +3,12 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
+import org.kotools.types.number.NonZeroInteger.Companion.fromInteger
+import org.kotools.types.number.NonZeroInteger.Companion.fromIntegerOrNull
+import org.kotools.types.number.NonZeroInteger.Companion.fromLong
+import org.kotools.types.number.NonZeroInteger.Companion.fromLongOrNull
+import org.kotools.types.number.NonZeroInteger.Companion.parse
+import org.kotools.types.number.NonZeroInteger.Companion.parseOrNull
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
@@ -33,9 +39,9 @@ import kotlin.jvm.JvmSynthetic
  * @since 5.2.0
  */
 @ExperimentalKotoolsTypesApi
-public class NonZeroInteger private constructor(
-    private val value: Integer
-) {
+public class NonZeroInteger private constructor(private val value: Integer) {
+    // --------------------------- Factory functions ---------------------------
+
     /** Contains class-level declarations for the [NonZeroInteger] type. */
     public companion object {
         /**
@@ -69,8 +75,10 @@ public class NonZeroInteger private constructor(
          * throwing an exception when [value] is `0`.
          */
         @JvmStatic
-        public fun fromLong(value: Long): NonZeroInteger =
-            fromInteger(Integer.of(value))
+        public fun fromLong(value: Long): NonZeroInteger {
+            val integer: Integer = Integer.fromLong(value)
+            return this.fromInteger(integer)
+        }
 
         /**
          * Returns a [NonZeroInteger] representing the specified [value], or
@@ -95,8 +103,10 @@ public class NonZeroInteger private constructor(
          * returning `null` when [value] is `0`.
          */
         @JvmSynthetic
-        public fun fromLongOrNull(value: Long): NonZeroInteger? =
-            fromIntegerOrNull(Integer.of(value))
+        public fun fromLongOrNull(value: Long): NonZeroInteger? {
+            val integer: Integer = Integer.fromLong(value)
+            return this.fromIntegerOrNull(integer)
+        }
 
         /**
          * Returns a [NonZeroInteger] representing the specified [value], or
@@ -130,7 +140,11 @@ public class NonZeroInteger private constructor(
          */
         @JvmStatic
         public fun fromInteger(value: Integer): NonZeroInteger {
-            if (value == Integer.of(0)) zeroIntegerError(value)
+            if (value == Integer.fromLong(0)) {
+                val message: String =
+                    errorMessage("Integer other than zero", value)
+                throw IllegalArgumentException(message)
+            }
             return NonZeroInteger(value)
         }
 
@@ -158,7 +172,8 @@ public class NonZeroInteger private constructor(
          */
         @JvmSynthetic
         public fun fromIntegerOrNull(value: Integer): NonZeroInteger? =
-            if (value == Integer.of(0)) null else NonZeroInteger(value)
+            if (value == Integer.fromLong(0)) null
+            else NonZeroInteger(value)
 
         /**
          * Returns a [NonZeroInteger] representing the number described by
@@ -198,7 +213,7 @@ public class NonZeroInteger private constructor(
         @JvmStatic
         public fun parse(value: String): NonZeroInteger {
             val integer: Integer = Integer.parse(value)
-            return fromInteger(integer)
+            return this.fromInteger(integer)
         }
 
         /**
@@ -230,12 +245,7 @@ public class NonZeroInteger private constructor(
         @JvmSynthetic
         public fun parseOrNull(value: String): NonZeroInteger? {
             val integer: Integer = Integer.parseOrNull(value) ?: return null
-            return fromIntegerOrNull(integer)
-        }
-
-        private fun zeroIntegerError(value: Integer): Nothing {
-            val message: String = errorMessage("Integer other than zero", value)
-            throw IllegalArgumentException(message)
+            return this.fromIntegerOrNull(integer)
         }
     }
 

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -141,8 +141,7 @@ public class NonZeroInteger private constructor(private val value: Integer) {
         @JvmStatic
         public fun fromInteger(value: Integer): NonZeroInteger {
             if (value == Integer.fromLong(0)) {
-                val message: String =
-                    errorMessage("Integer other than zero", value)
+                val message: String = errorMessage("Zero integer")
                 throw IllegalArgumentException(message)
             }
             return NonZeroInteger(value)

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -21,8 +21,11 @@ import kotlin.jvm.JvmSynthetic
  * (see [fromLong], [fromInteger] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][NonZeroInteger.equals] (`x == y`, `x != y`).
- * - **Arithmetic operations:** [Negate][unaryMinus] (`-x`) non-zero
- * integers, always producing another non-zero integer.
+ * - **Arithmetic operations:** [Negate][unaryMinus] (`-x`) or
+ * [multiply][times] (`x * y`) non-zero integers, always producing another
+ * non-zero integer. Addition and subtraction are intentionally absent,
+ * because the set of non-zero integers isn't closed under these operations
+ * (e.g., `x + (-x) = 0`).
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]),
  * or to its decimal string representation (see [NonZeroInteger.toString]).
  * </details>
@@ -335,6 +338,34 @@ public class NonZeroInteger private constructor(
      */
     public operator fun unaryMinus(): NonZeroInteger =
         NonZeroInteger(-this.value)
+
+    /**
+     * Multiplies this integer by the [other] one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.times
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.times
+     * </details>
+     */
+    public operator fun times(other: NonZeroInteger): NonZeroInteger =
+        NonZeroInteger(this.value * other.value)
 
     // ------------------------------ Conversions ------------------------------
 

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -1,0 +1,130 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.errorMessage
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
+
+/**
+ * Represents an [Integer] that is other than zero.
+ *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Key features</b>
+ * </summary>
+ *
+ * ### Key features
+ *
+ * - **Creations:** Create from an [Integer] (see [fromInteger]).
+ * - **Conversions:** Convert to its decimal string representation (see
+ * [NonZeroInteger.toString]).
+ * </details>
+ *
+ * @since 5.2.0
+ */
+@ExperimentalKotoolsTypesApi
+public class NonZeroInteger private constructor(
+    private val value: Integer
+) {
+    /** Contains class-level declarations for the [NonZeroInteger] type. */
+    public companion object {
+        /**
+         * Returns a [NonZeroInteger] representing the specified [value], or
+         * throws an [IllegalArgumentException] if [value] represents zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromInteger
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.fromInteger
+         * </details>
+         * <br>
+         *
+         * See the [fromIntegerOrNull] function for returning `null` instead
+         * of throwing an exception when [value] represents zero.
+         */
+        @JvmStatic
+        public fun fromInteger(value: Integer): NonZeroInteger {
+            if (value == Integer.of(0)) zeroIntegerError(value)
+            return NonZeroInteger(value)
+        }
+
+        /**
+         * Returns a [NonZeroInteger] representing the specified [value], or
+         * returns `null` if [value] represents zero.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromInteger
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromInteger] function for throwing an exception instead
+         * of returning `null` when [value] represents zero.
+         */
+        @JvmSynthetic
+        public fun fromIntegerOrNull(value: Integer): NonZeroInteger? =
+            if (value == Integer.of(0)) null else NonZeroInteger(value)
+
+        private fun zeroIntegerError(value: Integer): Nothing {
+            val message: String = errorMessage("Integer other than zero", value)
+            throw IllegalArgumentException(message)
+        }
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    /**
+     * Returns the decimal string representation of this integer, delegating
+     * to [Integer.toString].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.toStringOverride
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.toStringOverride
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun toString(): String = this.value.toString()
+}

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -21,8 +21,8 @@ import kotlin.jvm.JvmSynthetic
  * (see [fromLong], [fromInteger] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][NonZeroInteger.equals] (`x == y`, `x != y`).
- * - **Conversions:** Convert to its decimal string representation (see
- * [NonZeroInteger.toString]).
+ * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]),
+ * or to its decimal string representation (see [NonZeroInteger.toString]).
  * </details>
  *
  * @since 5.2.0
@@ -305,6 +305,33 @@ public class NonZeroInteger private constructor(
     }
 
     // ------------------------------ Conversions ------------------------------
+
+    /**
+     * Returns this integer as an [Integer].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.toInteger
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.toInteger
+     * </details>
+     */
+    public fun toInteger(): Integer = this.value
 
     /**
      * Returns the decimal string representation of this integer, delegating

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -1,6 +1,7 @@
 package org.kotools.types.number
 
 import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -18,6 +19,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * - **Creations:** Create from a [Long], an [Integer], or a decimal string
  * (see [fromLong], [fromInteger] and [parse]).
+ * - **Comparisons:** Compare integers using
+ * [structural equality][NonZeroInteger.equals] (`x == y`, `x != y`).
  * - **Conversions:** Convert to its decimal string representation (see
  * [NonZeroInteger.toString]).
  * </details>
@@ -229,6 +232,76 @@ public class NonZeroInteger private constructor(
             val message: String = errorMessage("Integer other than zero", value)
             throw IllegalArgumentException(message)
         }
+    }
+
+    // ------------------------------ Comparisons ------------------------------
+
+    /**
+     * Returns `true` if the [other] object is a [NonZeroInteger] representing
+     * the same numeric value as this one, or returns `false` otherwise.
+     *
+     * This function follows the contract of [Any.equals].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.structuralEquality
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun equals(other: Any?): Boolean =
+        other is NonZeroInteger && this.value == other.value
+
+    /**
+     * Returns a hash code value for this integer.
+     *
+     * This function follows the contract of [Any.hashCode], with an
+     * additional property: if two instances of [NonZeroInteger] are not
+     * equal, then calling this function on these objects must produce
+     * different hash codes.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.structuralEquality
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun hashCode(): Int {
+        val seed: Int = HashSeed.NonZeroInteger.toInt()
+        return 31 * seed + this.value.hashCode()
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -16,7 +16,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from an [Integer] (see [fromInteger]).
+ * - **Creations:** Create from a [Long] or an [Integer] (see [fromLong] and
+ * [fromInteger]).
  * - **Conversions:** Convert to its decimal string representation (see
  * [NonZeroInteger.toString]).
  * </details>
@@ -29,6 +30,66 @@ public class NonZeroInteger private constructor(
 ) {
     /** Contains class-level declarations for the [NonZeroInteger] type. */
     public companion object {
+        /**
+         * Returns a [NonZeroInteger] representing the specified [value], or
+         * throws an [IllegalArgumentException] if [value] is `0`.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromLong
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.fromLong
+         * </details>
+         * <br>
+         *
+         * See the [fromLongOrNull] function for returning `null` instead of
+         * throwing an exception when [value] is `0`.
+         */
+        @JvmStatic
+        public fun fromLong(value: Long): NonZeroInteger =
+            fromInteger(Integer.of(value))
+
+        /**
+         * Returns a [NonZeroInteger] representing the specified [value], or
+         * returns `null` if [value] is `0`.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.fromLong
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromLong] function for throwing an exception instead of
+         * returning `null` when [value] is `0`.
+         */
+        @JvmSynthetic
+        public fun fromLongOrNull(value: Long): NonZeroInteger? =
+            fromIntegerOrNull(Integer.of(value))
+
         /**
          * Returns a [NonZeroInteger] representing the specified [value], or
          * throws an [IllegalArgumentException] if [value] represents zero.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -21,6 +21,8 @@ import kotlin.jvm.JvmSynthetic
  * (see [fromLong], [fromInteger] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][NonZeroInteger.equals] (`x == y`, `x != y`).
+ * - **Arithmetic operations:** [Negate][unaryMinus] (`-x`) non-zero
+ * integers, always producing another non-zero integer.
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]),
  * or to its decimal string representation (see [NonZeroInteger.toString]).
  * </details>
@@ -303,6 +305,36 @@ public class NonZeroInteger private constructor(
         val seed: Int = HashSeed.NonZeroInteger.toInt()
         return 31 * seed + this.value.hashCode()
     }
+
+    // ------------------------- Arithmetic operations -------------------------
+
+    /**
+     * Returns the negative of this integer.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.unaryMinus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.unaryMinus
+     * </details>
+     */
+    public operator fun unaryMinus(): NonZeroInteger =
+        NonZeroInteger(-this.value)
 
     // ------------------------------ Conversions ------------------------------
 

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -16,8 +16,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from a [Long] or an [Integer] (see [fromLong] and
- * [fromInteger]).
+ * - **Creations:** Create from a [Long], an [Integer], or a decimal string
+ * (see [fromLong], [fromInteger] and [parse]).
  * - **Conversions:** Convert to its decimal string representation (see
  * [NonZeroInteger.toString]).
  * </details>
@@ -151,6 +151,79 @@ public class NonZeroInteger private constructor(
         @JvmSynthetic
         public fun fromIntegerOrNull(value: Integer): NonZeroInteger? =
             if (value == Integer.of(0)) null else NonZeroInteger(value)
+
+        /**
+         * Returns a [NonZeroInteger] representing the number described by
+         * [value], or throws [NumberFormatException] if [value] doesn't
+         * represent an integer, or [IllegalArgumentException] if [value]
+         * represents zero.
+         *
+         * See the [Integer.Companion.parse] function for the grammar of a
+         * valid integer representation.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.parsing
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerJavaSample.parsing
+         * </details>
+         * <br>
+         *
+         * See the [parseOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid or zero [value].
+         */
+        @JvmStatic
+        public fun parse(value: String): NonZeroInteger {
+            val integer: Integer = Integer.parse(value)
+            return fromInteger(integer)
+        }
+
+        /**
+         * Returns a [NonZeroInteger] representing the number described by
+         * [value], or returns `null` if [value] doesn't represent an integer
+         * or represents zero.
+         *
+         * See the [Integer.Companion.parse] function for the grammar of a
+         * valid integer representation.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonZeroIntegerSample.parsing
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [parse] function for throwing an exception instead of
+         * returning `null` in case of invalid or zero [value].
+         */
+        @JvmSynthetic
+        public fun parseOrNull(value: String): NonZeroInteger? {
+            val integer: Integer = Integer.parseOrNull(value) ?: return null
+            return fromIntegerOrNull(integer)
+        }
 
         private fun zeroIntegerError(value: Integer): Nothing {
             val message: String = errorMessage("Integer other than zero", value)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -2,6 +2,7 @@ package org.kotools.types
 
 import org.kotools.types.number.Decimal
 import org.kotools.types.number.Integer
+import org.kotools.types.number.NonZeroInteger
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.random.nextLong
@@ -93,6 +94,23 @@ internal fun Random.integerExcept(illegal: Integer): Integer {
 internal fun Random.positiveInteger(): Integer {
     val value: String = this.positiveIntegerString()
     return Integer.parse(value)
+}
+
+// --------------------------- Random non-zero integers ------------------------
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.nonZeroInteger(): NonZeroInteger {
+    val integer: Integer = this.integerExcept(illegal = Integer.of(0))
+    return NonZeroInteger.fromInteger(integer)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.nonZeroIntegerExcept(
+    illegal: NonZeroInteger
+): NonZeroInteger {
+    var candidate: NonZeroInteger = this.nonZeroInteger()
+    while (candidate == illegal) candidate = this.nonZeroInteger()
+    return candidate
 }
 
 // ------------------------------ Random strings -------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -100,7 +100,8 @@ internal fun Random.positiveInteger(): Integer {
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 internal fun Random.nonZeroInteger(): NonZeroInteger {
-    val integer: Integer = this.integerExcept(illegal = Integer.of(0))
+    val zero: Integer = Integer.fromLong(0)
+    val integer: Integer = this.integerExcept(zero)
     return NonZeroInteger.fromInteger(integer)
 }
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -1,0 +1,35 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import kotlin.test.Test
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class NonZeroIntegerSample {
+    // ------------------------------- Creations -------------------------------
+
+    @Test
+    fun fromInteger() {
+        val value: Integer = Integer.of(42)
+        val result: NonZeroInteger = NonZeroInteger.fromInteger(value)
+        check("$result" == "42")
+
+        val zero: Integer = Integer.of(0)
+        val exception: Throwable? =
+            runCatching { NonZeroInteger.fromInteger(zero) }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+
+        val safeResult: NonZeroInteger? =
+            NonZeroInteger.fromIntegerOrNull(zero)
+        check(safeResult == null)
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toStringOverride() {
+        val value: Integer = Integer.of(-42)
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(value)
+        val result: String = nonZeroInteger.toString()
+        check(result == "-42")
+    }
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -53,6 +53,20 @@ class NonZeroIntegerSample {
         check(safeResult == null)
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEquality() {
+        val x: NonZeroInteger = NonZeroInteger.fromLong(42)
+        val y: NonZeroInteger = NonZeroInteger.parse("+00042")
+        check(x == y)
+        check(x.hashCode() == y.hashCode())
+
+        val z: NonZeroInteger = NonZeroInteger.fromLong(-42)
+        check(x != z)
+        check(x.hashCode() != z.hashCode())
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -8,6 +8,19 @@ class NonZeroIntegerSample {
     // ------------------------------- Creations -------------------------------
 
     @Test
+    fun fromLong() {
+        val result: NonZeroInteger = NonZeroInteger.fromLong(42)
+        check("$result" == "42")
+
+        val exception: Throwable? =
+            runCatching { NonZeroInteger.fromLong(0) }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+
+        val safeResult: NonZeroInteger? = NonZeroInteger.fromLongOrNull(0)
+        check(safeResult == null)
+    }
+
+    @Test
     fun fromInteger() {
         val value: Integer = Integer.of(42)
         val result: NonZeroInteger = NonZeroInteger.fromInteger(value)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -21,6 +21,23 @@ class NonZeroIntegerSample {
     }
 
     @Test
+    fun parsing() {
+        val result: NonZeroInteger = NonZeroInteger.parse("+00042")
+        check("$result" == "42")
+
+        val invalid: Throwable? =
+            runCatching { NonZeroInteger.parse("3.14") }.exceptionOrNull()
+        check(invalid is NumberFormatException)
+
+        val zero: Throwable? =
+            runCatching { NonZeroInteger.parse("0") }.exceptionOrNull()
+        check(zero is IllegalArgumentException)
+
+        check(NonZeroInteger.parseOrNull("3.14") == null)
+        check(NonZeroInteger.parseOrNull("0") == null)
+    }
+
+    @Test
     fun fromInteger() {
         val value: Integer = Integer.of(42)
         val result: NonZeroInteger = NonZeroInteger.fromInteger(value)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -77,6 +77,16 @@ class NonZeroIntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun times() {
+        val x: NonZeroInteger = NonZeroInteger.fromLong(99999999999999999)
+        val y: NonZeroInteger = NonZeroInteger.fromLong(10)
+        val result: NonZeroInteger = x * y
+        val expected: NonZeroInteger =
+            NonZeroInteger.parse("999999999999999990")
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -21,6 +21,22 @@ class NonZeroIntegerSample {
     }
 
     @Test
+    fun fromInteger() {
+        val value: Integer = Integer.fromLong(42)
+        val result: NonZeroInteger = NonZeroInteger.fromInteger(value)
+        check("$result" == "42")
+
+        val zero: Integer = Integer.fromLong(0)
+        val exception: Throwable? =
+            runCatching { NonZeroInteger.fromInteger(zero) }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+
+        val safeResult: NonZeroInteger? =
+            NonZeroInteger.fromIntegerOrNull(zero)
+        check(safeResult == null)
+    }
+
+    @Test
     fun parsing() {
         val result: NonZeroInteger = NonZeroInteger.parse("+00042")
         check("$result" == "42")
@@ -35,22 +51,6 @@ class NonZeroIntegerSample {
 
         check(NonZeroInteger.parseOrNull("3.14") == null)
         check(NonZeroInteger.parseOrNull("0") == null)
-    }
-
-    @Test
-    fun fromInteger() {
-        val value: Integer = Integer.fromLong(42)
-        val result: NonZeroInteger = NonZeroInteger.fromInteger(value)
-        check("$result" == "42")
-
-        val zero: Integer = Integer.fromLong(0)
-        val exception: Throwable? =
-            runCatching { NonZeroInteger.fromInteger(zero) }.exceptionOrNull()
-        check(exception is IllegalArgumentException)
-
-        val safeResult: NonZeroInteger? =
-            NonZeroInteger.fromIntegerOrNull(zero)
-        check(safeResult == null)
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -5,7 +5,7 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonZeroIntegerSample {
-    // ------------------------------- Creations -------------------------------
+    // --------------------------- Factory functions ---------------------------
 
     @Test
     fun fromLong() {
@@ -39,11 +39,11 @@ class NonZeroIntegerSample {
 
     @Test
     fun fromInteger() {
-        val value: Integer = Integer.of(42)
+        val value: Integer = Integer.fromLong(42)
         val result: NonZeroInteger = NonZeroInteger.fromInteger(value)
         check("$result" == "42")
 
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val exception: Throwable? =
             runCatching { NonZeroInteger.fromInteger(zero) }.exceptionOrNull()
         check(exception is IllegalArgumentException)
@@ -93,12 +93,12 @@ class NonZeroIntegerSample {
     fun toInteger() {
         val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromLong(42)
         val result: Integer = nonZeroInteger.toInteger()
-        check(result == Integer.of(42))
+        check(result == Integer.fromLong(42))
     }
 
     @Test
     fun toStringOverride() {
-        val value: Integer = Integer.of(-42)
+        val value: Integer = Integer.fromLong(-42)
         val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(value)
         val result: String = nonZeroInteger.toString()
         check(result == "-42")

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -70,6 +70,13 @@ class NonZeroIntegerSample {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    fun toInteger() {
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromLong(42)
+        val result: Integer = nonZeroInteger.toInteger()
+        check(result == Integer.of(42))
+    }
+
+    @Test
     fun toStringOverride() {
         val value: Integer = Integer.of(-42)
         val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(value)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerSample.kt
@@ -67,6 +67,16 @@ class NonZeroIntegerSample {
         check(x.hashCode() != z.hashCode())
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    fun unaryMinus() {
+        val x: NonZeroInteger = NonZeroInteger.fromLong(42)
+        val result: NonZeroInteger = -x
+        val expected: NonZeroInteger = NonZeroInteger.fromLong(-42)
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -1,0 +1,58 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.integerExcept
+import org.kotools.types.internal.errorMessage
+import org.kotools.types.repeatTest
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class NonZeroIntegerTest {
+    // ------------------------------- Creations -------------------------------
+
+    @Test
+    fun fromIntegerPreservesValue(): Unit = repeatTest {
+        val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
+
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.fromIntegerOrNull(integer)
+
+        val expected: String = integer.toString()
+        val message = "Input: $integer"
+        assertEquals(expected, actual = nonZeroInteger.toString(), message)
+        assertEquals(expected, actual = safeNonZeroInteger.toString(), message)
+    }
+
+    @Test
+    fun fromIntegerFailsWithZero() {
+        val zero: Integer = Integer.of(0)
+
+        val exception: IllegalArgumentException = assertFailsWith {
+            NonZeroInteger.fromInteger(zero)
+        }
+        val expected: String = errorMessage("Integer other than zero", zero)
+        assertEquals(expected, actual = exception.message)
+
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.fromIntegerOrNull(zero)
+        assertNull(safeNonZeroInteger)
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toStringDelegatesToInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
+
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
+
+        val actual: String = nonZeroInteger.toString()
+        val expected: String = integer.toString()
+        assertEquals(expected, actual, message = "Input: $integer")
+    }
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -5,6 +5,7 @@ import org.kotools.types.integerExcept
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.repeatTest
 import kotlin.random.Random
+import kotlin.random.nextLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -13,6 +14,34 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonZeroIntegerTest {
     // ------------------------------- Creations -------------------------------
+
+    @Test
+    fun fromLongPreservesValue(): Unit = repeatTest {
+        val value: Long = Random.nextLong(1..Long.MAX_VALUE)
+            .let { if (Random.nextBoolean()) it else -it }
+
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromLong(value)
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.fromLongOrNull(value)
+
+        val expected: String = value.toString()
+        val message = "Input: $value"
+        assertEquals(expected, actual = nonZeroInteger.toString(), message)
+        assertEquals(expected, actual = safeNonZeroInteger.toString(), message)
+    }
+
+    @Test
+    fun fromLongFailsWithZero() {
+        val exception: IllegalArgumentException =
+            assertFailsWith { NonZeroInteger.fromLong(0) }
+        val expected: String =
+            errorMessage("Integer other than zero", Integer.of(0))
+        assertEquals(expected, actual = exception.message)
+
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.fromLongOrNull(0)
+        assertNull(safeNonZeroInteger)
+    }
 
     @Test
     fun fromIntegerPreservesValue(): Unit = repeatTest {

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonZeroIntegerTest {
-    // ------------------------------- Creations -------------------------------
+    // --------------------------- Factory functions ---------------------------
 
     @Test
     fun fromLongPreservesValue(): Unit = repeatTest {
@@ -44,7 +44,7 @@ class NonZeroIntegerTest {
         val exception: IllegalArgumentException =
             assertFailsWith { NonZeroInteger.fromLong(0) }
         val expected: String =
-            errorMessage("Integer other than zero", Integer.of(0))
+            errorMessage("Integer other than zero", Integer.fromLong(0))
         assertEquals(expected, actual = exception.message)
 
         val safeNonZeroInteger: NonZeroInteger? =
@@ -75,7 +75,10 @@ class NonZeroIntegerTest {
         assertFailsWith<NumberFormatException>(message = "Input: \"$value\"") {
             NonZeroInteger.parse(value)
         }
-        assertNull(NonZeroInteger.parseOrNull(value), message = "Input: \"$value\"")
+        assertNull(
+            NonZeroInteger.parseOrNull(value),
+            message = "Input: \"$value\""
+        )
     }
 
     @Test
@@ -86,15 +89,20 @@ class NonZeroIntegerTest {
             message = "Input: \"$value\""
         ) { NonZeroInteger.parse(value) }
         val expected: String =
-            errorMessage("Integer other than zero", Integer.of(0))
+            errorMessage("Integer other than zero", Integer.fromLong(0))
         assertEquals(expected, actual = exception.message)
 
-        assertNull(NonZeroInteger.parseOrNull(value), message = "Input: \"$value\"")
+        assertNull(
+            NonZeroInteger.parseOrNull(value),
+            message = "Input: \"$value\""
+        )
     }
 
     @Test
     fun fromIntegerPreservesValue(): Unit = repeatTest {
-        val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val integer: Integer = Random.integerExcept(
+            illegal = Integer.fromLong(0)
+        )
 
         val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
         val safeNonZeroInteger: NonZeroInteger? =
@@ -108,7 +116,7 @@ class NonZeroIntegerTest {
 
     @Test
     fun fromIntegerFailsWithZero() {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
 
         val exception: IllegalArgumentException = assertFailsWith {
             NonZeroInteger.fromInteger(zero)
@@ -225,7 +233,7 @@ class NonZeroIntegerTest {
 
     @Test
     fun unaryMinusInversesSign(): Unit = repeatTest {
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val x: NonZeroInteger = Random.nonZeroInteger()
 
         val xSign: Int = x.toInteger()
@@ -293,9 +301,9 @@ class NonZeroIntegerTest {
         val x: NonZeroInteger = Random.nonZeroInteger()
         val y: NonZeroInteger = Random.nonZeroInteger()
 
-        val result: NonZeroInteger = x * y // Throws if the result is zero.
+        val result: NonZeroInteger = x * y
 
-        val zero: Integer = Integer.of(0)
+        val zero: Integer = Integer.fromLong(0)
         val message = "Inputs: x = $x, y = $y"
         assertNotEquals(zero, result.toInteger(), message)
     }
@@ -314,7 +322,9 @@ class NonZeroIntegerTest {
 
     @Test
     fun toIntegerRoundTripsWithFromInteger(): Unit = repeatTest {
-        val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val integer: Integer = Random.integerExcept(
+            illegal = Integer.fromLong(0)
+        )
 
         val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
         val actual: Integer = nonZeroInteger.toInteger()
@@ -324,7 +334,9 @@ class NonZeroIntegerTest {
 
     @Test
     fun toStringDelegatesToInteger(): Unit = repeatTest {
-        val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
+        val integer: Integer = Random.integerExcept(
+            illegal = Integer.fromLong(0)
+        )
 
         val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -53,6 +53,37 @@ class NonZeroIntegerTest {
     }
 
     @Test
+    fun fromIntegerPreservesValue(): Unit = repeatTest {
+        val integer: Integer = Random.integerExcept(
+            illegal = Integer.fromLong(0)
+        )
+
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.fromIntegerOrNull(integer)
+
+        val expected: String = integer.toString()
+        val message = "Input: $integer"
+        assertEquals(expected, actual = nonZeroInteger.toString(), message)
+        assertEquals(expected, actual = safeNonZeroInteger.toString(), message)
+    }
+
+    @Test
+    fun fromIntegerFailsWithZero() {
+        val zero: Integer = Integer.fromLong(0)
+
+        val exception: IllegalArgumentException = assertFailsWith {
+            NonZeroInteger.fromInteger(zero)
+        }
+        val expected: String = errorMessage("Integer other than zero", zero)
+        assertEquals(expected, actual = exception.message)
+
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.fromIntegerOrNull(zero)
+        assertNull(safeNonZeroInteger)
+    }
+
+    @Test
     fun parsingRemovesLeadingZeros(): Unit = repeatTest {
         val value: String = Random.nonZeroIntegerStringWithLeadingZeros()
 
@@ -96,37 +127,6 @@ class NonZeroIntegerTest {
             NonZeroInteger.parseOrNull(value),
             message = "Input: \"$value\""
         )
-    }
-
-    @Test
-    fun fromIntegerPreservesValue(): Unit = repeatTest {
-        val integer: Integer = Random.integerExcept(
-            illegal = Integer.fromLong(0)
-        )
-
-        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
-        val safeNonZeroInteger: NonZeroInteger? =
-            NonZeroInteger.fromIntegerOrNull(integer)
-
-        val expected: String = integer.toString()
-        val message = "Input: $integer"
-        assertEquals(expected, actual = nonZeroInteger.toString(), message)
-        assertEquals(expected, actual = safeNonZeroInteger.toString(), message)
-    }
-
-    @Test
-    fun fromIntegerFailsWithZero() {
-        val zero: Integer = Integer.fromLong(0)
-
-        val exception: IllegalArgumentException = assertFailsWith {
-            NonZeroInteger.fromInteger(zero)
-        }
-        val expected: String = errorMessage("Integer other than zero", zero)
-        assertEquals(expected, actual = exception.message)
-
-        val safeNonZeroInteger: NonZeroInteger? =
-            NonZeroInteger.fromIntegerOrNull(zero)
-        assertNull(safeNonZeroInteger)
     }
 
     // ------------------------------ Comparisons ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -214,6 +214,50 @@ class NonZeroIntegerTest {
         assertFalse(hashEquality, message)
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    fun unaryMinusIsInvolutory(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val actual: NonZeroInteger = -(-x)
+        assertEquals(x, actual, message = "Input: $x")
+    }
+
+    @Test
+    fun unaryMinusInversesSign(): Unit = repeatTest {
+        val zero: Integer = Integer.of(0)
+        val x: NonZeroInteger = Random.nonZeroInteger()
+
+        val xSign: Int = x.toInteger()
+            .compareTo(zero)
+        val negXSign: Int = (-x).toInteger()
+            .compareTo(zero)
+
+        val message = "Input: $x"
+        when {
+            xSign > 0 -> assertTrue(negXSign < 0, message)
+            else -> assertTrue(negXSign > 0, message)
+        }
+    }
+
+    @Test
+    fun unaryMinusOnPositiveInteger() {
+        val x: NonZeroInteger = NonZeroInteger.parse("99999999999999999999")
+        val actual: NonZeroInteger = -x
+        val expected: NonZeroInteger =
+            NonZeroInteger.parse("-99999999999999999999")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun unaryMinusOnNegativeInteger() {
+        val x: NonZeroInteger = NonZeroInteger.parse("-99999999999999999999")
+        val actual: NonZeroInteger = -x
+        val expected: NonZeroInteger =
+            NonZeroInteger.parse("99999999999999999999")
+        assertEquals(expected, actual)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -4,6 +4,8 @@ import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.integerExcept
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.nonIntegerString
+import org.kotools.types.nonZeroInteger
+import org.kotools.types.nonZeroIntegerExcept
 import org.kotools.types.nonZeroIntegerStringWithLeadingZeros
 import org.kotools.types.repeatTest
 import org.kotools.types.zeroString
@@ -12,7 +14,10 @@ import kotlin.random.nextLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
@@ -114,6 +119,99 @@ class NonZeroIntegerTest {
         val safeNonZeroInteger: NonZeroInteger? =
             NonZeroInteger.fromIntegerOrNull(zero)
         assertNull(safeNonZeroInteger)
+    }
+
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEqualityPassesWithSameValues(): Unit = repeatTest {
+        val nonZeroInteger: NonZeroInteger = Random.nonZeroInteger()
+        val other: NonZeroInteger =
+            NonZeroInteger.parse("$nonZeroInteger")
+
+        val message = "Inputs: this = $nonZeroInteger, other = $other"
+        assertEquals(nonZeroInteger, other, message)
+        assertEquals(nonZeroInteger.hashCode(), other.hashCode(), message)
+    }
+
+    @Test
+    fun structuralEqualityIsReflexive(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+
+        val message = "Input: $x"
+        assertSame(x, x, message)
+        assertEquals(x.hashCode(), x.hashCode(), message)
+    }
+
+    @Test
+    fun structuralEqualityIsSymmetrical(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val y: NonZeroInteger = NonZeroInteger.parse("$x")
+
+        val xHashCode: Int = x.hashCode()
+        val yHashCode: Int = y.hashCode()
+
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(x, y, message)
+        assertEquals(xHashCode, yHashCode, message)
+
+        assertEquals(y, x, message)
+        assertEquals(yHashCode, xHashCode, message)
+    }
+
+    @Test
+    fun structuralEqualityIsTransitive(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val y: NonZeroInteger = NonZeroInteger.parse("$x")
+        val z: NonZeroInteger = NonZeroInteger.parse("$y")
+
+        val xHashCode: Int = x.hashCode()
+        val yHashCode: Int = y.hashCode()
+        val zHashCode: Int = z.hashCode()
+
+        val message = "Inputs: x = $x, y = $y, z = $z"
+        assertEquals(x, y, message)
+        assertEquals(xHashCode, yHashCode, message)
+
+        assertEquals(y, z, message)
+        assertEquals(yHashCode, zHashCode, message)
+
+        assertEquals(x, z, message)
+        assertEquals(xHashCode, zHashCode, message)
+    }
+
+    @Test
+    fun structuralEqualityFailsWithDifferentValues(): Unit = repeatTest {
+        val nonZeroInteger: NonZeroInteger = Random.nonZeroInteger()
+        val other: NonZeroInteger =
+            Random.nonZeroIntegerExcept(illegal = nonZeroInteger)
+
+        val message = "Inputs: this = $nonZeroInteger, other = $other"
+        assertNotEquals(nonZeroInteger, other, message)
+        assertNotEquals(nonZeroInteger.hashCode(), other.hashCode(), message)
+    }
+
+    @Test
+    fun structuralEqualityFailsWithDifferentTypes(): Unit = repeatTest {
+        val nonZeroInteger: NonZeroInteger = Random.nonZeroInteger()
+        val other: Any = nonZeroInteger.toString()
+
+        val message = "Inputs: this = $nonZeroInteger, other = \"$other\""
+        assertNotEquals(nonZeroInteger, other, message)
+        assertNotEquals(nonZeroInteger.hashCode(), other.hashCode(), message)
+    }
+
+    @Test
+    fun structuralEqualityFailsWithNull(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val y: Any? = null
+
+        val equality: Boolean = x == y
+        val hashEquality: Boolean = x.hashCode() == y.hashCode()
+
+        val message = "Structural equality must fail with null."
+        assertFalse(equality, message)
+        assertFalse(hashEquality, message)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -3,13 +3,17 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.integerExcept
 import org.kotools.types.internal.errorMessage
+import org.kotools.types.nonIntegerString
+import org.kotools.types.nonZeroIntegerStringWithLeadingZeros
 import org.kotools.types.repeatTest
+import org.kotools.types.zeroString
 import kotlin.random.Random
 import kotlin.random.nextLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonZeroIntegerTest {
@@ -41,6 +45,46 @@ class NonZeroIntegerTest {
         val safeNonZeroInteger: NonZeroInteger? =
             NonZeroInteger.fromLongOrNull(0)
         assertNull(safeNonZeroInteger)
+    }
+
+    @Test
+    fun parsingRemovesLeadingZeros(): Unit = repeatTest {
+        val value: String = Random.nonZeroIntegerStringWithLeadingZeros()
+
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.parse(value)
+        val safeNonZeroInteger: NonZeroInteger? =
+            NonZeroInteger.parseOrNull(value)
+
+        val actual: String = nonZeroInteger.toString()
+        val message = "Input: \"$value\""
+        assertTrue(
+            "\"$actual\" must not have leading zeros (input: \"$value\")."
+        ) { actual.first(Char::isDigit) != '0' }
+        assertEquals(actual, safeNonZeroInteger.toString(), message)
+    }
+
+    @Test
+    fun parsingFailsWithNonintegerString(): Unit = repeatTest {
+        val value: String = Random.nonIntegerString()
+
+        assertFailsWith<NumberFormatException>(message = "Input: \"$value\"") {
+            NonZeroInteger.parse(value)
+        }
+        assertNull(NonZeroInteger.parseOrNull(value), message = "Input: \"$value\"")
+    }
+
+    @Test
+    fun parsingFailsWithZero(): Unit = repeatTest {
+        val value: String = Random.zeroString()
+
+        val exception: IllegalArgumentException = assertFailsWith(
+            message = "Input: \"$value\""
+        ) { NonZeroInteger.parse(value) }
+        val expected: String =
+            errorMessage("Integer other than zero", Integer.of(0))
+        assertEquals(expected, actual = exception.message)
+
+        assertNull(NonZeroInteger.parseOrNull(value), message = "Input: \"$value\"")
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -43,8 +43,7 @@ class NonZeroIntegerTest {
     fun fromLongFailsWithZero() {
         val exception: IllegalArgumentException =
             assertFailsWith { NonZeroInteger.fromLong(0) }
-        val expected: String =
-            errorMessage("Integer other than zero", Integer.fromLong(0))
+        val expected: String = errorMessage("Zero integer")
         assertEquals(expected, actual = exception.message)
 
         val safeNonZeroInteger: NonZeroInteger? =
@@ -75,7 +74,7 @@ class NonZeroIntegerTest {
         val exception: IllegalArgumentException = assertFailsWith {
             NonZeroInteger.fromInteger(zero)
         }
-        val expected: String = errorMessage("Integer other than zero", zero)
+        val expected: String = errorMessage("Zero integer")
         assertEquals(expected, actual = exception.message)
 
         val safeNonZeroInteger: NonZeroInteger? =
@@ -119,8 +118,7 @@ class NonZeroIntegerTest {
         val exception: IllegalArgumentException = assertFailsWith(
             message = "Input: \"$value\""
         ) { NonZeroInteger.parse(value) }
-        val expected: String =
-            errorMessage("Integer other than zero", Integer.fromLong(0))
+        val expected: String = errorMessage("Zero integer")
         assertEquals(expected, actual = exception.message)
 
         assertNull(

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -217,6 +217,16 @@ class NonZeroIntegerTest {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    fun toIntegerRoundTripsWithFromInteger(): Unit = repeatTest {
+        val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
+
+        val nonZeroInteger: NonZeroInteger = NonZeroInteger.fromInteger(integer)
+        val actual: Integer = nonZeroInteger.toInteger()
+
+        assertEquals(integer, actual, message = "Input: $integer")
+    }
+
+    @Test
     fun toStringDelegatesToInteger(): Unit = repeatTest {
         val integer: Integer = Random.integerExcept(illegal = Integer.of(0))
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonZeroIntegerTest.kt
@@ -258,6 +258,58 @@ class NonZeroIntegerTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun timesIsCommutative(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val y: NonZeroInteger = Random.nonZeroInteger()
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(x * y, y * x, message)
+    }
+
+    @Test
+    fun timesHasOneAsIdentityElement(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val one: NonZeroInteger = NonZeroInteger.fromLong(1)
+        val message = "Input: $x"
+        assertEquals(x, x * one, message)
+        assertEquals(x, one * x, message)
+    }
+
+    @Test
+    fun timesIsAssociative(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val y: NonZeroInteger = Random.nonZeroInteger()
+        val z: NonZeroInteger = Random.nonZeroInteger()
+
+        val actual: NonZeroInteger = (x * y) * z
+
+        val expected: NonZeroInteger = x * (y * z)
+        val message = "Inputs: x = $x, y = $y, z = $z"
+        assertEquals(expected, actual, message)
+    }
+
+    @Test
+    fun timesIsAlwaysNonZero(): Unit = repeatTest {
+        val x: NonZeroInteger = Random.nonZeroInteger()
+        val y: NonZeroInteger = Random.nonZeroInteger()
+
+        val result: NonZeroInteger = x * y // Throws if the result is zero.
+
+        val zero: Integer = Integer.of(0)
+        val message = "Inputs: x = $x, y = $y"
+        assertNotEquals(zero, result.toInteger(), message)
+    }
+
+    @Test
+    fun timesSanityCheck() {
+        val x: NonZeroInteger = NonZeroInteger.parse("99999999999999999999")
+        val y: NonZeroInteger = NonZeroInteger.parse("10")
+        val actual: NonZeroInteger = x * y
+        val expected: NonZeroInteger =
+            NonZeroInteger.parse("999999999999999999990")
+        assertEquals(expected, actual)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NewClassNamingConvention")
 public class NonZeroIntegerJavaSample {
-    // ------------------------------- Creations -------------------------------
+    // --------------------------- Factory functions ---------------------------
 
     @Test
     void fromLong() {
@@ -40,12 +40,12 @@ public class NonZeroIntegerJavaSample {
 
     @Test
     void fromInteger() {
-        final Integer value = Integer.of(42);
+        final Integer value = Integer.fromLong(42);
         final NonZeroInteger result = NonZeroInteger.fromInteger(value);
         final boolean check = String.valueOf(result).equals("42");
         if (!check) throw new IllegalStateException("Check failed.");
 
-        final Integer zero = Integer.of(0);
+        final Integer zero = Integer.fromLong(0);
         try {
             NonZeroInteger.fromInteger(zero);
             throw new IllegalStateException("Check failed.");
@@ -96,13 +96,13 @@ public class NonZeroIntegerJavaSample {
     void toInteger() {
         final NonZeroInteger nonZeroInteger = NonZeroInteger.fromLong(42L);
         final Integer result = nonZeroInteger.toInteger();
-        final boolean check = result.equals(Integer.of(42L));
+        final boolean check = result.equals(Integer.fromLong(42L));
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
     @Test
     void toStringOverride() {
-        final Integer value = Integer.of(-42);
+        final Integer value = Integer.fromLong(-42);
         final NonZeroInteger nonZeroInteger = NonZeroInteger.fromInteger(value);
         final String result = String.valueOf(nonZeroInteger);
         final boolean check = result.equals("-42");

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -7,6 +7,19 @@ public class NonZeroIntegerJavaSample {
     // ------------------------------- Creations -------------------------------
 
     @Test
+    void fromLong() {
+        final NonZeroInteger result = NonZeroInteger.fromLong(42L);
+        final boolean check = String.valueOf(result).equals("42");
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        try {
+            NonZeroInteger.fromLong(0L);
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
     void fromInteger() {
         final Integer value = Integer.of(42);
         final NonZeroInteger result = NonZeroInteger.fromInteger(value);

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -53,6 +53,21 @@ public class NonZeroIntegerJavaSample {
         }
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    void structuralEquality() {
+        final NonZeroInteger x = NonZeroInteger.fromLong(42L);
+        final NonZeroInteger y = NonZeroInteger.parse("+00042");
+        final boolean equality = x.equals(y) && x.hashCode() == y.hashCode();
+        if (!equality) throw new IllegalStateException("Check failed.");
+
+        final NonZeroInteger z = NonZeroInteger.fromLong(-42L);
+        final boolean inequality =
+                !x.equals(z) && x.hashCode() != z.hashCode();
+        if (!inequality) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -20,6 +20,21 @@ public class NonZeroIntegerJavaSample {
     }
 
     @Test
+    void fromInteger() {
+        final Integer value = Integer.fromLong(42);
+        final NonZeroInteger result = NonZeroInteger.fromInteger(value);
+        final boolean check = String.valueOf(result).equals("42");
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        final Integer zero = Integer.fromLong(0);
+        try {
+            NonZeroInteger.fromInteger(zero);
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
     void parsing() {
         final NonZeroInteger result = NonZeroInteger.parse("+00042");
         final boolean check = String.valueOf(result).equals("42");
@@ -33,21 +48,6 @@ public class NonZeroIntegerJavaSample {
 
         try {
             NonZeroInteger.parse("0");
-            throw new IllegalStateException("Check failed.");
-        } catch (IllegalArgumentException ignored) {
-        }
-    }
-
-    @Test
-    void fromInteger() {
-        final Integer value = Integer.fromLong(42);
-        final NonZeroInteger result = NonZeroInteger.fromInteger(value);
-        final boolean check = String.valueOf(result).equals("42");
-        if (!check) throw new IllegalStateException("Check failed.");
-
-        final Integer zero = Integer.fromLong(0);
-        try {
-            NonZeroInteger.fromInteger(zero);
             throw new IllegalStateException("Check failed.");
         } catch (IllegalArgumentException ignored) {
         }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -79,6 +79,17 @@ public class NonZeroIntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void times() {
+        final NonZeroInteger x = NonZeroInteger.fromLong(99999999999999999L);
+        final NonZeroInteger y = NonZeroInteger.fromLong(10L);
+        final NonZeroInteger result = x.times(y);
+        final NonZeroInteger expected =
+                NonZeroInteger.parse("999999999999999990");
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -1,0 +1,34 @@
+package org.kotools.types.number;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NewClassNamingConvention")
+public class NonZeroIntegerJavaSample {
+    // ------------------------------- Creations -------------------------------
+
+    @Test
+    void fromInteger() {
+        final Integer value = Integer.of(42);
+        final NonZeroInteger result = NonZeroInteger.fromInteger(value);
+        final boolean check = String.valueOf(result).equals("42");
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        final Integer zero = Integer.of(0);
+        try {
+            NonZeroInteger.fromInteger(zero);
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    void toStringOverride() {
+        final Integer value = Integer.of(-42);
+        final NonZeroInteger nonZeroInteger = NonZeroInteger.fromInteger(value);
+        final String result = String.valueOf(nonZeroInteger);
+        final boolean check = result.equals("-42");
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+}

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -20,6 +20,25 @@ public class NonZeroIntegerJavaSample {
     }
 
     @Test
+    void parsing() {
+        final NonZeroInteger result = NonZeroInteger.parse("+00042");
+        final boolean check = String.valueOf(result).equals("42");
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        try {
+            NonZeroInteger.parse("3.14");
+            throw new IllegalStateException("Check failed.");
+        } catch (NumberFormatException ignored) {
+        }
+
+        try {
+            NonZeroInteger.parse("0");
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
     void fromInteger() {
         final Integer value = Integer.of(42);
         final NonZeroInteger result = NonZeroInteger.fromInteger(value);

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -71,6 +71,14 @@ public class NonZeroIntegerJavaSample {
     // ------------------------------ Conversions ------------------------------
 
     @Test
+    void toInteger() {
+        final NonZeroInteger nonZeroInteger = NonZeroInteger.fromLong(42L);
+        final Integer result = nonZeroInteger.toInteger();
+        final boolean check = result.equals(Integer.of(42L));
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
+    @Test
     void toStringOverride() {
         final Integer value = Integer.of(-42);
         final NonZeroInteger nonZeroInteger = NonZeroInteger.fromInteger(value);

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonZeroIntegerJavaSample.java
@@ -68,6 +68,17 @@ public class NonZeroIntegerJavaSample {
         if (!inequality) throw new IllegalStateException("Check failed.");
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    void unaryMinus() {
+        final NonZeroInteger x = NonZeroInteger.fromLong(42L);
+        final NonZeroInteger result = x.unaryMinus();
+        final NonZeroInteger expected = NonZeroInteger.fromLong(-42L);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test


### PR DESCRIPTION
## Summary

Adds the `NonZeroInteger` experimental type to the `org.kotools.types.number` package, representing an `Integer` other than zero.

- Creation via `fromLong`, `fromInteger`, `parse`, and their `OrNull` variants
- Structural equality (`equals`/`hashCode`)
- Arithmetic: `unaryMinus` and `times` (addition/subtraction intentionally excluded, see ADR-013)
- Conversions: `toInteger` and `toString`

Closes #1011

🤖 Generated with [Claude Code](https://claude.ai/code)