### PR TITLE
✨ Add NonPositiveInteger type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ adheres to its own [versioning strategy][versioning-strategy].
 - `NonNegativeInteger` **experimental** class to `org.kotools.types.number`
   package, representing an `Integer` that is greater than or equal to zero.
   (module: `types`, ref: [#998])
+- `NonPositiveInteger` **experimental** class to `org.kotools.types.number`
+  package, representing an `Integer` that is less than or equal to zero.
+  (module: `types`, ref: [#1013])
 - `Decimal` **experimental** class to `org.kotools.types.number` package,
   representing mathematical decimal numbers with exact arithmetic. (module:
   `types`, ref: [#925] originally suggested by [@CLOVIS-AI])
@@ -158,3 +161,4 @@ adheres to its own [versioning strategy][versioning-strategy].
 [#998]: https://github.com/kotools/types/issues/998
 [#1010]: https://github.com/kotools/types/issues/1010
 [#1011]: https://github.com/kotools/types/issues/1011
+[#1013]: https://github.com/kotools/types/issues/1013

--- a/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/HashSeed.kt
+++ b/subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/HashSeed.kt
@@ -12,6 +12,9 @@ public enum class HashSeed {
     /** Hash seed for the `NonNegativeInteger` type. */
     NonNegativeInteger,
 
+    /** Hash seed for the `NonPositiveInteger` type. */
+    NonPositiveInteger,
+
     /** Hash seed for the `NonZeroInteger` type. */
     NonZeroInteger;
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -441,6 +441,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public final fun hashCode ()I
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
+	public final fun toString ()Ljava/lang/String;
 }
 
 public final class org/kotools/types/number/NonPositiveInteger$Companion {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -436,12 +436,14 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public static final field Companion Lorg/kotools/types/number/NonPositiveInteger$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
+	public static final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 }
 
 public final class org/kotools/types/number/NonPositiveInteger$Companion {
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
 }
 
 public final class org/kotools/types/number/NonZeroInteger {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -447,6 +447,7 @@ public final class org/kotools/types/number/NonPositiveInteger$Companion {
 	public final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
 	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 }
 
 public final class org/kotools/types/number/NonZeroInteger {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -437,6 +437,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
+	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 }
 
@@ -445,6 +446,7 @@ public final class org/kotools/types/number/NonPositiveInteger$Companion {
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
 	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 }
 
 public final class org/kotools/types/number/NonZeroInteger {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -441,6 +441,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 
 public final class org/kotools/types/number/NonPositiveInteger$Companion {
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 }
 
 public final class org/kotools/types/number/NonZeroInteger {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -444,6 +444,7 @@ public final class org/kotools/types/number/NonPositiveInteger$Companion {
 	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final synthetic fun fromIntegerOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
+	public final synthetic fun fromLongOrNull (J)Lorg/kotools/types/number/NonPositiveInteger;
 }
 
 public final class org/kotools/types/number/NonZeroInteger {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -432,6 +432,17 @@ public final class org/kotools/types/number/NonNegativeInteger$Companion {
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/NonNegativeInteger;
 }
 
+public final class org/kotools/types/number/NonPositiveInteger {
+	public static final field Companion Lorg/kotools/types/number/NonPositiveInteger$Companion;
+	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun toInteger ()Lorg/kotools/types/number/Integer;
+}
+
+public final class org/kotools/types/number/NonPositiveInteger$Companion {
+	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
+}
+
 public final class org/kotools/types/number/NonZeroInteger {
 	public static final field Companion Lorg/kotools/types/number/NonZeroInteger$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -435,8 +435,10 @@ public final class org/kotools/types/number/NonNegativeInteger$Companion {
 public final class org/kotools/types/number/NonPositiveInteger {
 	public static final field Companion Lorg/kotools/types/number/NonPositiveInteger$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun hashCode ()I
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 }

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -1,6 +1,7 @@
 package org.kotools.types.number
 
 import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
@@ -18,6 +19,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * - **Creations:** Create from a [Long], an [Integer], or a decimal string
  * (see [fromLong], [fromInteger] and [parse]).
+ * - **Comparisons:** Compare integers using
+ * [structural equality][NonPositiveInteger.equals] (`x == y`, `x != y`).
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]).
  * </details>
  *
@@ -235,6 +238,77 @@ public class NonPositiveInteger private constructor(
             val integer: Integer = Integer.parseOrNull(value) ?: return null
             return this.fromIntegerOrNull(integer)
         }
+    }
+
+    // ------------------------------ Comparisons ------------------------------
+
+    /**
+     * Returns `true` if the [other] object is a [NonPositiveInteger]
+     * representing the same numeric value as this one, or returns `false`
+     * otherwise.
+     *
+     * This function follows the contract of [Any.equals].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.structuralEquality
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun equals(other: Any?): Boolean =
+        other is NonPositiveInteger && this.value == other.value
+
+    /**
+     * Returns a hash code value for this integer.
+     *
+     * This function follows the contract of [Any.hashCode], with an
+     * additional property: if two instances of [NonPositiveInteger] are not
+     * equal, then calling this function on these objects must produce
+     * different hash codes.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.structuralEquality
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.structuralEquality
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun hashCode(): Int {
+        val seed: Int = HashSeed.NonPositiveInteger.toInt()
+        return 31 * seed + this.value.hashCode()
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -21,7 +21,9 @@ import kotlin.jvm.JvmSynthetic
  * (see [fromLong], [fromInteger] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][NonPositiveInteger.equals] (`x == y`, `x != y`).
- * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]).
+ * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]),
+ * or to its decimal string representation (see
+ * [NonPositiveInteger.toString]).
  * </details>
  *
  * @since 5.2.0
@@ -339,4 +341,33 @@ public class NonPositiveInteger private constructor(
      * </details>
      */
     public fun toInteger(): Integer = this.value
+
+    /**
+     * Returns the decimal string representation of this integer, delegating
+     * to [Integer.toString].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.toStringOverride
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.toStringOverride
+     * </details>
+     */
+    @Suppress("RedundantModalityModifier")
+    final override fun toString(): String = this.value.toString()
 }

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -16,7 +16,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from an [Integer] (see [fromInteger]).
+ * - **Creations:** Create from a [Long] or an [Integer] (see [fromLong] and
+ * [fromInteger]).
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]).
  * </details>
  *
@@ -30,6 +31,38 @@ public class NonPositiveInteger private constructor(
 
     /** Contains class-level declarations for the [NonPositiveInteger] type. */
     public companion object {
+        /**
+         * Returns a [NonPositiveInteger] representing the specified [value],
+         * or throws an [IllegalArgumentException] if [value] is positive.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.fromLong
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.fromLong
+         * </details>
+         */
+        @JvmStatic
+        public fun fromLong(value: Long): NonPositiveInteger {
+            val integer: Integer = Integer.fromLong(value)
+            return this.fromInteger(integer)
+        }
+
         /**
          * Returns a [NonPositiveInteger] representing the specified [value],
          * or throws an [IllegalArgumentException] if [value] is positive.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -16,8 +16,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from a [Long] or an [Integer] (see [fromLong] and
- * [fromInteger]).
+ * - **Creations:** Create from a [Long], an [Integer], or a decimal string
+ * (see [fromLong], [fromInteger] and [parse]).
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]).
  * </details>
  *
@@ -161,6 +161,47 @@ public class NonPositiveInteger private constructor(
         public fun fromIntegerOrNull(value: Integer): NonPositiveInteger? {
             val zero: Integer = Integer.fromLong(0)
             return if (value > zero) null else NonPositiveInteger(value)
+        }
+
+        /**
+         * Returns a [NonPositiveInteger] representing the number described
+         * by [value], or throws [NumberFormatException] if [value] doesn't
+         * represent an integer, or [IllegalArgumentException] if [value]
+         * represents a positive integer.
+         *
+         * See the [Integer.Companion.parse] function for the grammar of a
+         * valid integer representation.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.parsing
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.parsing
+         * </details>
+         * <br>
+         *
+         * See the [parseOrNull] function for returning `null` instead of
+         * throwing an exception in case of invalid or positive [value].
+         */
+        @JvmStatic
+        public fun parse(value: String): NonPositiveInteger {
+            val integer: Integer = Integer.parse(value)
+            return this.fromInteger(integer)
         }
     }
 

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -203,6 +203,38 @@ public class NonPositiveInteger private constructor(
             val integer: Integer = Integer.parse(value)
             return this.fromInteger(integer)
         }
+
+        /**
+         * Returns a [NonPositiveInteger] representing the number described
+         * by [value], or returns `null` if [value] doesn't represent an
+         * integer or represents a positive integer.
+         *
+         * See the [Integer.Companion.parse] function for the grammar of a
+         * valid integer representation.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.parsing
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [parse] function for throwing an exception instead of
+         * returning `null` in case of invalid or positive [value].
+         */
+        @JvmSynthetic
+        public fun parseOrNull(value: String): NonPositiveInteger? {
+            val integer: Integer = Integer.parseOrNull(value) ?: return null
+            return this.fromIntegerOrNull(integer)
+        }
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -3,6 +3,7 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.errorMessage
 import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Represents an [Integer] that is less than or equal to zero.
@@ -54,6 +55,10 @@ public class NonPositiveInteger private constructor(
          *
          * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.fromInteger
          * </details>
+         * <br>
+         *
+         * See the [fromIntegerOrNull] function for returning `null` instead
+         * of throwing an exception when [value] is positive.
          */
         @JvmStatic
         public fun fromInteger(value: Integer): NonPositiveInteger {
@@ -63,6 +68,34 @@ public class NonPositiveInteger private constructor(
                 throw IllegalArgumentException(message)
             }
             return NonPositiveInteger(value)
+        }
+
+        /**
+         * Returns a [NonPositiveInteger] representing the specified [value],
+         * or returns `null` if [value] is positive.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.fromInteger
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromInteger] function for throwing an exception instead
+         * of returning `null` when [value] is positive.
+         */
+        @JvmSynthetic
+        public fun fromIntegerOrNull(value: Integer): NonPositiveInteger? {
+            val zero: Integer = Integer.fromLong(0)
+            return if (value > zero) null else NonPositiveInteger(value)
         }
     }
 

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -56,11 +56,43 @@ public class NonPositiveInteger private constructor(
          *
          * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.fromLong
          * </details>
+         * <br>
+         *
+         * See the [fromLongOrNull] function for returning `null` instead of
+         * throwing an exception when [value] is positive.
          */
         @JvmStatic
         public fun fromLong(value: Long): NonPositiveInteger {
             val integer: Integer = Integer.fromLong(value)
             return this.fromInteger(integer)
+        }
+
+        /**
+         * Returns a [NonPositiveInteger] representing the specified [value],
+         * or returns `null` if [value] is positive.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.fromLong
+         * </details>
+         * <br>
+         *
+         * This function is hidden from Java, because nullability is not
+         * explicit in its type system.
+         *
+         * See the [fromLong] function for throwing an exception instead of
+         * returning `null` when [value] is positive.
+         */
+        @JvmSynthetic
+        public fun fromLongOrNull(value: Long): NonPositiveInteger? {
+            val integer: Integer = Integer.fromLong(value)
+            return this.fromIntegerOrNull(integer)
         }
 
         /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -1,0 +1,97 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.errorMessage
+import kotlin.jvm.JvmStatic
+
+/**
+ * Represents an [Integer] that is less than or equal to zero.
+ *
+ * <br>
+ * <details>
+ * <summary>
+ *     <b>Key features</b>
+ * </summary>
+ *
+ * ### Key features
+ *
+ * - **Creations:** Create from an [Integer] (see [fromInteger]).
+ * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]).
+ * </details>
+ *
+ * @since 5.2.0
+ */
+@ExperimentalKotoolsTypesApi
+public class NonPositiveInteger private constructor(
+    private val value: Integer
+) {
+    // --------------------------- Factory functions ---------------------------
+
+    /** Contains class-level declarations for the [NonPositiveInteger] type. */
+    public companion object {
+        /**
+         * Returns a [NonPositiveInteger] representing the specified [value],
+         * or throws an [IllegalArgumentException] if [value] is positive.
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.fromInteger
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.fromInteger
+         * </details>
+         */
+        @JvmStatic
+        public fun fromInteger(value: Integer): NonPositiveInteger {
+            val zero: Integer = Integer.fromLong(0)
+            if (value > zero) {
+                val message: String = errorMessage("Positive integer", value)
+                throw IllegalArgumentException(message)
+            }
+            return NonPositiveInteger(value)
+        }
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    /**
+     * Returns this integer as an [Integer].
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.toInteger
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.toInteger
+     * </details>
+     */
+    public fun toInteger(): Integer = this.value
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/TestingSupport.kt
@@ -3,6 +3,7 @@ package org.kotools.types
 import org.kotools.types.number.Decimal
 import org.kotools.types.number.Integer
 import org.kotools.types.number.NonNegativeInteger
+import org.kotools.types.number.NonPositiveInteger
 import org.kotools.types.number.NonZeroInteger
 import kotlin.random.Random
 import kotlin.random.nextInt
@@ -131,6 +132,25 @@ internal fun Random.nonNegativeIntegerExcept(
 ): NonNegativeInteger {
     var candidate: NonNegativeInteger = this.nonNegativeInteger()
     while (candidate == illegal) candidate = this.nonNegativeInteger()
+    return candidate
+}
+
+// ----------------------- Random non-positive integers -----------------------
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.nonPositiveInteger(): NonPositiveInteger {
+    val zero: Integer = Integer.fromLong(0)
+    val integer: Integer = this.integer()
+        .let { if (it > zero) -it else it }
+    return NonPositiveInteger.fromInteger(integer)
+}
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+internal fun Random.nonPositiveIntegerExcept(
+    illegal: NonPositiveInteger
+): NonPositiveInteger {
+    var candidate: NonPositiveInteger = this.nonPositiveInteger()
+    while (candidate == illegal) candidate = this.nonPositiveInteger()
     return candidate
 }
 

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -15,6 +15,10 @@ class NonPositiveIntegerSample {
         val exception: Throwable? =
             runCatching { NonPositiveInteger.fromLong(1) }.exceptionOrNull()
         check(exception is IllegalArgumentException)
+
+        val safeResult: NonPositiveInteger? =
+            NonPositiveInteger.fromLongOrNull(1)
+        check(safeResult == null)
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -55,6 +55,22 @@ class NonPositiveIntegerSample {
         check(NonPositiveInteger.parseOrNull("1") == null)
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEquality() {
+        val value: Integer = Integer.fromLong(-42)
+        val x: NonPositiveInteger = NonPositiveInteger.fromInteger(value)
+        val y: NonPositiveInteger = NonPositiveInteger.fromInteger(value)
+        check(x == y)
+        check(x.hashCode() == y.hashCode())
+
+        val other: Integer = Integer.fromLong(-7)
+        val z: NonPositiveInteger = NonPositiveInteger.fromInteger(other)
+        check(x != z)
+        check(x.hashCode() != z.hashCode())
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -81,4 +81,13 @@ class NonPositiveIntegerSample {
         val result: Integer = nonPositiveInteger.toInteger()
         check(result == value)
     }
+
+    @Test
+    fun toStringOverride() {
+        val value: Integer = Integer.fromLong(-42)
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(value)
+        val result: String = nonPositiveInteger.toString()
+        check(result == "-42")
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -38,6 +38,20 @@ class NonPositiveIntegerSample {
         check(safeResult == null)
     }
 
+    @Test
+    fun parsing() {
+        val result: NonPositiveInteger = NonPositiveInteger.parse("-00042")
+        check(result.toInteger() == Integer.fromLong(-42))
+
+        val invalid: Throwable? =
+            runCatching { NonPositiveInteger.parse("3.14") }.exceptionOrNull()
+        check(invalid is NumberFormatException)
+
+        val positive: Throwable? =
+            runCatching { NonPositiveInteger.parse("1") }.exceptionOrNull()
+        check(positive is IllegalArgumentException)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -18,6 +18,10 @@ class NonPositiveIntegerSample {
             NonPositiveInteger.fromInteger(positive)
         }.exceptionOrNull()
         check(exception is IllegalArgumentException)
+
+        val safeResult: NonPositiveInteger? =
+            NonPositiveInteger.fromIntegerOrNull(positive)
+        check(safeResult == null)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -50,6 +50,9 @@ class NonPositiveIntegerSample {
         val positive: Throwable? =
             runCatching { NonPositiveInteger.parse("1") }.exceptionOrNull()
         check(positive is IllegalArgumentException)
+
+        check(NonPositiveInteger.parseOrNull("3.14") == null)
+        check(NonPositiveInteger.parseOrNull("1") == null)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -1,0 +1,33 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import kotlin.test.Test
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class NonPositiveIntegerSample {
+    // --------------------------- Factory functions ---------------------------
+
+    @Test
+    fun fromInteger() {
+        val value: Integer = Integer.fromLong(-42)
+        val result: NonPositiveInteger = NonPositiveInteger.fromInteger(value)
+        check(result.toInteger() == value)
+
+        val positive: Integer = Integer.fromLong(1)
+        val exception: Throwable? = runCatching {
+            NonPositiveInteger.fromInteger(positive)
+        }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toInteger() {
+        val value: Integer = Integer.fromLong(-42)
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(value)
+        val result: Integer = nonPositiveInteger.toInteger()
+        check(result == value)
+    }
+}

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -8,6 +8,16 @@ class NonPositiveIntegerSample {
     // --------------------------- Factory functions ---------------------------
 
     @Test
+    fun fromLong() {
+        val result: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
+        check(result.toInteger() == Integer.fromLong(-42))
+
+        val exception: Throwable? =
+            runCatching { NonPositiveInteger.fromLong(1) }.exceptionOrNull()
+        check(exception is IllegalArgumentException)
+    }
+
+    @Test
     fun fromInteger() {
         val value: Integer = Integer.fromLong(-42)
         val result: NonPositiveInteger = NonPositiveInteger.fromInteger(value)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -9,10 +9,30 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonPositiveIntegerTest {
     // --------------------------- Factory functions ---------------------------
+
+    @Test
+    fun fromIntegerPreservesValue(): Unit = repeatTest {
+        val integer: Integer = Random.nonPositiveInteger()
+            .toInteger()
+
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(integer)
+        val safeNonPositiveInteger: NonPositiveInteger? =
+            NonPositiveInteger.fromIntegerOrNull(integer)
+
+        val message = "Input: $integer"
+        assertEquals(integer, actual = nonPositiveInteger.toInteger(), message)
+        assertEquals(
+            integer,
+            actual = safeNonPositiveInteger?.toInteger(),
+            message
+        )
+    }
 
     @Test
     fun fromIntegerFailsWithPositiveValue(): Unit = repeatTest {
@@ -23,6 +43,10 @@ class NonPositiveIntegerTest {
         ) { NonPositiveInteger.fromInteger(integer) }
         val expected: String = errorMessage("Positive integer", integer)
         assertEquals(expected, actual = exception.message)
+
+        val safeNonPositiveInteger: NonPositiveInteger? =
+            NonPositiveInteger.fromIntegerOrNull(integer)
+        assertNull(safeNonPositiveInteger, message = "Input: $integer")
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -22,12 +22,20 @@ class NonPositiveIntegerTest {
 
         val nonPositiveInteger: NonPositiveInteger =
             NonPositiveInteger.fromLong(value)
+        val safeNonPositiveInteger: NonPositiveInteger? =
+            NonPositiveInteger.fromLongOrNull(value)
 
         val expected: Integer = Integer.fromLong(value)
+        val message = "Input: $value"
         assertEquals(
             expected,
             actual = nonPositiveInteger.toInteger(),
-            message = "Input: $value"
+            message
+        )
+        assertEquals(
+            expected,
+            actual = safeNonPositiveInteger?.toInteger(),
+            message
         )
     }
 
@@ -41,6 +49,10 @@ class NonPositiveIntegerTest {
         val expected: String =
             errorMessage("Positive integer", Integer.fromLong(value))
         assertEquals(expected, actual = exception.message)
+
+        val safeNonPositiveInteger: NonPositiveInteger? =
+            NonPositiveInteger.fromLongOrNull(value)
+        assertNull(safeNonPositiveInteger, message = "Input: $value")
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -99,10 +99,17 @@ class NonPositiveIntegerTest {
 
         val nonPositiveInteger: NonPositiveInteger =
             NonPositiveInteger.parse(value)
+        val safeNonPositiveInteger: NonPositiveInteger? =
+            NonPositiveInteger.parseOrNull(value)
 
         val zero: Integer = Integer.fromLong(0)
         val message = "Input: \"$value\""
         assertEquals(zero, actual = nonPositiveInteger.toInteger(), message)
+        assertEquals(
+            zero,
+            actual = safeNonPositiveInteger?.toInteger(),
+            message
+        )
     }
 
     @Test
@@ -111,12 +118,19 @@ class NonPositiveIntegerTest {
 
         val nonPositiveInteger: NonPositiveInteger =
             NonPositiveInteger.parse(value)
+        val safeNonPositiveInteger: NonPositiveInteger? =
+            NonPositiveInteger.parseOrNull(value)
 
         val expected: Integer = Integer.parse(value)
         val message = "Input: \"$value\""
         assertEquals(
             expected,
             actual = nonPositiveInteger.toInteger(),
+            message
+        )
+        assertEquals(
+            expected,
+            actual = safeNonPositiveInteger?.toInteger(),
             message
         )
     }
@@ -128,6 +142,10 @@ class NonPositiveIntegerTest {
         assertFailsWith<NumberFormatException>(message = "Input: \"$value\"") {
             NonPositiveInteger.parse(value)
         }
+        assertNull(
+            NonPositiveInteger.parseOrNull(value),
+            message = "Input: \"$value\""
+        )
     }
 
     @Test
@@ -140,6 +158,11 @@ class NonPositiveIntegerTest {
         val integer: Integer = Integer.parse(value)
         val expected: String = errorMessage("Positive integer", integer)
         assertEquals(expected, actual = exception.message)
+
+        assertNull(
+            NonPositiveInteger.parseOrNull(value),
+            message = "Input: \"$value\""
+        )
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -2,9 +2,13 @@ package org.kotools.types.number
 
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.errorMessage
+import org.kotools.types.negativeIntegerString
+import org.kotools.types.nonIntegerString
 import org.kotools.types.nonPositiveInteger
 import org.kotools.types.positiveInteger
+import org.kotools.types.positiveIntegerString
 import org.kotools.types.repeatTest
+import org.kotools.types.zeroString
 import kotlin.random.Random
 import kotlin.random.nextLong
 import kotlin.test.Test
@@ -87,6 +91,55 @@ class NonPositiveIntegerTest {
         val safeNonPositiveInteger: NonPositiveInteger? =
             NonPositiveInteger.fromIntegerOrNull(integer)
         assertNull(safeNonPositiveInteger, message = "Input: $integer")
+    }
+
+    @Test
+    fun parsingPreservesValueWithZero(): Unit = repeatTest {
+        val value: String = Random.zeroString()
+
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.parse(value)
+
+        val zero: Integer = Integer.fromLong(0)
+        val message = "Input: \"$value\""
+        assertEquals(zero, actual = nonPositiveInteger.toInteger(), message)
+    }
+
+    @Test
+    fun parsingPreservesValueWithNegativeValue(): Unit = repeatTest {
+        val value: String = Random.negativeIntegerString()
+
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.parse(value)
+
+        val expected: Integer = Integer.parse(value)
+        val message = "Input: \"$value\""
+        assertEquals(
+            expected,
+            actual = nonPositiveInteger.toInteger(),
+            message
+        )
+    }
+
+    @Test
+    fun parsingFailsWithNonIntegerString(): Unit = repeatTest {
+        val value: String = Random.nonIntegerString()
+
+        assertFailsWith<NumberFormatException>(message = "Input: \"$value\"") {
+            NonPositiveInteger.parse(value)
+        }
+    }
+
+    @Test
+    fun parsingFailsWithPositiveValue(): Unit = repeatTest {
+        val value: String = Random.positiveIntegerString()
+
+        val exception: IllegalArgumentException = assertFailsWith(
+            message = "Input: \"$value\""
+        ) { NonPositiveInteger.parse(value) }
+        val integer: Integer = Integer.parse(value)
+        val expected: String = errorMessage("Positive integer", integer)
+        assertEquals(expected, actual = exception.message)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -286,4 +286,17 @@ class NonPositiveIntegerTest {
 
         assertEquals(integer, actual, message = "Input: $integer")
     }
+
+    @Test
+    fun toStringDelegatesToInteger(): Unit = repeatTest {
+        val integer: Integer = Random.nonPositiveInteger()
+            .toInteger()
+
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(integer)
+
+        val actual: String = nonPositiveInteger.toString()
+        val expected: String = integer.toString()
+        assertEquals(expected, actual, message = "Input: $integer")
+    }
 }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -5,6 +5,7 @@ import org.kotools.types.internal.errorMessage
 import org.kotools.types.negativeIntegerString
 import org.kotools.types.nonIntegerString
 import org.kotools.types.nonPositiveInteger
+import org.kotools.types.nonPositiveIntegerExcept
 import org.kotools.types.positiveInteger
 import org.kotools.types.positiveIntegerString
 import org.kotools.types.repeatTest
@@ -14,7 +15,10 @@ import kotlin.random.nextLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonPositiveIntegerTest {
@@ -163,6 +167,110 @@ class NonPositiveIntegerTest {
             NonPositiveInteger.parseOrNull(value),
             message = "Input: \"$value\""
         )
+    }
+
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    fun structuralEqualityPassesWithSameValues(): Unit = repeatTest {
+        val nonPositiveInteger: NonPositiveInteger = Random.nonPositiveInteger()
+        val other: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(nonPositiveInteger.toInteger())
+
+        val message = "Inputs: this = $nonPositiveInteger, other = $other"
+        assertEquals(nonPositiveInteger, other, message)
+        assertEquals(nonPositiveInteger.hashCode(), other.hashCode(), message)
+    }
+
+    @Test
+    fun structuralEqualityIsReflexive(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val message = "Input: $x"
+        assertSame(x, x, message)
+        assertEquals(x.hashCode(), x.hashCode(), message)
+    }
+
+    @Test
+    fun structuralEqualityIsSymmetrical(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(x.toInteger())
+
+        val xHashCode: Int = x.hashCode()
+        val yHashCode: Int = y.hashCode()
+
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(x, y, message)
+        assertEquals(xHashCode, yHashCode, message)
+
+        assertEquals(y, x, message)
+        assertEquals(yHashCode, xHashCode, message)
+    }
+
+    @Test
+    fun structuralEqualityIsTransitive(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(x.toInteger())
+        val z: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(y.toInteger())
+
+        val xHashCode: Int = x.hashCode()
+        val yHashCode: Int = y.hashCode()
+        val zHashCode: Int = z.hashCode()
+
+        val message = "Inputs: x = $x, y = $y, z = $z"
+        assertEquals(x, y, message)
+        assertEquals(xHashCode, yHashCode, message)
+
+        assertEquals(y, z, message)
+        assertEquals(yHashCode, zHashCode, message)
+
+        assertEquals(x, z, message)
+        assertEquals(xHashCode, zHashCode, message)
+    }
+
+    @Test
+    fun structuralEqualityFailsWithDifferentValues(): Unit = repeatTest {
+        val nonPositiveInteger: NonPositiveInteger = Random.nonPositiveInteger()
+        val other: NonPositiveInteger =
+            Random.nonPositiveIntegerExcept(illegal = nonPositiveInteger)
+
+        val message = "Inputs: this = $nonPositiveInteger, other = $other"
+        assertNotEquals(nonPositiveInteger, other, message)
+        assertNotEquals(
+            nonPositiveInteger.hashCode(),
+            other.hashCode(),
+            message
+        )
+    }
+
+    @Test
+    fun structuralEqualityFailsWithDifferentTypes(): Unit = repeatTest {
+        val nonPositiveInteger: NonPositiveInteger = Random.nonPositiveInteger()
+        val other: Any = nonPositiveInteger.toInteger()
+
+        val message = "Inputs: this = $nonPositiveInteger, other = $other"
+        assertNotEquals(nonPositiveInteger, other, message)
+        assertNotEquals(
+            nonPositiveInteger.hashCode(),
+            other.hashCode(),
+            message
+        )
+    }
+
+    @Test
+    fun structuralEqualityFailsWithNull(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: Any? = null
+
+        val equality: Boolean = x == y
+        val hashEquality: Boolean = x.hashCode() == y.hashCode()
+
+        val message = "Structural equality must fail with null."
+        assertFalse(equality, message)
+        assertFalse(hashEquality, message)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -6,6 +6,7 @@ import org.kotools.types.nonPositiveInteger
 import org.kotools.types.positiveInteger
 import org.kotools.types.repeatTest
 import kotlin.random.Random
+import kotlin.random.nextLong
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -14,6 +15,33 @@ import kotlin.test.assertNull
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonPositiveIntegerTest {
     // --------------------------- Factory functions ---------------------------
+
+    @Test
+    fun fromLongPreservesValue(): Unit = repeatTest {
+        val value: Long = Random.nextLong(Long.MIN_VALUE..0)
+
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.fromLong(value)
+
+        val expected: Integer = Integer.fromLong(value)
+        assertEquals(
+            expected,
+            actual = nonPositiveInteger.toInteger(),
+            message = "Input: $value"
+        )
+    }
+
+    @Test
+    fun fromLongFailsWithPositiveValue(): Unit = repeatTest {
+        val value: Long = Random.nextLong(1..Long.MAX_VALUE)
+
+        val exception: IllegalArgumentException = assertFailsWith(
+            message = "Input: $value"
+        ) { NonPositiveInteger.fromLong(value) }
+        val expected: String =
+            errorMessage("Positive integer", Integer.fromLong(value))
+        assertEquals(expected, actual = exception.message)
+    }
 
     @Test
     fun fromIntegerPreservesValue(): Unit = repeatTest {

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -1,0 +1,41 @@
+package org.kotools.types.number
+
+import org.kotools.types.ExperimentalKotoolsTypesApi
+import org.kotools.types.internal.errorMessage
+import org.kotools.types.nonPositiveInteger
+import org.kotools.types.positiveInteger
+import org.kotools.types.repeatTest
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(ExperimentalKotoolsTypesApi::class)
+class NonPositiveIntegerTest {
+    // --------------------------- Factory functions ---------------------------
+
+    @Test
+    fun fromIntegerFailsWithPositiveValue(): Unit = repeatTest {
+        val integer: Integer = Random.positiveInteger()
+
+        val exception: IllegalArgumentException = assertFailsWith(
+            message = "Input: $integer"
+        ) { NonPositiveInteger.fromInteger(integer) }
+        val expected: String = errorMessage("Positive integer", integer)
+        assertEquals(expected, actual = exception.message)
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    fun toIntegerRoundTripsWithFromInteger(): Unit = repeatTest {
+        val integer: Integer = Random.nonPositiveInteger()
+            .toInteger()
+
+        val nonPositiveInteger: NonPositiveInteger =
+            NonPositiveInteger.fromInteger(integer)
+        val actual: Integer = nonPositiveInteger.toInteger()
+
+        assertEquals(integer, actual, message = "Input: $integer")
+    }
+}

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -54,6 +54,23 @@ public class NonPositiveIntegerJavaSample {
         }
     }
 
+    // ------------------------------ Comparisons ------------------------------
+
+    @Test
+    void structuralEquality() {
+        final Integer value = Integer.fromLong(-42);
+        final NonPositiveInteger x = NonPositiveInteger.fromInteger(value);
+        final NonPositiveInteger y = NonPositiveInteger.fromInteger(value);
+        final boolean equality = x.equals(y) && x.hashCode() == y.hashCode();
+        if (!equality) throw new IllegalStateException("Check failed.");
+
+        final Integer other = Integer.fromLong(-7);
+        final NonPositiveInteger z = NonPositiveInteger.fromInteger(other);
+        final boolean inequality =
+                !x.equals(z) && x.hashCode() != z.hashCode();
+        if (!inequality) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -7,6 +7,19 @@ public class NonPositiveIntegerJavaSample {
     // --------------------------- Factory functions ---------------------------
 
     @Test
+    void fromLong() {
+        final NonPositiveInteger result = NonPositiveInteger.fromLong(-42L);
+        final boolean check = result.toInteger().equals(Integer.fromLong(-42));
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        try {
+            NonPositiveInteger.fromLong(1L);
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    @Test
     void fromInteger() {
         final Integer value = Integer.fromLong(-42);
         final NonPositiveInteger result =

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -35,6 +35,25 @@ public class NonPositiveIntegerJavaSample {
         }
     }
 
+    @Test
+    void parsing() {
+        final NonPositiveInteger result = NonPositiveInteger.parse("-00042");
+        final boolean check = result.toInteger().equals(Integer.fromLong(-42));
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        try {
+            NonPositiveInteger.parse("3.14");
+            throw new IllegalStateException("Check failed.");
+        } catch (NumberFormatException ignored) {
+        }
+
+        try {
+            NonPositiveInteger.parse("1");
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -82,4 +82,14 @@ public class NonPositiveIntegerJavaSample {
         final boolean check = result.equals(value);
         if (!check) throw new IllegalStateException("Check failed.");
     }
+
+    @Test
+    void toStringOverride() {
+        final Integer value = Integer.fromLong(-42);
+        final NonPositiveInteger nonPositiveInteger =
+                NonPositiveInteger.fromInteger(value);
+        final String result = String.valueOf(nonPositiveInteger);
+        final boolean check = result.equals("-42");
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
 }

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -1,0 +1,36 @@
+package org.kotools.types.number;
+
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NewClassNamingConvention")
+public class NonPositiveIntegerJavaSample {
+    // --------------------------- Factory functions ---------------------------
+
+    @Test
+    void fromInteger() {
+        final Integer value = Integer.fromLong(-42);
+        final NonPositiveInteger result =
+                NonPositiveInteger.fromInteger(value);
+        final boolean check = result.toInteger().equals(value);
+        if (!check) throw new IllegalStateException("Check failed.");
+
+        final Integer positive = Integer.fromLong(1);
+        try {
+            NonPositiveInteger.fromInteger(positive);
+            throw new IllegalStateException("Check failed.");
+        } catch (IllegalArgumentException ignored) {
+        }
+    }
+
+    // ------------------------------ Conversions ------------------------------
+
+    @Test
+    void toInteger() {
+        final Integer value = Integer.fromLong(-42);
+        final NonPositiveInteger nonPositiveInteger =
+                NonPositiveInteger.fromInteger(value);
+        final Integer result = nonPositiveInteger.toInteger();
+        final boolean check = result.equals(value);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `NonPositiveInteger` experimental class to `org.kotools.types.number`, representing an `Integer` that is less than or equal to zero.

- `Companion.fromLong`/`fromLongOrNull`, `fromInteger`/`fromIntegerOrNull`, `parse`/`parseOrNull` factory functions
- `equals`/`hashCode` structural equality, mirrored on `Integer`
- `toInteger` and `toString` conversions
- New `HashSeed.NonPositiveInteger` entry
- Full KDoc with Kotlin/Java samples, tests, and ABI dump per function
- Changelog entry

Closes #1013.

🤖 Generated with [Claude Code](https://claude.ai/code)