### PR TITLE
✨ Add arithmetic operations to `NonPositiveInteger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,8 @@ The format is based on [Keep a Changelog], and this project adheres to its own
   package, representing an `Integer` that is greater than or equal to zero.
   (module: `types`, refs: [#998], [#1014])
 - `NonPositiveInteger` **experimental** class to `org.kotools.types.number`
-  package, representing an `Integer` that is less than or equal to zero,
-  with arithmetic operations for negation, addition, subtraction, and
-  multiplication. (module: `types`, refs: [#1013], [#1024])
+  package, representing an `Integer` that is less than or equal to zero.
+  (module: `types`, refs: [#1013], [#1024])
 - `Decimal` **experimental** class to `org.kotools.types.number` package,
   representing mathematical decimal numbers with exact arithmetic. (module:
   `types`, ref: [#925] originally suggested by [@CLOVIS-AI])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,9 @@ The format is based on [Keep a Changelog], and this project adheres to its own
   package, representing an `Integer` that is greater than or equal to zero.
   (module: `types`, refs: [#998], [#1014])
 - `NonPositiveInteger` **experimental** class to `org.kotools.types.number`
-  package, representing an `Integer` that is less than or equal to zero.
-  (module: `types`, ref: [#1013])
+  package, representing an `Integer` that is less than or equal to zero,
+  with arithmetic operations for negation, addition, subtraction, and
+  multiplication. (module: `types`, refs: [#1013], [#1024])
 - `Decimal` **experimental** class to `org.kotools.types.number` package,
   representing mathematical decimal numbers with exact arithmetic. (module:
   `types`, ref: [#925] originally suggested by [@CLOVIS-AI])
@@ -168,3 +169,4 @@ The format is based on [Keep a Changelog], and this project adheres to its own
 [#1011]: https://github.com/kotools/types/issues/1011
 [#1013]: https://github.com/kotools/types/issues/1013
 [#1014]: https://github.com/kotools/types/issues/1014
+[#1024]: https://github.com/kotools/types/issues/1024

--- a/documentation/decisions/ADR-017-nonpositiveinteger-exclusions.md
+++ b/documentation/decisions/ADR-017-nonpositiveinteger-exclusions.md
@@ -1,0 +1,94 @@
+# ⚖️ ADR-017: Exclusions from `NonPositiveInteger` arithmetic
+
+This document records the decision to omit certain subtraction and
+multiplication combinations, as well as division and remainder, from the
+`NonPositiveInteger` type's arithmetic API.
+
+## 🤔 Context
+
+`NonPositiveInteger` represents an `Integer` that is less than or equal to zero.
+Negation (`unaryMinus`), addition (`plus`), subtraction (`minus`), and
+multiplication (`times`) are provided wherever their result can always be
+represented within `NonPositiveInteger` or `NonNegativeInteger`:
+
+- `-x` is always non-negative.
+- `x + y` (two non-positive integers) is always non-positive.
+- `x - y` (a non-positive integer minus a non-negative one) is always
+  non-positive.
+- `x * y` (a non-positive integer times a non-negative one) is always
+  non-positive.
+- `x * y` (two non-positive integers) is always non-negative.
+
+The question that arose during design was: should `NonPositiveInteger` also
+provide `minus` overloads accepting `NonPositiveInteger`, `NonZeroInteger`, or
+`Integer`; a `times` overload accepting `NonZeroInteger`; or `div`/`rem`
+operators, like `Integer` does?
+
+## ✅ Decision: Some combinations are excluded
+
+Only the five operations listed above are defined on `NonPositiveInteger`. The
+following are intentionally absent:
+
+- **`minus(NonPositiveInteger)`, `minus(NonZeroInteger)`, and
+  `minus(Integer)`.**
+- **`times(NonZeroInteger)`.**
+- **`div` and `rem`, for any operand type.**
+
+**Rationale:**
+
+- **The set of non-positive integers is not closed under subtracting another
+  non-positive, non-zero, or unrestricted integer.** For any two non-positive
+  integers `x` and `y` where `x > y`, `x - y` is positive (e.g.,
+  `-1 - (-5) = 4`). The same unrestricted sign applies when subtracting a
+  `NonZeroInteger` or an `Integer`. The result of these subtractions cannot
+  always be represented as a `NonPositiveInteger`.
+- **The set of non-positive integers is not closed under multiplying by a
+  non-zero integer.** A `NonZeroInteger` can be positive or negative, so the
+  sign of `x * y` is indeterminate: it cannot be guaranteed non-positive or
+  non-negative, and therefore cannot be represented as either
+  `NonPositiveInteger` or `NonNegativeInteger`.
+- **A nullable, throwing, or widened return type would break the type's
+  contract.** Returning an optional type, throwing on the unrepresentable case,
+  or widening the return type to `Integer` would make these operators behave
+  unlike every other arithmetic operator in this codebase, where operators are
+  total functions over their declared types.
+- **Consistent with `NonZeroInteger` and `NonNegativeInteger` design.**
+  [ADR-013] and [ADR-014] exclude operations from those types for the same
+  underlying reason: only operations that keep results within a modeled set are
+  exposed. `NonPositiveInteger` follows the same principle.
+- **`div` and `rem` are excluded entirely, consistent with every other
+  variant.** None of `NonZeroInteger`, `NonNegativeInteger`, or
+  `NonPositiveInteger` define division or remainder operators, because their
+  semantics would be identical to `Integer.div` and `Integer.rem` (Euclidean
+  division). Adding them to a variant would be redundant rather than
+  closure-driven.
+- **The five included operations stay because closure holds.** Each of
+  `unaryMinus`, `plus`, the `minus(NonNegativeInteger)` overload, and both
+  `times` overloads always produces a value representable in
+  `NonPositiveInteger` or `NonNegativeInteger`, so they are safe to expose as
+  total functions.
+- **Explicit delegation to the caller.** Users who need an excluded operation
+  can convert to `Integer` via `toInteger`, perform the operation there, and
+  convert back with `fromInteger` (or its `OrNull` variant) if they need to
+  re-establish the non-positive invariant, making the unrepresentable case an
+  explicit decision at the call site rather than a silent one inside
+  `NonPositiveInteger`.
+
+## 🔗 Consequences
+
+- The KDoc of `NonPositiveInteger` documents which combinations are included,
+  with a counter-example illustrating why some are missing, so users are not
+  left guessing why `NonPositiveInteger` doesn't mirror every arithmetic
+  operator of `Integer`. This ADR, not the KDoc, is the contributor-facing
+  record of the full exclusion rationale.
+- The five provided operations are each closed over `NonPositiveInteger` or
+  `NonNegativeInteger`.
+- Converting to `Integer` remains the documented path for any arithmetic that
+  isn't closed under "non-positive", consistent with how `NonZeroInteger` and
+  `NonNegativeInteger` document converting to `Integer` for their own excluded
+  operations.
+
+<!----------------------------------- Links ----------------------------------->
+
+[ADR-013]: ADR-013-nonzerointeger-additive-exclusion.md
+[ADR-014]: ADR-014-nonnegativeinteger-subtractive-exclusion.md

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -24,6 +24,7 @@ rationale behind it, and its consequences.
 | [ADR-014](ADR-014-nonnegativeinteger-subtractive-exclusion.md) | Exclusion of subtraction from `NonNegativeInteger` arithmetic     | ✅ Accepted               |
 | [ADR-015](ADR-015-integer-typed-divisor-division.md)           | Typed-divisor Euclidean division for `Integer`                    | ✅ Accepted               |
 | [ADR-016](ADR-016-nonnegativeinteger-cross-type-closure.md)    | Cross-type closure for `NonNegativeInteger` arithmetic            | ✅ Accepted               |
+| [ADR-017](ADR-017-nonpositiveinteger-exclusions.md)            | Exclusions from `NonPositiveInteger` arithmetic                   | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -447,6 +447,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun plus (Lorg/kotools/types/number/NonPositiveInteger;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun times (Lorg/kotools/types/number/NonNegativeInteger;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun times (Lorg/kotools/types/number/NonPositiveInteger;)Lorg/kotools/types/number/NonNegativeInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/NonNegativeInteger;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -446,6 +446,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
+	public final fun unaryMinus ()Lorg/kotools/types/number/NonNegativeInteger;
 }
 
 public final class org/kotools/types/number/NonPositiveInteger$Companion {

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -444,6 +444,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun hashCode ()I
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun plus (Lorg/kotools/types/number/NonPositiveInteger;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/NonNegativeInteger;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -443,6 +443,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonPositiveInteger;
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun hashCode ()I
+	public final fun minus (Lorg/kotools/types/number/NonNegativeInteger;)Lorg/kotools/types/number/NonPositiveInteger;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun plus (Lorg/kotools/types/number/NonPositiveInteger;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -446,6 +446,7 @@ public final class org/kotools/types/number/NonPositiveInteger {
 	public final fun minus (Lorg/kotools/types/number/NonNegativeInteger;)Lorg/kotools/types/number/NonPositiveInteger;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun plus (Lorg/kotools/types/number/NonPositiveInteger;)Lorg/kotools/types/number/NonPositiveInteger;
+	public final fun times (Lorg/kotools/types/number/NonNegativeInteger;)Lorg/kotools/types/number/NonPositiveInteger;
 	public final fun toInteger ()Lorg/kotools/types/number/Integer;
 	public final fun toString ()Ljava/lang/String;
 	public final fun unaryMinus ()Lorg/kotools/types/number/NonNegativeInteger;

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -403,6 +403,34 @@ public class NonPositiveInteger private constructor(
     public operator fun minus(other: NonNegativeInteger): NonPositiveInteger =
         fromInteger(this.value - other.toInteger())
 
+    /**
+     * Multiplies this integer by the [other] one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.timesWithNonNegativeInteger
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.timesWithNonNegativeInteger
+     * </details>
+     */
+    public operator fun times(other: NonNegativeInteger): NonPositiveInteger =
+        fromInteger(this.value * other.toInteger())
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -434,8 +434,10 @@ public class NonPositiveInteger private constructor(
      * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.timesWithNonNegativeInteger
      * </details>
      */
-    public operator fun times(other: NonNegativeInteger): NonPositiveInteger =
-        fromInteger(this.value * other.toInteger())
+    public operator fun times(other: NonNegativeInteger): NonPositiveInteger {
+        val product: Integer = this.value * other.toInteger()
+        return fromInteger(product)
+    }
 
     /**
      * Multiplies this integer by the [other] one.

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -347,6 +347,34 @@ public class NonPositiveInteger private constructor(
     public operator fun unaryMinus(): NonNegativeInteger =
         NonNegativeInteger.fromInteger(-this.value)
 
+    /**
+     * Adds the [other] integer to this one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.plus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.plus
+     * </details>
+     */
+    public operator fun plus(other: NonPositiveInteger): NonPositiveInteger =
+        fromInteger(this.value + other.value)
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -431,6 +431,34 @@ public class NonPositiveInteger private constructor(
     public operator fun times(other: NonNegativeInteger): NonPositiveInteger =
         fromInteger(this.value * other.toInteger())
 
+    /**
+     * Multiplies this integer by the [other] one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.timesWithNonPositiveInteger
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.timesWithNonPositiveInteger
+     * </details>
+     */
+    public operator fun times(other: NonPositiveInteger): NonNegativeInteger =
+        NonNegativeInteger.fromInteger(this.value * other.value)
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -27,6 +27,12 @@ import kotlin.jvm.JvmSynthetic
  * (see [fromLong], [fromInteger] and [parse]).
  * - **Comparisons:** Compare integers using
  * [structural equality][NonPositiveInteger.equals] (`x == y`, `x != y`).
+ * - **Arithmetic operations:** [Negate][unaryMinus] (`-x`), [add][plus]
+ * (`x + y`), [subtract][minus] (`x - y`), or [multiply][times] (`x * y`)
+ * non-positive integers, each producing another non-positive or
+ * non-negative integer depending on the operation. Some combinations are
+ * intentionally absent, because the set of non-positive integers isn't
+ * closed under them (e.g., `-1 - (-5) = 4`).
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]),
  * or to its decimal string representation (see
  * [NonPositiveInteger.toString]).

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -317,6 +317,36 @@ public class NonPositiveInteger private constructor(
         return 31 * seed + this.value.hashCode()
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    /**
+     * Returns the negative of this integer.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.unaryMinus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.unaryMinus
+     * </details>
+     */
+    public operator fun unaryMinus(): NonNegativeInteger =
+        NonNegativeInteger.fromInteger(-this.value)
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -375,6 +375,34 @@ public class NonPositiveInteger private constructor(
     public operator fun plus(other: NonPositiveInteger): NonPositiveInteger =
         fromInteger(this.value + other.value)
 
+    /**
+     * Subtracts the [other] integer from this one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerSample.minus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonPositiveIntegerJavaSample.minus
+     * </details>
+     */
+    public operator fun minus(other: NonNegativeInteger): NonPositiveInteger =
+        fromInteger(this.value - other.toInteger())
+
     // ------------------------------ Conversions ------------------------------
 
     /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -407,7 +407,7 @@ public class NonPositiveInteger private constructor(
      * </details>
      */
     public operator fun minus(other: NonNegativeInteger): NonPositiveInteger =
-        fromInteger(this.value - other.toInteger())
+        this + (-other)
 
     /**
      * Multiplies this integer by the [other] one.

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -76,7 +76,9 @@ class NonPositiveIntegerSample {
     @Test
     fun unaryMinus() {
         val x: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
+
         val result: NonNegativeInteger = -x
+
         val expected: NonNegativeInteger = NonNegativeInteger.fromLong(42)
         check(result == expected)
     }
@@ -85,7 +87,9 @@ class NonPositiveIntegerSample {
     fun plus() {
         val x: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
         val y: NonPositiveInteger = NonPositiveInteger.fromLong(-8)
+
         val result: NonPositiveInteger = x + y
+
         val expected: NonPositiveInteger = NonPositiveInteger.fromLong(-50)
         check(result == expected)
     }
@@ -94,7 +98,9 @@ class NonPositiveIntegerSample {
     fun minus() {
         val x: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
         val y: NonNegativeInteger = NonNegativeInteger.fromLong(8)
+
         val result: NonPositiveInteger = x - y
+
         val expected: NonPositiveInteger = NonPositiveInteger.fromLong(-50)
         check(result == expected)
     }
@@ -104,7 +110,9 @@ class NonPositiveIntegerSample {
         val x: NonPositiveInteger =
             NonPositiveInteger.fromLong(-99999999999999999)
         val y: NonNegativeInteger = NonNegativeInteger.fromLong(10)
+
         val result: NonPositiveInteger = x * y
+
         val expected: NonPositiveInteger =
             NonPositiveInteger.parse("-999999999999999990")
         check(result == expected)
@@ -115,7 +123,9 @@ class NonPositiveIntegerSample {
         val x: NonPositiveInteger =
             NonPositiveInteger.fromLong(-99999999999999999)
         val y: NonPositiveInteger = NonPositiveInteger.fromLong(-10)
+
         val result: NonNegativeInteger = x * y
+
         val expected: NonNegativeInteger =
             NonNegativeInteger.parse("999999999999999990")
         check(result == expected)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -71,6 +71,16 @@ class NonPositiveIntegerSample {
         check(x.hashCode() != z.hashCode())
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    fun unaryMinus() {
+        val x: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
+        val result: NonNegativeInteger = -x
+        val expected: NonNegativeInteger = NonNegativeInteger.fromLong(42)
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -90,6 +90,15 @@ class NonPositiveIntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun minus() {
+        val x: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
+        val y: NonNegativeInteger = NonNegativeInteger.fromLong(8)
+        val result: NonPositiveInteger = x - y
+        val expected: NonPositiveInteger = NonPositiveInteger.fromLong(-50)
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -99,6 +99,17 @@ class NonPositiveIntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun timesWithNonNegativeInteger() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.fromLong(-99999999999999999)
+        val y: NonNegativeInteger = NonNegativeInteger.fromLong(10)
+        val result: NonPositiveInteger = x * y
+        val expected: NonPositiveInteger =
+            NonPositiveInteger.parse("-999999999999999990")
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -110,6 +110,17 @@ class NonPositiveIntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun timesWithNonPositiveInteger() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.fromLong(-99999999999999999)
+        val y: NonPositiveInteger = NonPositiveInteger.fromLong(-10)
+        val result: NonNegativeInteger = x * y
+        val expected: NonNegativeInteger =
+            NonNegativeInteger.parse("999999999999999990")
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerSample.kt
@@ -81,6 +81,15 @@ class NonPositiveIntegerSample {
         check(result == expected)
     }
 
+    @Test
+    fun plus() {
+        val x: NonPositiveInteger = NonPositiveInteger.fromLong(-42)
+        val y: NonPositiveInteger = NonPositiveInteger.fromLong(-8)
+        val result: NonPositiveInteger = x + y
+        val expected: NonPositiveInteger = NonPositiveInteger.fromLong(-50)
+        check(result == expected)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -390,6 +390,47 @@ class NonPositiveIntegerTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun timesWithNonNegativeIntegerHasOneAsIdentityElement(): Unit =
+        repeatTest {
+            val x: NonPositiveInteger = Random.nonPositiveInteger()
+            val one: NonNegativeInteger = NonNegativeInteger.fromLong(1)
+            val actual: NonPositiveInteger = x * one
+            assertEquals(x, actual, message = "Input: $x")
+        }
+
+    @Test
+    fun timesWithNonNegativeIntegerHasZeroAsAbsorbingElement(): Unit =
+        repeatTest {
+            val x: NonPositiveInteger = Random.nonPositiveInteger()
+            val zero: NonNegativeInteger = NonNegativeInteger.fromLong(0)
+            val actual: NonPositiveInteger = x * zero
+            val expected: NonPositiveInteger = NonPositiveInteger.fromLong(0)
+            assertEquals(expected, actual, message = "Input: $x")
+        }
+
+    @Test
+    fun timesWithNonNegativeIntegerIsAlwaysNonPositive(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonNegativeInteger = Random.nonNegativeInteger()
+
+        val product: NonPositiveInteger = x * y
+
+        val actual: Boolean = product.toInteger() <= Integer.ZERO
+        assertTrue(actual, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun timesWithNonNegativeIntegerSanityCheck() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.parse("-99999999999999999999")
+        val y: NonNegativeInteger = NonNegativeInteger.parse("10")
+        val actual: NonPositiveInteger = x * y
+        val expected: NonPositiveInteger =
+            NonPositiveInteger.parse("-999999999999999999990")
+        assertEquals(expected, actual)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -307,6 +307,58 @@ class NonPositiveIntegerTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun plusIsCommutative(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger = Random.nonPositiveInteger()
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(x + y, y + x, message)
+    }
+
+    @Test
+    fun plusHasZeroAsIdentityElement(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val zero: NonPositiveInteger = NonPositiveInteger.fromLong(0)
+        val message = "Input: $x"
+        assertEquals(x, x + zero, message)
+        assertEquals(x, zero + x, message)
+    }
+
+    @Test
+    fun plusIsAssociative(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger = Random.nonPositiveInteger()
+        val z: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val actual: NonPositiveInteger = (x + y) + z
+
+        val expected: NonPositiveInteger = x + (y + z)
+        val message = "Inputs: x = $x, y = $y, z = $z"
+        assertEquals(expected, actual, message)
+    }
+
+    @Test
+    fun plusIsAlwaysNonPositive(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val sum: NonPositiveInteger = x + y
+
+        val actual: Boolean = sum.toInteger() <= Integer.ZERO
+        assertTrue(actual, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun plusSanityCheck() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.parse("-99999999999999999999")
+        val y: NonPositiveInteger = NonPositiveInteger.parse("-1")
+        val actual: NonPositiveInteger = x + y
+        val expected: NonPositiveInteger =
+            NonPositiveInteger.parse("-100000000000000000000")
+        assertEquals(expected, actual)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalKotoolsTypesApi::class)
 class NonPositiveIntegerTest {
@@ -271,6 +272,39 @@ class NonPositiveIntegerTest {
         val message = "Structural equality must fail with null."
         assertFalse(equality, message)
         assertFalse(hashEquality, message)
+    }
+
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    fun unaryMinusProducesNonNegativeInteger(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val result: NonNegativeInteger = -x
+
+        val actual: Boolean = result.toInteger() >= Integer.ZERO
+        assertTrue(actual, message = "Input: $x")
+    }
+
+    @Test
+    fun unaryMinusInversesValue(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val result: NonNegativeInteger = -x
+
+        val expected: Integer = -x.toInteger()
+        val message = "Input: $x"
+        assertEquals(expected, actual = result.toInteger(), message)
+    }
+
+    @Test
+    fun unaryMinusSanityCheck() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.parse("-99999999999999999999")
+        val actual: NonNegativeInteger = -x
+        val expected: NonNegativeInteger =
+            NonNegativeInteger.parse("99999999999999999999")
+        assertEquals(expected, actual)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -4,6 +4,7 @@ import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.negativeIntegerString
 import org.kotools.types.nonIntegerString
+import org.kotools.types.nonNegativeInteger
 import org.kotools.types.nonPositiveInteger
 import org.kotools.types.nonPositiveIntegerExcept
 import org.kotools.types.positiveInteger
@@ -354,6 +355,36 @@ class NonPositiveIntegerTest {
             NonPositiveInteger.parse("-99999999999999999999")
         val y: NonPositiveInteger = NonPositiveInteger.parse("-1")
         val actual: NonPositiveInteger = x + y
+        val expected: NonPositiveInteger =
+            NonPositiveInteger.parse("-100000000000000000000")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun minusHasZeroAsIdentityElement(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val zero: NonNegativeInteger = NonNegativeInteger.fromLong(0)
+        val actual: NonPositiveInteger = x - zero
+        assertEquals(x, actual, message = "Input: $x")
+    }
+
+    @Test
+    fun minusIsAlwaysNonPositive(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonNegativeInteger = Random.nonNegativeInteger()
+
+        val difference: NonPositiveInteger = x - y
+
+        val actual: Boolean = difference.toInteger() <= Integer.ZERO
+        assertTrue(actual, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun minusSanityCheck() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.parse("-99999999999999999999")
+        val y: NonNegativeInteger = NonNegativeInteger.parse("1")
+        val actual: NonPositiveInteger = x - y
         val expected: NonPositiveInteger =
             NonPositiveInteger.parse("-100000000000000000000")
         assertEquals(expected, actual)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonPositiveIntegerTest.kt
@@ -431,6 +431,36 @@ class NonPositiveIntegerTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun timesWithNonPositiveIntegerIsCommutative(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger = Random.nonPositiveInteger()
+        val message = "Inputs: x = $x, y = $y"
+        assertEquals(x * y, y * x, message)
+    }
+
+    @Test
+    fun timesWithNonPositiveIntegerIsAlwaysNonNegative(): Unit = repeatTest {
+        val x: NonPositiveInteger = Random.nonPositiveInteger()
+        val y: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val product: NonNegativeInteger = x * y
+
+        val actual: Boolean = product.toInteger() >= Integer.ZERO
+        assertTrue(actual, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun timesWithNonPositiveIntegerSanityCheck() {
+        val x: NonPositiveInteger =
+            NonPositiveInteger.parse("-99999999999999999999")
+        val y: NonPositiveInteger = NonPositiveInteger.parse("-10")
+        val actual: NonNegativeInteger = x * y
+        val expected: NonNegativeInteger =
+            NonNegativeInteger.parse("999999999999999999990")
+        assertEquals(expected, actual)
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -82,6 +82,16 @@ public class NonPositiveIntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void plus() {
+        final NonPositiveInteger x = NonPositiveInteger.fromLong(-42L);
+        final NonPositiveInteger y = NonPositiveInteger.fromLong(-8L);
+        final NonPositiveInteger result = x.plus(y);
+        final NonPositiveInteger expected = NonPositiveInteger.fromLong(-50L);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -71,6 +71,17 @@ public class NonPositiveIntegerJavaSample {
         if (!inequality) throw new IllegalStateException("Check failed.");
     }
 
+    // ------------------------- Arithmetic operations -------------------------
+
+    @Test
+    void unaryMinus() {
+        final NonPositiveInteger x = NonPositiveInteger.fromLong(-42L);
+        final NonNegativeInteger result = x.unaryMinus();
+        final NonNegativeInteger expected = NonNegativeInteger.fromLong(42L);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -114,6 +114,18 @@ public class NonPositiveIntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void timesWithNonPositiveInteger() {
+        final NonPositiveInteger x =
+                NonPositiveInteger.fromLong(-99999999999999999L);
+        final NonPositiveInteger y = NonPositiveInteger.fromLong(-10L);
+        final NonNegativeInteger result = x.times(y);
+        final NonNegativeInteger expected =
+                NonNegativeInteger.parse("999999999999999990");
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -92,6 +92,16 @@ public class NonPositiveIntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void minus() {
+        final NonPositiveInteger x = NonPositiveInteger.fromLong(-42L);
+        final NonNegativeInteger y = NonNegativeInteger.fromLong(8L);
+        final NonPositiveInteger result = x.minus(y);
+        final NonPositiveInteger expected = NonPositiveInteger.fromLong(-50L);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -102,6 +102,18 @@ public class NonPositiveIntegerJavaSample {
         if (!check) throw new IllegalStateException("Check failed.");
     }
 
+    @Test
+    void timesWithNonNegativeInteger() {
+        final NonPositiveInteger x =
+                NonPositiveInteger.fromLong(-99999999999999999L);
+        final NonNegativeInteger y = NonNegativeInteger.fromLong(10L);
+        final NonPositiveInteger result = x.times(y);
+        final NonPositiveInteger expected =
+                NonPositiveInteger.parse("-999999999999999990");
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
     // ------------------------------ Conversions ------------------------------
 
     @Test

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonPositiveIntegerJavaSample.java
@@ -76,7 +76,9 @@ public class NonPositiveIntegerJavaSample {
     @Test
     void unaryMinus() {
         final NonPositiveInteger x = NonPositiveInteger.fromLong(-42L);
+
         final NonNegativeInteger result = x.unaryMinus();
+
         final NonNegativeInteger expected = NonNegativeInteger.fromLong(42L);
         final boolean check = result.equals(expected);
         if (!check) throw new IllegalStateException("Check failed.");
@@ -86,7 +88,9 @@ public class NonPositiveIntegerJavaSample {
     void plus() {
         final NonPositiveInteger x = NonPositiveInteger.fromLong(-42L);
         final NonPositiveInteger y = NonPositiveInteger.fromLong(-8L);
+
         final NonPositiveInteger result = x.plus(y);
+
         final NonPositiveInteger expected = NonPositiveInteger.fromLong(-50L);
         final boolean check = result.equals(expected);
         if (!check) throw new IllegalStateException("Check failed.");
@@ -96,7 +100,9 @@ public class NonPositiveIntegerJavaSample {
     void minus() {
         final NonPositiveInteger x = NonPositiveInteger.fromLong(-42L);
         final NonNegativeInteger y = NonNegativeInteger.fromLong(8L);
+
         final NonPositiveInteger result = x.minus(y);
+
         final NonPositiveInteger expected = NonPositiveInteger.fromLong(-50L);
         final boolean check = result.equals(expected);
         if (!check) throw new IllegalStateException("Check failed.");
@@ -107,7 +113,9 @@ public class NonPositiveIntegerJavaSample {
         final NonPositiveInteger x =
                 NonPositiveInteger.fromLong(-99999999999999999L);
         final NonNegativeInteger y = NonNegativeInteger.fromLong(10L);
+
         final NonPositiveInteger result = x.times(y);
+
         final NonPositiveInteger expected =
                 NonPositiveInteger.parse("-999999999999999990");
         final boolean check = result.equals(expected);
@@ -119,7 +127,9 @@ public class NonPositiveIntegerJavaSample {
         final NonPositiveInteger x =
                 NonPositiveInteger.fromLong(-99999999999999999L);
         final NonPositiveInteger y = NonPositiveInteger.fromLong(-10L);
+
         final NonNegativeInteger result = x.times(y);
+
         final NonNegativeInteger expected =
                 NonNegativeInteger.parse("999999999999999990");
         final boolean check = result.equals(expected);


### PR DESCRIPTION
## Summary

Adds arithmetic operations to `NonPositiveInteger`: `unaryMinus`, `plus`, `minus`, and two `times` overloads, each closed under `NonPositiveInteger` or `NonNegativeInteger`. Adds KDoc, Kotlin/Java samples, tests, a refreshed ABI dump, a new ADR-017 documenting the excluded combinations, and a changelog update.

Closes #1024.

Generated with [Claude Code](https://claude.ai/code)