### PR TITLE
✨ Overload `Integer` division functions with `NonZeroInteger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog], and this project adheres to its own
 - `toLong()` and `toLongOrNull()` **experimental** functions to `Integer` class,
   returning the `Long` representation of an `Integer`. (module: `types`, ref:
   [#1010])
+- `div(NonZeroInteger)` and `rem(NonZeroInteger)` **experimental** functions to
+  `Integer` class, returning the Euclidean quotient and non-negative remainder
+  of dividing by a non-zero divisor without throwing. (module: `types`, ref:
+  [#999])
 - `NonZeroInteger` **experimental** class to `org.kotools.types.number` package,
   representing an `Integer` other than zero. (module: `types`, ref: [#1011])
 - `NonNegativeInteger` **experimental** class to `org.kotools.types.number`
@@ -159,6 +163,7 @@ The format is based on [Keep a Changelog], and this project adheres to its own
 [#989]: https://github.com/kotools/types/issues/989
 [#990]: https://github.com/kotools/types/issues/990
 [#998]: https://github.com/kotools/types/issues/998
+[#999]: https://github.com/kotools/types/issues/999
 [#1010]: https://github.com/kotools/types/issues/1010
 [#1011]: https://github.com/kotools/types/issues/1011
 [#1013]: https://github.com/kotools/types/issues/1013

--- a/documentation/decisions/ADR-015-integer-typed-divisor-division.md
+++ b/documentation/decisions/ADR-015-integer-typed-divisor-division.md
@@ -1,22 +1,20 @@
 # ⚖️ ADR-015: Typed-divisor Euclidean division for `Integer`
 
 This document records the decision to add `div(NonZeroInteger)` and
-`rem(NonZeroInteger)` overloads to the [`Integer`][Integer] type's arithmetic
-API.
+`rem(NonZeroInteger)` overloads to the `Integer` type's arithmetic API.
 
 ## 🤔 Context
 
-[`Integer.div(Integer)`][div] and [`Integer.rem(Integer)`][rem] implement
-Euclidean division (see [ADR-001][ADR-001]), but must throw an
-`ArithmeticException` when the divisor is zero, because nothing in the
-`Integer` type rules out that case. The non-throwing `divOrNull`/`remOrNull`
-variants exist for callers who'd rather get `null` than catch an exception.
+`Integer.div(Integer)` and `Integer.rem(Integer)` implement Euclidean division
+(see [ADR-001]), but must throw an `ArithmeticException` when the divisor is
+zero, because nothing in the `Integer` type rules out that case. The
+non-throwing `divOrNull`/`remOrNull` variants exist for callers who'd rather get
+`null` than catch an exception.
 
-Now that [`NonZeroInteger`][NonZeroInteger] exists, representing an `Integer`
-that is guaranteed to never be zero, the zero-divisor case can be ruled out by
-the type system instead of being checked at runtime. The question that arose
-was: should `Integer` provide `div`/`rem` overloads accepting a
-`NonZeroInteger` divisor?
+Now that `NonZeroInteger` exists, representing an `Integer` that is guaranteed
+to never be zero, the zero-divisor case can be ruled out by the type system
+instead of being checked at runtime. The question that arose was: should
+`Integer` provide `div`/`rem` overloads accepting a `NonZeroInteger` divisor?
 
 ## ✅ Decision: Add total `div`/`rem` overloads accepting `NonZeroInteger`
 
@@ -32,16 +30,16 @@ was: should `Integer` provide `div`/`rem` overloads accepting a
   exception to throw, and no `null` to return. Consequently, no
   `divOrNull(NonZeroInteger)` or `remOrNull(NonZeroInteger)` overloads are
   added — they would be redundant given there's nothing to make nullable.
-- **`rem(NonZeroInteger)` returns [`NonNegativeInteger`][NonNegativeInteger],
-  not `Integer`.** Euclidean division guarantees the remainder satisfies
-  `0 <= r < |divisor|` (see [ADR-001][ADR-001]). Narrowing the return type to
-  `NonNegativeInteger` encodes that postcondition directly in the type, instead
-  of leaving callers to re-validate a non-negative `Integer` themselves.
+- **`rem(NonZeroInteger)` returns `NonNegativeInteger`, not `Integer`.**
+  Euclidean division guarantees the remainder satisfies `0 <= r < |divisor|`
+  (see [ADR-001]). Narrowing the return type to `NonNegativeInteger` encodes
+  that postcondition directly in the type, instead of leaving callers to
+  re-validate a non-negative `Integer` themselves.
 - **Consistent with the codebase's typed-narrowing pattern.** This mirrors how
-  [`NonZeroInteger.times`][NonZeroInteger] and
-  [`NonNegativeInteger.times`][NonNegativeInteger] stay closed-form: narrowing
-  an operand's type to rule out a failure case, and narrowing the return type
-  to encode a postcondition, rather than introducing a new design language.
+  `NonZeroInteger.times` and `NonNegativeInteger.times` stay closed-form:
+  narrowing an operand's type to rule out a failure case, and narrowing the
+  return type to encode a postcondition, rather than introducing a new design
+  language.
 
 ## 🔗 Consequences
 
@@ -54,9 +52,4 @@ was: should `Integer` provide `div`/`rem` overloads accepting a
 
 <!----------------------------------- Links ----------------------------------->
 
-[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
-[div]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
-[rem]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
-[NonZeroInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
-[NonNegativeInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
 [ADR-001]: ADR-001-integer-euclidean-division.md

--- a/documentation/decisions/ADR-015-integer-typed-divisor-division.md
+++ b/documentation/decisions/ADR-015-integer-typed-divisor-division.md
@@ -1,0 +1,62 @@
+# ⚖️ ADR-015: Typed-divisor Euclidean division for `Integer`
+
+This document records the decision to add `div(NonZeroInteger)` and
+`rem(NonZeroInteger)` overloads to the [`Integer`][Integer] type's arithmetic
+API.
+
+## 🤔 Context
+
+[`Integer.div(Integer)`][div] and [`Integer.rem(Integer)`][rem] implement
+Euclidean division (see [ADR-001][ADR-001]), but must throw an
+`ArithmeticException` when the divisor is zero, because nothing in the
+`Integer` type rules out that case. The non-throwing `divOrNull`/`remOrNull`
+variants exist for callers who'd rather get `null` than catch an exception.
+
+Now that [`NonZeroInteger`][NonZeroInteger] exists, representing an `Integer`
+that is guaranteed to never be zero, the zero-divisor case can be ruled out by
+the type system instead of being checked at runtime. The question that arose
+was: should `Integer` provide `div`/`rem` overloads accepting a
+`NonZeroInteger` divisor?
+
+## ✅ Decision: Add total `div`/`rem` overloads accepting `NonZeroInteger`
+
+`Integer` gains two new overloads:
+
+- `div(other: NonZeroInteger): Integer`
+- `rem(other: NonZeroInteger): NonNegativeInteger`
+
+**Rationale:**
+
+- **A `NonZeroInteger` divisor makes these total functions.** Since the
+  divisor can never be zero, there is no failure case left to handle: no
+  exception to throw, and no `null` to return. Consequently, no
+  `divOrNull(NonZeroInteger)` or `remOrNull(NonZeroInteger)` overloads are
+  added — they would be redundant given there's nothing to make nullable.
+- **`rem(NonZeroInteger)` returns [`NonNegativeInteger`][NonNegativeInteger],
+  not `Integer`.** Euclidean division guarantees the remainder satisfies
+  `0 <= r < |divisor|` (see [ADR-001][ADR-001]). Narrowing the return type to
+  `NonNegativeInteger` encodes that postcondition directly in the type, instead
+  of leaving callers to re-validate a non-negative `Integer` themselves.
+- **Consistent with the codebase's typed-narrowing pattern.** This mirrors how
+  [`NonZeroInteger.times`][NonZeroInteger] and
+  [`NonNegativeInteger.times`][NonNegativeInteger] stay closed-form: narrowing
+  an operand's type to rule out a failure case, and narrowing the return type
+  to encode a postcondition, rather than introducing a new design language.
+
+## 🔗 Consequences
+
+- `div(NonZeroInteger)` and `rem(NonZeroInteger)` never throw and never return
+  `null`; their KDoc documents this explicitly so callers don't expect the
+  same failure modes as their `Integer`-parameter counterparts.
+- Future typed-divisor overloads (if any) should follow the same shape:
+  narrow the parameter to rule out the failure case, and narrow the return
+  type to encode the postcondition.
+
+<!----------------------------------- Links ----------------------------------->
+
+[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+[div]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+[rem]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+[NonZeroInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+[NonNegativeInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
+[ADR-001]: ADR-001-integer-euclidean-division.md

--- a/documentation/decisions/ADR-015-integer-typed-divisor-division.md
+++ b/documentation/decisions/ADR-015-integer-typed-divisor-division.md
@@ -25,11 +25,11 @@ instead of being checked at runtime. The question that arose was: should
 
 **Rationale:**
 
-- **A `NonZeroInteger` divisor makes these total functions.** Since the
-  divisor can never be zero, there is no failure case left to handle: no
-  exception to throw, and no `null` to return. Consequently, no
-  `divOrNull(NonZeroInteger)` or `remOrNull(NonZeroInteger)` overloads are
-  added — they would be redundant given there's nothing to make nullable.
+- **A `NonZeroInteger` divisor makes these total functions.** Since the divisor
+  can never be zero, there is no failure case left to handle: no exception to
+  throw, and no `null` to return. Consequently, no `divOrNull(NonZeroInteger)`
+  or `remOrNull(NonZeroInteger)` overloads are added — they would be redundant
+  given there's nothing to make nullable.
 - **`rem(NonZeroInteger)` returns `NonNegativeInteger`, not `Integer`.**
   Euclidean division guarantees the remainder satisfies `0 <= r < |divisor|`
   (see [ADR-001]). Narrowing the return type to `NonNegativeInteger` encodes
@@ -44,11 +44,11 @@ instead of being checked at runtime. The question that arose was: should
 ## 🔗 Consequences
 
 - `div(NonZeroInteger)` and `rem(NonZeroInteger)` never throw and never return
-  `null`; their KDoc documents this explicitly so callers don't expect the
-  same failure modes as their `Integer`-parameter counterparts.
-- Future typed-divisor overloads (if any) should follow the same shape:
-  narrow the parameter to rule out the failure case, and narrow the return
-  type to encode the postcondition.
+  `null`; their KDoc documents this explicitly so callers don't expect the same
+  failure modes as their `Integer`-parameter counterparts.
+- Future typed-divisor overloads (if any) should follow the same shape: narrow
+  the parameter to rule out the failure case, and narrow the return type to
+  encode the postcondition.
 
 <!----------------------------------- Links ----------------------------------->
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -22,6 +22,7 @@ rationale behind it, and its consequences.
 | [ADR-012](ADR-012-native-decimal-io-chunking.md)          | 10⁹-chunk decimal I/O for `NativeInteger`                         | ✅ Accepted               |
 | [ADR-013](ADR-013-nonzerointeger-additive-exclusion.md)   | Exclusion of additive operations from `NonZeroInteger` arithmetic | ✅ Accepted               |
 | [ADR-014](ADR-014-nonnegativeinteger-subtractive-exclusion.md) | Exclusion of subtraction from `NonNegativeInteger` arithmetic | ✅ Accepted               |
+| [ADR-015](ADR-015-integer-typed-divisor-division.md)      | Typed-divisor Euclidean division for `Integer`                    | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -396,6 +396,7 @@ public final class org/kotools/types/number/Integer {
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun plus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
+	public final fun rem (Lorg/kotools/types/number/NonZeroInteger;)Lorg/kotools/types/number/NonNegativeInteger;
 	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toLong ()J

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -387,6 +387,7 @@ public final class org/kotools/types/number/Integer {
 	public synthetic fun <init> (Lorg/kotools/types/internal/number/PlatformInteger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun compareTo (Lorg/kotools/types/number/Integer;)I
 	public final fun div (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
+	public final fun div (Lorg/kotools/types/number/NonZeroInteger;)Lorg/kotools/types/number/Integer;
 	public final synthetic fun divOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromLong (J)Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -602,6 +602,48 @@ public class Integer private constructor(
 
     /**
      * Returns the Euclidean remainder of dividing this integer by the [other]
+     * one.
+     *
+     * This function uses Euclidean division: the remainder is always
+     * non-negative and less than the absolute value of [other]
+     * (`0 <= remainder < |other|`), regardless of the sign of this integer.
+     * Since [other] is guaranteed to be other than zero, this function never
+     * throws.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivisionByNonZeroInteger
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.euclideanDivisionByNonZeroInteger
+     * </details>
+     * <br>
+     *
+     * See also [div] for returning the Euclidean quotient of this division.
+     *
+     * @since 5.2.0
+     */
+    public operator fun rem(other: NonZeroInteger): NonNegativeInteger {
+        val remainder = Integer(this.delegate % other.toInteger().delegate)
+        return NonNegativeInteger.fromInteger(remainder)
+    }
+
+    /**
+     * Returns the Euclidean remainder of dividing this integer by the [other]
      * one, or throws an [ArithmeticException] if the [other] integer is zero.
      *
      * This function uses Euclidean division: the remainder is always

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -495,6 +495,44 @@ public class Integer private constructor(
 
     /**
      * Returns the Euclidean quotient of dividing this integer by the [other]
+     * one.
+     *
+     * This function uses Euclidean division: the remainder is always
+     * non-negative, regardless of the sign of this integer. Since [other] is
+     * guaranteed to be other than zero, this function never throws.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivisionByNonZeroInteger
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.IntegerJavaSample.euclideanDivisionByNonZeroInteger
+     * </details>
+     * <br>
+     *
+     * See also [rem] for returning the Euclidean remainder of this division.
+     *
+     * @since 5.2.0
+     */
+    public operator fun div(other: NonZeroInteger): Integer =
+        Integer(this.delegate / other.toInteger().delegate)
+
+    /**
+     * Returns the Euclidean quotient of dividing this integer by the [other]
      * one, or throws an [ArithmeticException] if the [other] integer is zero.
      *
      * This function uses Euclidean division: the remainder is always

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -198,6 +198,16 @@ class IntegerSample {
     }
 
     @Test
+    fun euclideanDivisionByNonZeroInteger() {
+        val x: Integer = Integer.fromLong(-7)
+        val y: NonZeroInteger = NonZeroInteger.fromLong(2)
+
+        val quotient: Integer = x / y
+
+        check(quotient == Integer.fromLong(-4))
+    }
+
+    @Test
     fun euclideanDivisionOrNull() {
         val x: Integer = Integer.fromLong(-7)
         val y: Integer = Integer.fromLong(2)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -203,8 +203,11 @@ class IntegerSample {
         val y: NonZeroInteger = NonZeroInteger.fromLong(2)
 
         val quotient: Integer = x / y
+        val remainder: NonNegativeInteger = x % y
 
         check(quotient == Integer.fromLong(-4))
+        check(remainder == NonNegativeInteger.fromLong(1))
+        check(x == quotient * y.toInteger() + remainder.toInteger())
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -5,6 +5,7 @@ import org.kotools.types.integer
 import org.kotools.types.integerExcept
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.nonIntegerString
+import org.kotools.types.nonZeroInteger
 import org.kotools.types.nonZeroIntegerStringWithLeadingZeros
 import org.kotools.types.positiveInteger
 import org.kotools.types.positiveIntegerString
@@ -791,6 +792,50 @@ class IntegerTest {
         val actual: Integer? = x.divOrNull(y)
 
         assertNull(actual)
+    }
+
+    @Test
+    fun divByNonZeroIntegerSanityCheck() {
+        val x: Integer = Integer.parse("922337203685477580700")
+        val y: NonZeroInteger = NonZeroInteger.fromLong(10)
+
+        val actual: Integer = x / y
+
+        val expected: Integer = Integer.parse("92233720368547758070")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun divByNonZeroIntegerHasRightIdentity(): Unit = repeatTest {
+        val x: Integer = Random.integer()
+        val one: NonZeroInteger = NonZeroInteger.fromLong(1)
+
+        val actual: Integer = x / one
+
+        assertEquals(expected = x, actual, message = "Input: $x")
+    }
+
+    @Test
+    fun divByNonZeroIntegerIsConsistentWithDiv(): Unit = repeatTest {
+        val x: Integer = Random.integer()
+        val y: NonZeroInteger = Random.nonZeroInteger()
+
+        val actual: Integer = x / y
+
+        val expected: Integer = x / y.toInteger()
+        assertEquals(expected, actual, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun divByNonZeroIntegerSatisfiesDivisionAlgorithm(): Unit = repeatTest {
+        val x: Integer = Random.integer()
+        val y: NonZeroInteger = Random.nonZeroInteger()
+
+        val quotient: Integer = x / y
+        val remainder: Integer = x % y.toInteger()
+        val actual: Integer = quotient * y.toInteger() + remainder
+
+        assertEquals(expected = x, actual, message = "Inputs: x = $x, y = $y")
     }
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -839,6 +839,59 @@ class IntegerTest {
     }
 
     @Test
+    fun remByNonZeroIntegerSanityCheck() {
+        val x: Integer = Integer.fromLong(42)
+        val y: NonZeroInteger = NonZeroInteger.fromLong(5)
+
+        val actual: NonNegativeInteger = x % y
+
+        val expected: NonNegativeInteger = NonNegativeInteger.fromLong(2)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun remByNonZeroIntegerIsConsistentWithRem(): Unit = repeatTest {
+        val x: Integer = Random.integer()
+        val y: NonZeroInteger = Random.nonZeroInteger()
+
+        val actual: NonNegativeInteger = x % y
+
+        val expected: Integer = x % y.toInteger()
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(expected, actual = actual.toInteger(), message)
+    }
+
+    @Test
+    fun remByNonZeroIntegerIsBoundedByAbsoluteValueOfDivisor(): Unit =
+        repeatTest {
+            val x: Integer = Random.integer()
+            val y: NonZeroInteger = Random.nonZeroInteger()
+
+            val remainder: NonNegativeInteger = x % y
+
+            val divisor: Integer = y.toInteger()
+            val absDivisor: Integer =
+                if (divisor > Integer.ZERO) divisor else -divisor
+            val message = "Inputs: x = $x, y = $y"
+            assertTrue(remainder.toInteger() < absDivisor, message)
+        }
+
+    @Test
+    fun divAndRemByNonZeroIntegerSatisfyDivisionAlgorithm(): Unit =
+        repeatTest {
+            val x: Integer = Random.integer()
+            val y: NonZeroInteger = Random.nonZeroInteger()
+
+            val quotient: Integer = x / y
+            val remainder: NonNegativeInteger = x % y
+            val actual: Integer =
+                quotient * y.toInteger() + remainder.toInteger()
+
+            val message = "Inputs: x = $x, y = $y"
+            assertEquals(expected = x, actual, message)
+        }
+
+    @Test
     fun remSanityCheck() {
         val x: Integer = Integer.fromLong(42)
         val y: Integer = Integer.fromLong(5)

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -166,8 +166,10 @@ public class IntegerJavaSample {
         final NonZeroInteger y = NonZeroInteger.fromLong(2);
 
         final Integer quotient = x.div(y);
+        final NonNegativeInteger remainder = x.rem(y);
 
-        final boolean check = quotient.equals(Integer.fromLong(-4));
+        final boolean check = quotient.equals(Integer.fromLong(-4))
+                && remainder.equals(NonNegativeInteger.fromLong(1));
         if (!check) throw new IllegalStateException("Check failed.");
     }
 

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -160,6 +160,17 @@ public class IntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void euclideanDivisionByNonZeroInteger() {
+        final Integer x = Integer.fromLong(-7);
+        final NonZeroInteger y = NonZeroInteger.fromLong(2);
+
+        final Integer quotient = x.div(y);
+
+        final boolean check = quotient.equals(Integer.fromLong(-4));
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test


### PR DESCRIPTION
## Summary

Adds total (non-throwing) `div(NonZeroInteger): Integer` and `rem(NonZeroInteger): NonNegativeInteger` overloads to `Integer`, following Kotlin's overload-layout convention (each placed before its `Integer`-parameter counterpart).

- Adds ADR-015 documenting the typed-divisor design.
- No `divOrNull`/`remOrNull` overloads, since these are total functions (`NonZeroInteger` rules out the zero-divisor case).
- `rem(NonZeroInteger)` uses `NonNegativeInteger.fromInteger(Integer)` to enforce the Euclidean invariant.
- Merges the Kotlin/Java samples for both functions into a single `euclideanDivisionByNonZeroInteger` sample, alongside unit tests and a changelog entry.

Closes #999.

🤖 Generated with [Claude Code](https://claude.ai/code)