### PR TITLE
✨ Add `fromInteger` function to `Decimal` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,8 @@ The format is based on [Keep a Changelog], and this project adheres to its own
   package, representing an `Integer` that is less than or equal to zero.
   (module: `types`, refs: [#1013], [#1024])
 - `Decimal` **experimental** class to `org.kotools.types.number` package,
-  representing mathematical decimal numbers with exact arithmetic, with a
-  `fromInteger` factory function for creating a `Decimal` from an `Integer`.
-  (module: `types`, refs: [#925] originally suggested by [@CLOVIS-AI], [#992])
+  representing mathematical decimal numbers with exact arithmetic. (module:
+  `types`, refs: [#925] originally suggested by [@CLOVIS-AI], [#992])
 
 ### ♻️ Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ The format is based on [Keep a Changelog], and this project adheres to its own
   package, representing an `Integer` that is less than or equal to zero.
   (module: `types`, refs: [#1013], [#1024])
 - `Decimal` **experimental** class to `org.kotools.types.number` package,
-  representing mathematical decimal numbers with exact arithmetic. (module:
-  `types`, ref: [#925] originally suggested by [@CLOVIS-AI])
+  representing mathematical decimal numbers with exact arithmetic, with a
+  `fromInteger` factory function for creating a `Decimal` from an `Integer`.
+  (module: `types`, refs: [#925] originally suggested by [@CLOVIS-AI], [#992])
 
 ### ♻️ Changed
 
@@ -162,6 +163,7 @@ The format is based on [Keep a Changelog], and this project adheres to its own
 [#988]: https://github.com/kotools/types/issues/988
 [#989]: https://github.com/kotools/types/issues/989
 [#990]: https://github.com/kotools/types/issues/990
+[#992]: https://github.com/kotools/types/issues/992
 [#998]: https://github.com/kotools/types/issues/998
 [#999]: https://github.com/kotools/types/issues/999
 [#1010]: https://github.com/kotools/types/issues/1010

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -366,6 +366,7 @@ public final class org/kotools/types/number/Decimal {
 	public synthetic fun <init> (Lorg/kotools/types/number/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun compareTo (Lorg/kotools/types/number/Decimal;)I
 	public final fun equals (Ljava/lang/Object;)Z
+	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Decimal;
 	public static final fun fromLong (J)Lorg/kotools/types/number/Decimal;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Decimal;)Lorg/kotools/types/number/Decimal;
@@ -377,6 +378,7 @@ public final class org/kotools/types/number/Decimal {
 }
 
 public final class org/kotools/types/number/Decimal$Companion {
+	public final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Decimal;
 	public final fun fromLong (J)Lorg/kotools/types/number/Decimal;
 	public final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Decimal;
 	public final synthetic fun parseOrNull (Ljava/lang/String;)Lorg/kotools/types/number/Decimal;

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -114,7 +114,7 @@ public class Decimal private constructor(
         @JvmStatic
         public fun fromLong(value: Long): Decimal {
             val unscaled: Integer = Integer.fromLong(value)
-            return Decimal(unscaled, scale = 0)
+            return fromInteger(unscaled)
         }
 
         /**

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -3,6 +3,7 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.internal.HashSeed
 import org.kotools.types.internal.errorMessage
+import org.kotools.types.number.Decimal.Companion.fromInteger
 import org.kotools.types.number.Decimal.Companion.fromLong
 import org.kotools.types.number.Decimal.Companion.parse
 import org.kotools.types.number.Decimal.Companion.parseOrNull
@@ -56,8 +57,8 @@ import kotlin.jvm.JvmSynthetic
  *
  * ### Key features
  *
- * - **Creations:** Create from Kotlin integer types or decimal string (see
- * [fromLong] and [parse]).
+ * - **Creations:** Create from Kotlin integer types, [Integer], or decimal
+ * string (see [fromLong], [fromInteger], and [parse]).
  * - **Comparisons:** Compare decimals using
  * [structural equality][Decimal.equals] (`x == y`, `x != y`) and
  * [ordering operators][compareTo] (`x < y`, `x <= y`, `x > y`, `x >= y`).
@@ -115,6 +116,37 @@ public class Decimal private constructor(
             val unscaled: Integer = Integer.fromLong(value)
             return Decimal(unscaled, scale = 0)
         }
+
+        /**
+         * Returns a [Decimal] representing the specified [value].
+         *
+         * This function preserves the canonical representation of [value].
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Kotlin</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Kotlin code:
+         *
+         * SAMPLE: org.kotools.types.number.DecimalSample.fromInteger
+         * </details>
+         *
+         * <br>
+         * <details>
+         * <summary>
+         *     <b>Calling from Java</b>
+         * </summary>
+         *
+         * Here's an example of calling this function from Java code:
+         *
+         * SAMPLE: org.kotools.types.number.DecimalJavaSample.fromInteger
+         * </details>
+         */
+        @JvmStatic
+        public fun fromInteger(value: Integer): Decimal =
+            Decimal(value, scale = 0)
 
         /**
          * Returns a [Decimal] representing the number described by [value],

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/DecimalSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/DecimalSample.kt
@@ -28,6 +28,18 @@ class DecimalSample {
     }
 
     @Test
+    fun fromInteger() {
+        fun createsFromInteger(input: Integer, expected: String) {
+            val result: Decimal = Decimal.fromInteger(input)
+            check("$result" == expected)
+        }
+
+        createsFromInteger(input = Integer.fromLong(0), expected = "0")
+        createsFromInteger(input = Integer.fromLong(42), expected = "42")
+        createsFromInteger(input = Integer.fromLong(-42), expected = "-42")
+    }
+
+    @Test
     fun parsing() {
         fun parsesTo(input: String, expected: String) {
             check(Decimal.parse(input).toString() == expected)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/DecimalTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/DecimalTest.kt
@@ -3,6 +3,7 @@ package org.kotools.types.number
 import org.kotools.types.ExperimentalKotoolsTypesApi
 import org.kotools.types.decimal
 import org.kotools.types.decimalExcept
+import org.kotools.types.integer
 import org.kotools.types.internal.errorMessage
 import org.kotools.types.nonDecimalString
 import org.kotools.types.positiveDecimal
@@ -26,6 +27,16 @@ class DecimalTest {
         val value: Long = Random.nextLong()
 
         val actual: Decimal = Decimal.fromLong(value)
+
+        val expected: String = value.toString()
+        assertEquals(expected, actual = "$actual", message = "Input: $value")
+    }
+
+    @Test
+    fun fromIntegerPreservesIntegerRepresentation(): Unit = repeatTest {
+        val value: Integer = Random.integer()
+
+        val actual: Decimal = Decimal.fromInteger(value)
 
         val expected: String = value.toString()
         assertEquals(expected, actual = "$actual", message = "Input: $value")

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/DecimalJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/DecimalJavaSample.java
@@ -26,6 +26,19 @@ public class DecimalJavaSample {
     }
 
     @Test
+    void fromInteger() {
+        final BiConsumer<Integer, String> creates = (input, expected) -> {
+            final Decimal result = Decimal.fromInteger(input);
+            final boolean check = String.valueOf(result).equals(expected);
+            if (!check) throw new IllegalStateException("Check failed.");
+        };
+
+        creates.accept(Integer.fromLong(0), "0");
+        creates.accept(Integer.fromLong(42), "42");
+        creates.accept(Integer.fromLong(-42), "-42");
+    }
+
+    @Test
     void parsing() {
         final BiConsumer<String, String> parsesTo = (input, expected) -> {
             final boolean check = String.valueOf(Decimal.parse(input))


### PR DESCRIPTION
## Summary

Adds an experimental `fromInteger(Integer)` factory function to the `Decimal` class, and refactors `fromLong` to reuse it.

Closes #992.

Generated with [Claude Code](https://claude.ai/code)