### PR TITLE
🔥 Remove links to source files from ADRs

### DIFF
--- a/documentation/decisions/ADR-001-integer-euclidean-division.md
+++ b/documentation/decisions/ADR-001-integer-euclidean-division.md
@@ -1,7 +1,7 @@
 # ⚖️ ADR-001: Euclidean division for `Integer`
 
 This document records two related architectural decisions made when implementing
-division semantics for the [`Integer`][Integer] type.
+division semantics for the `Integer` type.
 
 ## 🤔 Context
 
@@ -75,7 +75,3 @@ functions are introduced.
 - The division algorithm `a = q·b + r` always holds with `0 ≤ r < |b|`
 - A future `Rational` type must expose its construction through a dedicated API
   (factory function or infix operator) and must not reuse `div` / `rem`
-
-<!----------------------------------- Links ----------------------------------->
-
-[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt

--- a/documentation/decisions/ADR-002-integer-value-semantics.md
+++ b/documentation/decisions/ADR-002-integer-value-semantics.md
@@ -1,7 +1,7 @@
 # ⚖️ ADR-002: Value semantics for `Integer` arithmetic operations
 
 This document records the decision to eliminate reference-identity
-short-circuits from [`Integer`][Integer] arithmetic operations.
+short-circuits from `Integer` arithmetic operations.
 
 ## 🤔 Context
 
@@ -43,7 +43,3 @@ No operation may return `this` or any input operand as its result.
   invalid by design and must not be written.
 - Future arithmetic operations must follow the same rule: never return `this`
   or any input operand.
-
-<!----------------------------------- Links ----------------------------------->
-
-[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt

--- a/documentation/decisions/ADR-003-euclidean-division-platform-impl.md
+++ b/documentation/decisions/ADR-003-euclidean-division-platform-impl.md
@@ -2,16 +2,16 @@
 
 This document records how Euclidean division semantics (decided in
 [ADR-001][ADR-001]) are implemented across the three
-[`PlatformInteger`][PlatformInteger] backends.
+`PlatformInteger` backends.
 
 ## 🤔 Context
 
 `Integer` delegates all arithmetic to `PlatformInteger`, an `expect`/`actual`
 interface with three implementations:
 
-- [`JvmInteger`][PlatformInteger.jvm] — wraps `java.math.BigInteger`
-- [`JsInteger`][PlatformInteger.js] — wraps JS `BigInt`
-- [`NativeInteger`][PlatformInteger.native] — wraps kotlin-bignum `BigInteger`
+- `JvmInteger` — wraps `java.math.BigInteger`
+- `JsInteger` — wraps JS `BigInt`
+- `NativeInteger` — wraps kotlin-bignum `BigInteger`
 
 ADR-001 decided *what* the semantics should be. This ADR records *how* they
 are achieved on each platform.
@@ -56,7 +56,3 @@ construction.
 <!----------------------------------- Links ----------------------------------->
 
 [ADR-001]: ADR-001-integer-euclidean-division.md
-[PlatformInteger]: ../../subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
-[PlatformInteger.jvm]: ../../subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
-[PlatformInteger.js]: ../../subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
-[PlatformInteger.native]: ../../subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt

--- a/documentation/decisions/ADR-003-euclidean-division-platform-impl.md
+++ b/documentation/decisions/ADR-003-euclidean-division-platform-impl.md
@@ -1,8 +1,7 @@
 # 🔧 ADR-003: Platform implementation of Euclidean division
 
-This document records how Euclidean division semantics (decided in
-[ADR-001][ADR-001]) are implemented across the three
-`PlatformInteger` backends.
+This document records how Euclidean division semantics (decided in [ADR-001])
+are implemented across the three `PlatformInteger` backends.
 
 ## 🤔 Context
 

--- a/documentation/decisions/ADR-004-decimal-scaled-integer-repr.md
+++ b/documentation/decisions/ADR-004-decimal-scaled-integer-repr.md
@@ -1,7 +1,7 @@
 # ⚖️ ADR-004: Scaled-integer representation for `Decimal`
 
-This document records the decision about how `Decimal` stores
-decimal numbers internally.
+This document records the decision about how `Decimal` stores decimal numbers
+internally.
 
 ## 🤔 Context
 

--- a/documentation/decisions/ADR-004-decimal-scaled-integer-repr.md
+++ b/documentation/decisions/ADR-004-decimal-scaled-integer-repr.md
@@ -1,6 +1,6 @@
 # ⚖️ ADR-004: Scaled-integer representation for `Decimal`
 
-This document records the decision about how [`Decimal`][Decimal] stores
+This document records the decision about how `Decimal` stores
 decimal numbers internally.
 
 ## 🤔 Context
@@ -57,5 +57,4 @@ fractional digits.
 
 <!----------------------------------- Links ----------------------------------->
 
-[Decimal]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
 [ADR-005]: ADR-005-decimal-canonical-form.md

--- a/documentation/decisions/ADR-005-decimal-canonical-form.md
+++ b/documentation/decisions/ADR-005-decimal-canonical-form.md
@@ -5,8 +5,8 @@ every `Decimal` value, and how that invariant is maintained.
 
 ## 🤔 Context
 
-The scaled-integer representation chosen in [ADR-004][ADR-004] allows the
-same mathematical value to be expressed in multiple ways:
+The scaled-integer representation chosen in [ADR-004] allows the same
+mathematical value to be expressed in multiple ways:
 
 - `3.14` → `(314, 2)` and `3.140` → `(3140, 3)` represent the same number.
 - `+42` and `42` and `042` all denote the same integer.

--- a/documentation/decisions/ADR-005-decimal-canonical-form.md
+++ b/documentation/decisions/ADR-005-decimal-canonical-form.md
@@ -1,7 +1,7 @@
 # ⚖️ ADR-005: Canonical form for `Decimal`
 
 This document records the decision to enforce a unique canonical form for
-every [`Decimal`][Decimal] value, and how that invariant is maintained.
+every `Decimal` value, and how that invariant is maintained.
 
 ## 🤔 Context
 
@@ -73,5 +73,4 @@ never divisible by 10 unless the fractional part is empty (scale = 0).
 
 <!----------------------------------- Links ----------------------------------->
 
-[Decimal]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
 [ADR-004]: ADR-004-decimal-scaled-integer-repr.md

--- a/documentation/decisions/ADR-006-decimal-division-exclusion.md
+++ b/documentation/decisions/ADR-006-decimal-division-exclusion.md
@@ -1,7 +1,7 @@
 # ⚖️ ADR-006: Exclusion of division from `Decimal` arithmetic
 
 This document records the decision to omit division (and modulo) from the
-[`Decimal`][Decimal] type's arithmetic API.
+`Decimal` type's arithmetic API.
 
 ## 🤔 Context
 
@@ -53,7 +53,3 @@ operations provided are unary minus (`-x`), addition (`x + y`), subtraction
 - A future `Rational` type (ℚ) could accept two `Decimal` (or `Integer`)
   values as its numerator and denominator, covering the exact-division use
   case without compromising `Decimal`.
-
-<!----------------------------------- Links ----------------------------------->
-
-[Decimal]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt

--- a/documentation/decisions/ADR-006-decimal-division-exclusion.md
+++ b/documentation/decisions/ADR-006-decimal-division-exclusion.md
@@ -36,8 +36,8 @@ operations provided are unary minus (`-x`), addition (`x + y`), subtraction
   `Decimal` and would belong to a future `Rational` type.
 - **Consistent with `Integer` design.** The `Integer` type excludes
   operations that leave the set of integers: it has no square root and no
-  non-integer division. `Decimal` follows the same principle — only
-  operations that keep results within the modelled set are exposed.
+  noninteger division. `Decimal` follows the same principle — only
+  operations that keep results within the modeled set are exposed.
 - **Explicit delegation to the caller.** Users who need division can convert
   to `Double`, `Float`, or `java.math.BigDecimal` themselves, making the
   precision trade-off an explicit decision at the call site rather than a

--- a/documentation/decisions/ADR-007-native-integer-sign-magnitude-repr.md
+++ b/documentation/decisions/ADR-007-native-integer-sign-magnitude-repr.md
@@ -1,8 +1,8 @@
 # ⚖️ ADR-007: Sign-magnitude representation for `NativeInteger`
 
 This document records the decision about how
-[`NativeInteger`][PlatformInteger.native] — the Kotlin/Native implementation
-of [`PlatformInteger`][PlatformInteger] — represents and computes
+`NativeInteger` — the Kotlin/Native implementation
+of `PlatformInteger` — represents and computes
 arbitrary-precision integers.
 
 ## 🤔 Context
@@ -24,7 +24,7 @@ arithmetic without relying on `kotlin-bignum`?
 - `magnitude` holds the absolute value in **little-endian base-2³² limbs**,
   trimmed so that it never has a zero most-significant limb (the empty array
   represents zero).
-- [`IntegerSign`][IntegerSign] is an internal enum (`Negative`, `Zero`,
+- `IntegerSign` is an internal enum (`Negative`, `Zero`,
   `Positive`) with `unaryMinus`, `times` (sign propagation for
   multiplication and division) and `compare` (for ordering).
 
@@ -41,9 +41,8 @@ formatting).
 **Rationale:**
 
 - **Removes the only Native-only third-party dependency.** Aligns with the
-  "avoid useless dependencies" design goal: `kotlin-bignum` is dropped from
-  `gradle/libs.versions.toml` and
-  `subprojects/internal/build.gradle.kts`.
+  "avoid useless dependencies" design goal: `kotlin-bignum` is dropped as a
+  runtime dependency.
 - **Well-understood representation.** Sign-magnitude is the same
   representation used internally by `java.math.BigInteger` and most
   arbitrary-precision integer implementations, with well-known algorithms for
@@ -69,15 +68,11 @@ formatting).
 - `IntegerSign` and the magnitude algorithms are private to `nativeMain` and
   have no impact on the common-API ABI dumps.
 - Future bug fixes and performance improvements to Native arbitrary-precision
-  arithmetic are made directly in
-  `subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt`,
-  rather than tracked upstream in a third-party library.
+  arithmetic are made directly in the Native implementation, rather than
+  tracked upstream in a third-party library.
 
 <!----------------------------------- Links ----------------------------------->
 
-[PlatformInteger]: ../../subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
-[PlatformInteger.native]: ../../subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt
-[IntegerSign]: ../../subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/IntegerSign.kt
 [ADR-003]: ADR-003-euclidean-division-platform-impl.md
 [ADR-005]: ADR-005-decimal-canonical-form.md
 [ADR-008]: ADR-008-euclidean-division-platform-impl-v2.md

--- a/documentation/decisions/ADR-007-native-integer-sign-magnitude-repr.md
+++ b/documentation/decisions/ADR-007-native-integer-sign-magnitude-repr.md
@@ -1,8 +1,7 @@
 # ⚖️ ADR-007: Sign-magnitude representation for `NativeInteger`
 
-This document records the decision about how
-`NativeInteger` — the Kotlin/Native implementation
-of `PlatformInteger` — represents and computes
+This document records the decision about how `NativeInteger` — the Kotlin/Native
+implementation of `PlatformInteger` — represents and computes
 arbitrary-precision integers.
 
 ## 🤔 Context
@@ -11,47 +10,45 @@ Until now, `NativeInteger` delegated all arithmetic to `BigInteger` from
 `com.ionspin.kotlin:bignum`, the only third-party runtime dependency used
 exclusively by the Kotlin/Native target.
 
-One of the [design goals](../design-goals.md) of Kotools Types is to "avoid
-useless dependencies" and depend only on what is strictly necessary. This
-raised the question: can `NativeInteger` provide arbitrary-precision integer
-arithmetic without relying on `kotlin-bignum`?
+One of the [design goals] of Kotools Types is to "avoid useless dependencies"
+and depend only on what is strictly necessary. This raised the question: can
+`NativeInteger` provide arbitrary-precision integer arithmetic without relying
+on `kotlin-bignum`?
 
 ## ✅ Decision: Custom sign-magnitude representation
 
-`NativeInteger` stores its value as a pair of
-`(magnitude: UIntArray, sign: IntegerSign)`:
+`NativeInteger` stores its value as a pair of `(magnitude: UIntArray, sign:
+IntegerSign)`:
 
 - `magnitude` holds the absolute value in **little-endian base-2³² limbs**,
   trimmed so that it never has a zero most-significant limb (the empty array
   represents zero).
-- `IntegerSign` is an internal enum (`Negative`, `Zero`,
-  `Positive`) with `unaryMinus`, `times` (sign propagation for
-  multiplication and division) and `compare` (for ordering).
+- `IntegerSign` is an internal enum (`Negative`, `Zero`, `Positive`) with
+  `unaryMinus`, `times` (sign propagation for multiplication and division) and
+  `compare` (for ordering).
 
-A class invariant, enforced in `init`, ties the two fields together:
-`magnitude` is empty **if and only if** `sign == Zero`, and `magnitude` never
-carries a zero most-significant limb.
+A class invariant, enforced in `init`, ties the two fields together: `magnitude`
+is empty **if and only if** `sign == Zero`, and `magnitude` never carries a zero
+most-significant limb.
 
 All operations — `plus`, `minus`, `times`, `div`, `rem`, `compareTo`,
-`unaryMinus`, `parse`, and `toString` — are implemented from scratch on top
-of magnitude-level algorithms (addition, subtraction, multiplication, binary
-long division, bit shifts, and repeated division by ten for decimal
-formatting).
+`unaryMinus`, `parse`, and `toString` — are implemented from scratch on top of
+magnitude-level algorithms (addition, subtraction, multiplication, binary long
+division, bit shifts, and repeated division by ten for decimal formatting).
 
 **Rationale:**
 
 - **Removes the only Native-only third-party dependency.** Aligns with the
   "avoid useless dependencies" design goal: `kotlin-bignum` is dropped as a
   runtime dependency.
-- **Well-understood representation.** Sign-magnitude is the same
-  representation used internally by `java.math.BigInteger` and most
-  arbitrary-precision integer implementations, with well-known algorithms for
-  every operation.
+- **Well-understood representation.** Sign-magnitude is the same representation
+  used internally by `java.math.BigInteger` and most arbitrary-precision integer
+  implementations, with well-known algorithms for every operation.
 - **Canonical form enables cheap equality.** A trimmed magnitude (no leading
-  zero limb, empty array for zero) gives each value a unique
-  `(magnitude, sign)` representation, so `equals`/`hashCode` reduce to
-  comparing the two fields directly — the same canonical-form principle
-  established for `Decimal` in [ADR-005][ADR-005].
+  zero limb, empty array for zero) gives each value a unique `(magnitude, sign)`
+  representation, so `equals`/`hashCode` reduce to comparing the two fields
+  directly — the same canonical-form principle established for `Decimal` in
+  [ADR-005].
 - **Self-documenting sign arithmetic.** Modeling the sign as an `IntegerSign`
   enum — rather than a raw `Int` (`-1`/`0`/`1`) — lets sign propagation
   (`times`, `unaryMinus`) and ordering (`compare`) be expressed as exhaustive
@@ -59,20 +56,21 @@ formatting).
 
 ## 🔗 Consequences
 
-- `nativeMainImplementation(libs.bignum)` and the corresponding `bignum`
-  entries in `gradle/libs.versions.toml` are removed.
+- `nativeMainImplementation(libs.bignum)` and the corresponding `bignum` entries
+  in `gradle/libs.versions.toml` are removed.
 - The Native implementation of Euclidean division (`div`/`rem`) no longer
   delegates to a `mod()`-style function from `kotlin-bignum`; it is computed
-  directly from the magnitude representation introduced here (see
-  [ADR-008][ADR-008], which supersedes [ADR-003][ADR-003]).
+  directly from the magnitude representation introduced here (see [ADR-008],
+  which supersedes [ADR-003]).
 - `IntegerSign` and the magnitude algorithms are private to `nativeMain` and
   have no impact on the common-API ABI dumps.
 - Future bug fixes and performance improvements to Native arbitrary-precision
-  arithmetic are made directly in the Native implementation, rather than
-  tracked upstream in a third-party library.
+  arithmetic are made directly in the Native implementation, rather than tracked
+  upstream in a third-party library.
 
 <!----------------------------------- Links ----------------------------------->
 
 [ADR-003]: ADR-003-euclidean-division-platform-impl.md
 [ADR-005]: ADR-005-decimal-canonical-form.md
 [ADR-008]: ADR-008-euclidean-division-platform-impl-v2.md
+[design goals]: ../design-goals.md

--- a/documentation/decisions/ADR-008-euclidean-division-platform-impl-v2.md
+++ b/documentation/decisions/ADR-008-euclidean-division-platform-impl-v2.md
@@ -6,16 +6,16 @@
 
 This document records how Euclidean division semantics (decided in
 [ADR-001][ADR-001]) are implemented across the three
-[`PlatformInteger`][PlatformInteger] backends.
+`PlatformInteger` backends.
 
 ## 🤔 Context
 
 `Integer` delegates all arithmetic to `PlatformInteger`, an `expect`/`actual`
 interface with three implementations:
 
-- [`JvmInteger`][PlatformInteger.jvm] — wraps `java.math.BigInteger`
-- [`JsInteger`][PlatformInteger.js] — wraps JS `BigInt`
-- [`NativeInteger`][PlatformInteger.native] — a custom sign-magnitude integer
+- `JvmInteger` — wraps `java.math.BigInteger`
+- `JsInteger` — wraps JS `BigInt`
+- `NativeInteger` — a custom sign-magnitude integer
   (`magnitude: UIntArray` + `sign: IntegerSign`), as decided in
   [ADR-007][ADR-007]
 
@@ -76,7 +76,3 @@ The per-platform `rem`/`div` strategies are:
 [ADR-001]: ADR-001-integer-euclidean-division.md
 [ADR-003]: ADR-003-euclidean-division-platform-impl.md
 [ADR-007]: ADR-007-native-integer-sign-magnitude-repr.md
-[PlatformInteger]: ../../subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/number/PlatformInteger.kt
-[PlatformInteger.jvm]: ../../subprojects/internal/src/jvmMain/kotlin/org/kotools/types/internal/number/PlatformInteger.jvm.kt
-[PlatformInteger.js]: ../../subprojects/internal/src/jsMain/kotlin/org/kotools/types/internal/number/PlatformInteger.js.kt
-[PlatformInteger.native]: ../../subprojects/internal/src/nativeMain/kotlin/org/kotools/types/internal/number/PlatformInteger.native.kt

--- a/documentation/decisions/ADR-008-euclidean-division-platform-impl-v2.md
+++ b/documentation/decisions/ADR-008-euclidean-division-platform-impl-v2.md
@@ -1,12 +1,10 @@
 # 🔧 ADR-008: Platform implementation of Euclidean division (v2)
 
-> **Supersedes:** [ADR-003][ADR-003], whose description of the Native
-> backend no longer matches the implementation since the rewrite recorded in
-> [ADR-007][ADR-007].
+> **Supersedes:** [ADR-003], whose description of the Native backend no longer
+> matches the implementation since the rewrite recorded in [ADR-007].
 
-This document records how Euclidean division semantics (decided in
-[ADR-001][ADR-001]) are implemented across the three
-`PlatformInteger` backends.
+This document records how Euclidean division semantics (decided in [ADR-001])
+are implemented across the three `PlatformInteger` backends.
 
 ## 🤔 Context
 
@@ -15,11 +13,10 @@ interface with three implementations:
 
 - `JvmInteger` — wraps `java.math.BigInteger`
 - `JsInteger` — wraps JS `BigInt`
-- `NativeInteger` — a custom sign-magnitude integer
-  (`magnitude: UIntArray` + `sign: IntegerSign`), as decided in
-  [ADR-007][ADR-007]
+- `NativeInteger` — a custom sign-magnitude integer (`magnitude: UIntArray` + 
+  `sign: IntegerSign`), as decided in [ADR-007]
 
-ADR-001 decided *what* the semantics should be. This ADR records *how* they
+[ADR-001] decided *what* the semantics should be. This ADR records *how* they
 are achieved on each platform.
 
 The core challenge is that none of the three backends natively computes the
@@ -33,43 +30,41 @@ scratch on top of the magnitude representation.
 
 The per-platform `rem`/`div` strategies are:
 
-- **JVM:** `rem` is the primary operation —
-  `dividend.mod(divisor.abs())`. Java's `BigInteger.mod(m)` requires `m > 0`
-  and always returns a non-negative result. Passing the absolute value of the
-  divisor handles negative divisors without additional branching. `div` is
-  then derived from `rem` as `(dividend - remainder) / divisor`, so the
-  Euclidean identity `a = q·b + r` holds by construction.
-
-- **JS:** `rem` is the primary operation, computed as the T-remainder via
-  `%`, then `|divisor|` is added when the result is negative. JS `BigInt`
-  exposes only T-division; no native `mod` with a sign-safe contract exists.
-  `div` is derived from `rem` the same way as on JVM.
-
+- **JVM:** `rem` is the primary operation — `dividend.mod(divisor.abs())`.
+  Java's `BigInteger.mod(m)` requires `m > 0` and always returns a non-negative
+  result. Passing the absolute value of the divisor handles negative divisors
+  without additional branching. `div` is then derived from `rem` as
+  `(dividend - remainder) / divisor`, so the Euclidean identity `a = q·b + r`
+  holds by construction.
+- **JS:** `rem` is the primary operation, computed as the T-remainder via `%`,
+  then `|divisor|` is added when the result is negative. JS `BigInt` exposes
+  only T-division; no native `mod` with a sign-safe contract exists. `div` is
+  derived from `rem` the same way as on JVM.
 - **Native:** `div` and `rem` are produced **together** by a single shared
   `divModMagnitudes` helper — neither is derived from the other. This helper
-  performs binary long division on the absolute-value magnitudes, which
-  yields a non-negative quotient/remainder pair by construction. If the
-  dividend is negative, the result is corrected to satisfy Euclidean
-  semantics: the quotient magnitude is incremented by one, and the remainder
-  is replaced by `|divisor| − remainder`. This guarantees `0 ≤ r < |b|` for
-  every combination of signs.
+  performs binary long division on the absolute-value magnitudes, which yields a
+  non-negative quotient/remainder pair by construction. If the dividend is
+  negative, the result is corrected to satisfy Euclidean semantics: the quotient
+  magnitude is incremented by one, and the remainder is replaced by
+  `|divisor| − remainder`. This guarantees `0 ≤ r < |b|` for every combination
+  of signs.
 
 ## 🔗 Consequences
 
-- Cross-platform consistency: all three backends produce identical results
-  for any `(a, b)` pair, despite using three distinct sign-correction
-  strategies — JVM's `mod()` delegation, JS's `%`-then-add, and Native's
+- Cross-platform consistency: all three backends produce identical results for
+  any `(a, b)` pair, despite using three distinct sign-correction strategies —
+  JVM's `mod()` delegation, JS's `%`-then-add, and Native's
   magnitude-division-then-correct.
-- On JVM and JS, `div` calling `rem` remains the load-bearing derivation
-  order — `rem` must be defined first, and tests verifying Euclidean
-  semantics should target `rem` directly. **This does not apply to Native**,
-  where `div` and `rem` are two views of the same `divModMagnitudes` result;
-  tests for Native should exercise both `div` and `rem` independently.
-- Future platforms should pick whichever sign-correction pattern best fits
-  their available primitives — a `mod`-with-positive-modulus operation
-  (JVM-style), a `%`-then-add correction (JS-style), or a from-scratch
-  magnitude algorithm with post-hoc correction (Native-style) — as long as
-  the Euclidean identity (`a = q·b + r`, `0 ≤ r < |b|`) holds.
+- On JVM and JS, `div` calling `rem` remains the load-bearing derivation order —
+  `rem` must be defined first, and tests verifying Euclidean semantics should
+  target `rem` directly. **This does not apply to Native**, where `div` and
+  `rem` are two views of the same `divModMagnitudes` result; tests for Native
+  should exercise both `div` and `rem` independently.
+- Future platforms should pick whichever sign-correction pattern best fits their
+  available primitives — a `mod`-with-positive-modulus operation (JVM-style), a
+  `%`-then-add correction (JS-style), or a from-scratch magnitude algorithm with
+  post-hoc correction (Native-style) — as long as the Euclidean identity
+  (`a = q·b + r`, `0 ≤ r < |b|`) holds.
 
 <!----------------------------------- Links ----------------------------------->
 

--- a/documentation/decisions/ADR-009-default-serializer-serial-names.md
+++ b/documentation/decisions/ADR-009-default-serializer-serial-names.md
@@ -1,14 +1,13 @@
 # 🏷️ ADR-009: Explicit serial names for default serializers
 
 This document records how the `SerialDescriptor.serialName` of the default
-`kotlinx.serialization` serializers is determined in
-`SerializersModule`.
+`kotlinx.serialization` serializers is determined in `SerializersModule`.
 
 ## 🤔 Context
 
-`KotoolsTypesSerializersModule()` provides default
-serializers for `EmailAddress` and `EmailAddressRegex`, encoding and decoding
-both types as `String`.
+`KotoolsTypesSerializersModule()` provides default serializers for
+`EmailAddress` and `EmailAddressRegex`, encoding and decoding both types as
+`String`.
 
 Each serializer's `SerialDescriptor` carries a `serialName`. Until now, this
 name was computed at runtime by a private reified helper,
@@ -18,8 +17,8 @@ name was computed at runtime by a private reified helper,
 This was fragile for two reasons:
 
 - `KClass.simpleName` is **nullable**, forcing a `checkNotNull` /
-  `fail("Serial name can't be null.")` fallback at runtime for a value that
-  is, in practice, always known at compile time.
+  `fail("Serial name can't be null.")` fallback at runtime for a value that is,
+  in practice, always known at compile time.
 - A bare simple name such as `"EmailAddress"` is not globally unique.
   `kotlinx.serialization` recommends fully-qualified names for
   `SerialDescriptor.serialName` to avoid clashes with other types sharing the
@@ -45,10 +44,10 @@ private enum class SerialName(private val value: String) {
 ```
 
 Each serializer's `descriptor` is now an eagerly-initialized `val` (instead of
-a `get()` accessor), built as
-`PrimitiveSerialDescriptor(serialName = SerialName.X.toString(), PrimitiveKind.STRING)`.
-The reified `StringSerialDescriptor<T>()` helper and its `KClass.simpleName`
-lookup are removed entirely.
+a `get()` accessor), built as `PrimitiveSerialDescriptor(serialName =
+SerialName.X.toString(), PrimitiveKind.STRING)`. The reified
+`StringSerialDescriptor<T>()` helper and its `KClass.simpleName` lookup are
+removed entirely.
 
 ## 🔗 Consequences
 
@@ -58,8 +57,8 @@ lookup are removed entirely.
   JS and Native, where `KClass.simpleName` is not guaranteed to match the
   source-level class name.
 - Adding a default serializer for a new type to
-  `KotoolsTypesSerializersModule()` requires adding a
-  matching entry to the private `SerialName` enum with the type's
-  fully-qualified name, following the same pattern.
+  `KotoolsTypesSerializersModule()` requires adding a matching entry to the
+  private `SerialName` enum with the type's fully-qualified name, following the
+  same pattern.
 - Tests assert against the literal fully-qualified serial name rather than
   `Type::class.simpleName`.

--- a/documentation/decisions/ADR-009-default-serializer-serial-names.md
+++ b/documentation/decisions/ADR-009-default-serializer-serial-names.md
@@ -2,11 +2,11 @@
 
 This document records how the `SerialDescriptor.serialName` of the default
 `kotlinx.serialization` serializers is determined in
-[`SerializersModule`][SerializersModule].
+`SerializersModule`.
 
 ## 🤔 Context
 
-[`KotoolsTypesSerializersModule()`][SerializersModule] provides default
+`KotoolsTypesSerializersModule()` provides default
 serializers for `EmailAddress` and `EmailAddressRegex`, encoding and decoding
 both types as `String`.
 
@@ -58,12 +58,8 @@ lookup are removed entirely.
   JS and Native, where `KClass.simpleName` is not guaranteed to match the
   source-level class name.
 - Adding a default serializer for a new type to
-  [`KotoolsTypesSerializersModule()`][SerializersModule] requires adding a
+  `KotoolsTypesSerializersModule()` requires adding a
   matching entry to the private `SerialName` enum with the type's
   fully-qualified name, following the same pattern.
 - Tests assert against the literal fully-qualified serial name rather than
   `Type::class.simpleName`.
-
-<!----------------------------------- Links ----------------------------------->
-
-[SerializersModule]: ../../subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt

--- a/documentation/decisions/ADR-010-error-message-format.md
+++ b/documentation/decisions/ADR-010-error-message-format.md
@@ -8,17 +8,17 @@ declarations in the `org.kotools.types` package and its sub-packages.
 Error messages thrown by `org.kotools.types.*` declarations had inconsistent
 formats:
 
-- [`Decimal.Companion.parse`][Decimal] and
-  [`Integer.Companion.parse`][Integer] put the offending value first, followed
+- `Decimal.Companion.parse` and
+  `Integer.Companion.parse` put the offending value first, followed
   by a description and a trailing period:
   `"\"abc\" is not a valid integer."`.
-- [`Integer.div`][Integer] and [`Integer.rem`][Integer] repeated the type name
+- `Integer.div` and `Integer.rem` repeated the type name
   in a sentence ending with a period: `"Integer can't be divided by zero."`.
-- [`EmailAddressRegex.Companion.alphabetic`][EmailAddressRegex] and
-  [`EmailAddressRegex.Companion.alphanumeric`][EmailAddressRegex] put the
+- `EmailAddressRegex.Companion.alphabetic` and
+  `EmailAddressRegex.Companion.alphanumeric` put the
   offending value first: `"'<pattern>' is invalid for validating email
   addresses."`.
-- The [`org.kotools.types.kotlinx.serialization`][SerializersModule]
+- The `org.kotools.types.kotlinx.serialization`
   serializers used a `(was: <value>)` parenthetical:
   `"Invalid email address (was: <text>)."`.
 
@@ -43,14 +43,14 @@ Error messages thrown by `org.kotools.types.*` declarations follow a
 
 | Declaration                                                                                                                     | Before                                                     | After                                        |
 |---------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------|
-| [`Decimal.Companion.parse`][Decimal]                                                                                            | `"\"abc\" is not a valid decimal."`                        | `"Invalid decimal representation: 'abc'"`    |
-| [`Integer.Companion.parse`][Integer]                                                                                            | `"\"abc\" is not a valid integer."`                        | `"Invalid integer representation: 'abc'"`    |
-| [`Integer.div`][Integer] / [`Integer.rem`][Integer]                                                                             | `"Integer can't be divided by zero."`                      | `"Division by zero"`                         |
-| [`EmailAddressRegex.Companion.alphabetic`][EmailAddressRegex] / [`EmailAddressRegex.Companion.alphanumeric`][EmailAddressRegex] | `"'<pattern>' is invalid for validating email addresses."` | `"Invalid email address regex: '<pattern>'"` |
-| [`org.kotools.types.kotlinx.serialization`][SerializersModule] (`EmailAddress`)                                                 | `"Invalid email address (was: <text>)."`                   | `"Invalid email address: '<text>'"`          |
-| [`org.kotools.types.kotlinx.serialization`][SerializersModule] (`EmailAddressRegex`)                                            | `"Invalid email address regex (was: <text>)."`             | `"Invalid email address regex: '<text>'"`    |
+| `Decimal.Companion.parse`                                                                                            | `"\"abc\" is not a valid decimal."`                        | `"Invalid decimal representation: 'abc'"`    |
+| `Integer.Companion.parse`                                                                                            | `"\"abc\" is not a valid integer."`                        | `"Invalid integer representation: 'abc'"`    |
+| `Integer.div` / `Integer.rem`                                                                             | `"Integer can't be divided by zero."`                      | `"Division by zero"`                         |
+| `EmailAddressRegex.Companion.alphabetic` / `EmailAddressRegex.Companion.alphanumeric` | `"'<pattern>' is invalid for validating email addresses."` | `"Invalid email address regex: '<pattern>'"` |
+| `org.kotools.types.kotlinx.serialization` (`EmailAddress`)                                                 | `"Invalid email address (was: <text>)."`                   | `"Invalid email address: '<text>'"`          |
+| `org.kotools.types.kotlinx.serialization` (`EmailAddressRegex`)                                            | `"Invalid email address regex (was: <text>)."`             | `"Invalid email address regex: '<text>'"`    |
 
-The [`Decimal`][Decimal] constructor's `"Negative decimal scale: <scale>"`
+The `Decimal` constructor's `"Negative decimal scale: <scale>"`
 check already followed this structure and is unchanged.
 
 ## 🔗 Consequences
@@ -64,10 +64,3 @@ check already followed this structure and is unchanged.
   `kotools.types.*` package has its own message conventions via
   `kotools.types.internal.ErrorMessage`, which are out of scope for this
   decision.
-
-<!----------------------------------- Links ----------------------------------->
-
-[Decimal]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
-[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
-[EmailAddressRegex]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/EmailAddressRegex.kt
-[SerializersModule]: ../../subprojects/kotlinx-serialization/src/commonMain/kotlin/org/kotools/types/kotlinx/serialization/SerializersModule.kt

--- a/documentation/decisions/ADR-010-error-message-format.md
+++ b/documentation/decisions/ADR-010-error-message-format.md
@@ -8,50 +8,46 @@ declarations in the `org.kotools.types` package and its sub-packages.
 Error messages thrown by `org.kotools.types.*` declarations had inconsistent
 formats:
 
-- `Decimal.Companion.parse` and
-  `Integer.Companion.parse` put the offending value first, followed
-  by a description and a trailing period:
+- `Decimal.Companion.parse` and `Integer.Companion.parse` put the offending
+  value first, followed by a description and a trailing period:
   `"\"abc\" is not a valid integer."`.
-- `Integer.div` and `Integer.rem` repeated the type name
-  in a sentence ending with a period: `"Integer can't be divided by zero."`.
+- `Integer.div` and `Integer.rem` repeated the type name in a sentence ending
+  with a period: `"Integer can't be divided by zero."`.
 - `EmailAddressRegex.Companion.alphabetic` and
-  `EmailAddressRegex.Companion.alphanumeric` put the
-  offending value first: `"'<pattern>' is invalid for validating email
-  addresses."`.
-- The `org.kotools.types.kotlinx.serialization`
-  serializers used a `(was: <value>)` parenthetical:
-  `"Invalid email address (was: <text>)."`.
+  `EmailAddressRegex.Companion.alphanumeric` put the offending value first:
+  `"'<pattern>' is invalid for validating email addresses."`.
+- The `org.kotools.types.kotlinx.serialization` serializers used a
+  `(was: <value>)` parenthetical: `"Invalid email address (was: <text>)."`.
 
-This made messages harder to scan consistently and inconsistent with each
-other, despite describing the same kind of problem (an invalid value).
+This made messages harder to scan consistently and inconsistent with each other,
+despite describing the same kind of problem (an invalid value).
 
 ## ✅ Decision
 
 Error messages thrown by `org.kotools.types.*` declarations follow a
 `<description>: <value>` structure:
 
-- The constraint description comes first, the offending value last,
-  separated by `: `.
-- The first letter is capitalized, and the message has **no trailing
-  period**.
-- **String** offending values are wrapped in single quotes (`'...'`) as a
-  visual delimiter. **Numeric** offending values are left unquoted, since
-  they are self-delimiting.
+- The constraint description comes first, the offending value last, separated by
+  `: `.
+- The first letter is capitalized, and the message has **no trailing period**.
+- **String** offending values are wrapped in single quotes (`'...'`) as a visual
+  delimiter. **Numeric** offending values are left unquoted, since they are
+  self-delimiting.
 - If there's no variable offending value to report (e.g. division by zero,
-  where the divisor is always the constant `0`), the value is omitted
-  entirely — just the capitalized, period-free description.
+  where the divisor is always the constant `0`), the value is omitted entirely —
+  just the capitalized, period-free description.
 
-| Declaration                                                                                                                     | Before                                                     | After                                        |
-|---------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------|
-| `Decimal.Companion.parse`                                                                                            | `"\"abc\" is not a valid decimal."`                        | `"Invalid decimal representation: 'abc'"`    |
-| `Integer.Companion.parse`                                                                                            | `"\"abc\" is not a valid integer."`                        | `"Invalid integer representation: 'abc'"`    |
-| `Integer.div` / `Integer.rem`                                                                             | `"Integer can't be divided by zero."`                      | `"Division by zero"`                         |
+| Declaration                                                                           | Before                                                     | After                                        |
+|---------------------------------------------------------------------------------------|------------------------------------------------------------|----------------------------------------------|
+| `Decimal.Companion.parse`                                                             | `"\"abc\" is not a valid decimal."`                        | `"Invalid decimal representation: 'abc'"`    |
+| `Integer.Companion.parse`                                                             | `"\"abc\" is not a valid integer."`                        | `"Invalid integer representation: 'abc'"`    |
+| `Integer.div` / `Integer.rem`                                                         | `"Integer can't be divided by zero."`                      | `"Division by zero"`                         |
 | `EmailAddressRegex.Companion.alphabetic` / `EmailAddressRegex.Companion.alphanumeric` | `"'<pattern>' is invalid for validating email addresses."` | `"Invalid email address regex: '<pattern>'"` |
-| `org.kotools.types.kotlinx.serialization` (`EmailAddress`)                                                 | `"Invalid email address (was: <text>)."`                   | `"Invalid email address: '<text>'"`          |
-| `org.kotools.types.kotlinx.serialization` (`EmailAddressRegex`)                                            | `"Invalid email address regex (was: <text>)."`             | `"Invalid email address regex: '<text>'"`    |
+| `org.kotools.types.kotlinx.serialization` (`EmailAddress`)                            | `"Invalid email address (was: <text>)."`                   | `"Invalid email address: '<text>'"`          |
+| `org.kotools.types.kotlinx.serialization` (`EmailAddressRegex`)                       | `"Invalid email address regex (was: <text>)."`             | `"Invalid email address regex: '<text>'"`    |
 
-The `Decimal` constructor's `"Negative decimal scale: <scale>"`
-check already followed this structure and is unchanged.
+The `Decimal` constructor's `"Negative decimal scale: <scale>"` check already
+followed this structure and is unchanged.
 
 ## 🔗 Consequences
 

--- a/documentation/decisions/ADR-011-error-message-quote-escaping.md
+++ b/documentation/decisions/ADR-011-error-message-quote-escaping.md
@@ -1,16 +1,16 @@
 # 🏷️ ADR-011: String value quote escaping for `org.kotools.types`
 
-This document records how `errorMessage` (see [ADR-010])
-escapes `String` values that themselves contain a single quote.
+This document records how `errorMessage` (see [ADR-010]) escapes `String` values
+that themselves contain a single quote.
 
 ## 🤔 Context
 
-[ADR-010] wraps `String` offending values in single quotes (`'...'`) as a
-visual delimiter, e.g. `Invalid email address: 'abc'`.
+[ADR-010] wraps `String` offending values in single quotes (`'...'`) as a visual
+delimiter, e.g. `Invalid email address: 'abc'`.
 
-If the offending value itself contains a `'`, this delimiter becomes
-ambiguous. For example, `EmailAddress` accepts RFC 5322
-quoted-string local parts, so a value like `"o'brien"@example.com` produces:
+If the offending value itself contains a `'`, this delimiter becomes ambiguous.
+For example, `EmailAddress` accepts RFC 5322 quoted-string local parts, so a
+value like `"o'brien"@example.com` produces:
 
 ```
 Invalid email address: 'o'brien@example.com'
@@ -20,20 +20,19 @@ It's unclear here where the offending value starts and ends.
 
 ## ✅ Decision
 
-`errorMessage` escapes any `'` character within a `String`
-value with a backslash (`\'`) before wrapping it in single quotes.
+`errorMessage` escapes any `'` character within a `String` value with a
+backslash (`\'`) before wrapping it in single quotes.
 
 | Input value           | Resulting message                               |
-|------------------------|--------------------------------------------------|
+|-----------------------|-------------------------------------------------|
 | `o'brien@example.com` | `Invalid email address: 'o\'brien@example.com'` |
 
 ## 🔗 Consequences
 
-- `errorMessage`'s `String` branch escapes `'` as `\'`
-  before wrapping the value in single quotes.
-- This applies to every `org.kotools.types.*` declaration that builds its
-  error messages with `errorMessage`, without requiring any
-  change at call sites.
+- `errorMessage`'s `String` branch escapes `'` as `\'` before wrapping the value
+  in single quotes.
+- This applies to every `org.kotools.types.*` declaration that builds its error
+  messages with `errorMessage`, without requiring any change at call sites.
 
 <!----------------------------------- Links ----------------------------------->
 

--- a/documentation/decisions/ADR-011-error-message-quote-escaping.md
+++ b/documentation/decisions/ADR-011-error-message-quote-escaping.md
@@ -1,6 +1,6 @@
 # 🏷️ ADR-011: String value quote escaping for `org.kotools.types`
 
-This document records how [`errorMessage`][ErrorMessage] (see [ADR-010])
+This document records how `errorMessage` (see [ADR-010])
 escapes `String` values that themselves contain a single quote.
 
 ## 🤔 Context
@@ -9,7 +9,7 @@ escapes `String` values that themselves contain a single quote.
 visual delimiter, e.g. `Invalid email address: 'abc'`.
 
 If the offending value itself contains a `'`, this delimiter becomes
-ambiguous. For example, [`EmailAddress`][EmailAddress] accepts RFC 5322
+ambiguous. For example, `EmailAddress` accepts RFC 5322
 quoted-string local parts, so a value like `"o'brien"@example.com` produces:
 
 ```
@@ -20,7 +20,7 @@ It's unclear here where the offending value starts and ends.
 
 ## ✅ Decision
 
-[`errorMessage`][ErrorMessage] escapes any `'` character within a `String`
+`errorMessage` escapes any `'` character within a `String`
 value with a backslash (`\'`) before wrapping it in single quotes.
 
 | Input value           | Resulting message                               |
@@ -29,14 +29,12 @@ value with a backslash (`\'`) before wrapping it in single quotes.
 
 ## 🔗 Consequences
 
-- [`errorMessage`][ErrorMessage]'s `String` branch escapes `'` as `\'`
+- `errorMessage`'s `String` branch escapes `'` as `\'`
   before wrapping the value in single quotes.
 - This applies to every `org.kotools.types.*` declaration that builds its
-  error messages with [`errorMessage`][ErrorMessage], without requiring any
+  error messages with `errorMessage`, without requiring any
   change at call sites.
 
 <!----------------------------------- Links ----------------------------------->
 
 [ADR-010]: ADR-010-error-message-format.md
-[ErrorMessage]: ../../subprojects/internal/src/commonMain/kotlin/org/kotools/types/internal/ErrorMessage.kt
-[EmailAddress]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/EmailAddress.kt

--- a/documentation/decisions/ADR-012-native-decimal-io-chunking.md
+++ b/documentation/decisions/ADR-012-native-decimal-io-chunking.md
@@ -5,20 +5,19 @@ processing in the Kotlin/Native implementation of `Integer`.
 
 ## 🤔 Context
 
-`NativeInteger` (see [ADR-007]) stores its magnitude as a `UIntArray` in
-base 2³² (little-endian limbs). Before this decision, `parse()` and
-`toString()` processed one decimal digit per iteration — _d_ iterations
-for a _d_-digit number — making both operations O(_d_ × _n\_limbs_).
+`NativeInteger` (see [ADR-007]) stores its magnitude as a `UIntArray` in base
+2³² (little-endian limbs). Before this decision, `parse()` and `toString()`
+processed one decimal digit per iteration — _d_ iterations for a _d_-digit
+number — making both operations O(_d_ × _n\_limbs_).
 
-Batching multiple digits into a single chunk reduces the number of
-iterations to ⌈_d_ / chunk\_size⌉ while keeping the per-iteration cost
-roughly the same, yielding a near-linear speed-up proportional to the
-chunk size.
+Batching multiple digits into a single chunk reduces the number of iterations to
+⌈_d_ / chunk\_size⌉ while keeping the per-iteration cost roughly the same,
+yielding a near-linear speed-up proportional to the chunk size.
 
 ## ✅ Decision
 
-Batch decimal I/O in chunks of **10⁹** (one billion) — i.e., nine decimal
-digits at a time.
+Batch decimal I/O in chunks of **10⁹** (one billion) — i.e., nine decimal digits
+at a time.
 
 The constraint is that every chunk value must fit in a `UInt`:
 
@@ -35,23 +34,22 @@ UInt max        = 4_294_967_295 (= 2³² − 1)
 10¹⁰ = 10_000_000_000 > 2³² − 1  ✗  (does not fit)
 ```
 
-Using `UInt` for the chunk avoids a `Long` intermediate and keeps the
-arithmetic consistent with the rest of the magnitude helper functions.
+Using `UInt` for the chunk avoids a `Long` intermediate and keeps the arithmetic
+consistent with the rest of the magnitude helper functions.
 
 ## 🔗 Consequences
 
 - A file-level `private val BILLION: UIntArray = uintArrayOf(1_000_000_000u)`
   constant holds the base used by `parse()`.
 - `parse()` processes the digit string in groups of nine, multiplying the
-  accumulated magnitude by `BILLION` and adding each chunk — ⌈_d_/9⌉
-  iterations instead of _d_.
-- A `divideByBillion()` extension on `UIntArray` mirrors `divideByTen()`
-  but divides by 10⁹, returning a `(quotient, remainder)` pair where the
-  remainder is at most 999,999,999 and therefore fits in `Int`.
-- `toString()` collects nine-digit chunks via `divideByBillion()` and
-  formats them with `padStart(9, '0')` to preserve leading zeros in
-  interior groups — ⌈_d_/9⌉ iterations instead of _d_, with no final
-  `reversed()` call.
+  accumulated magnitude by `BILLION` and adding each chunk — ⌈_d_/9⌉ iterations
+  instead of _d_.
+- A `divideByBillion()` extension on `UIntArray` mirrors `divideByTen()` but
+  divides by 10⁹, returning a `(quotient, remainder)` pair where the remainder
+  is at most 999,999,999 and therefore fits in `Int`.
+- `toString()` collects nine-digit chunks via `divideByBillion()` and formats
+  them with `padStart(9, '0')` to preserve leading zeros in interior groups —
+  ⌈_d_/9⌉ iterations instead of _d_, with no final `reversed()` call.
 - `divideByTen()` is removed as dead code.
 - Iteration count for both operations drops by ~9× for large numbers.
 

--- a/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
+++ b/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
@@ -1,17 +1,17 @@
 # ⚖️ ADR-013: Exclusion of additive operations from `NonZeroInteger` arithmetic
 
 This document records the decision to omit addition and subtraction from the
-[`NonZeroInteger`][NonZeroInteger] type's arithmetic API.
+`NonZeroInteger` type's arithmetic API.
 
 ## 🤔 Context
 
-`NonZeroInteger` represents an [`Integer`][Integer] that is other than zero.
+`NonZeroInteger` represents an `Integer` that is other than zero.
 Negation (`unaryMinus`) and multiplication (`times`) both keep results within
 this set: the negation of a non-zero integer is never zero, and the product
 of two non-zero integers is never zero either.
 
 The question that arose during design was: should `NonZeroInteger` also
-provide `plus` and `minus` operators, like [`Integer`][Integer] does?
+provide `plus` and `minus` operators, like `Integer` does?
 
 ## ✅ Decision: Addition and subtraction are excluded
 
@@ -42,9 +42,9 @@ arithmetic operations provided are unary minus (`-x`) and multiplication
   integer is always non-zero, so both operations are safe to expose as total
   functions returning `NonZeroInteger`.
 - **Explicit delegation to the caller.** Users who need addition or
-  subtraction can convert to [`Integer`][Integer] via [`toInteger`][toInteger],
+  subtraction can convert to `Integer` via `toInteger`,
   perform the operation there, and convert back with
-  [`fromInteger`][fromInteger] (or its `OrNull` variant) if they need to
+  `fromInteger` (or its `OrNull` variant) if they need to
   re-establish the non-zero invariant, making the zero case an explicit
   decision at the call site rather than a silent one inside
   `NonZeroInteger`.
@@ -61,8 +61,4 @@ arithmetic operations provided are unary minus (`-x`) and multiplication
 
 <!----------------------------------- Links ----------------------------------->
 
-[NonZeroInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
-[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
 [ADR-006]: ADR-006-decimal-division-exclusion.md
-[toInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
-[fromInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt

--- a/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
+++ b/documentation/decisions/ADR-013-nonzerointeger-additive-exclusion.md
@@ -5,13 +5,13 @@ This document records the decision to omit addition and subtraction from the
 
 ## 🤔 Context
 
-`NonZeroInteger` represents an `Integer` that is other than zero.
-Negation (`unaryMinus`) and multiplication (`times`) both keep results within
-this set: the negation of a non-zero integer is never zero, and the product
-of two non-zero integers is never zero either.
+`NonZeroInteger` represents an `Integer` that is other than zero. Negation
+(`unaryMinus`) and multiplication (`times`) both keep results within this set:
+the negation of a non-zero integer is never zero, and the product of two
+non-zero integers is never zero either.
 
-The question that arose during design was: should `NonZeroInteger` also
-provide `plus` and `minus` operators, like `Integer` does?
+The question that arose during design was: should `NonZeroInteger` also provide
+`plus` and `minus` operators, like `Integer` does?
 
 ## ✅ Decision: Addition and subtraction are excluded
 
@@ -21,10 +21,10 @@ arithmetic operations provided are unary minus (`-x`) and multiplication
 
 **Rationale:**
 
-- **The set of non-zero integers is not closed under addition or
-  subtraction.** For any non-zero integer `x`, `x + (-x) = 0` and
-  `x - x = 0`. Both operations can produce zero from two non-zero operands,
-  so their result cannot always be represented as a `NonZeroInteger`.
+- **The set of non-zero integers is not closed under addition or subtraction.**
+  For any non-zero integer `x`, `x + (-x) = 0` and `x - x = 0`. Both operations
+  can produce zero from two non-zero operands, so their result cannot always be
+  represented as a `NonZeroInteger`.
 - **A nullable, throwing, or widened return type would break the type's
   contract.** Returning `NonZeroInteger?` or throwing on the zero case would
   make `plus`/`minus` behave unlike every other arithmetic operator in this
@@ -32,29 +32,26 @@ arithmetic operations provided are unary minus (`-x`) and multiplication
   Widening the return type to `Integer` would also be inconsistent: callers
   expecting closure under arithmetic operations would have to special-case
   `plus`/`minus` among the type's operators.
-- **Consistent with `Decimal` design.** [ADR-006][ADR-006] excludes division
-  from `Decimal` for the same underlying reason: the set of terminating
-  decimals is not closed under division. `NonZeroInteger` follows the same
-  principle — only operations that keep results within the modeled set are
-  exposed.
+- **Consistent with `Decimal` design.** [ADR-006] excludes division from
+  `Decimal` for the same underlying reason: the set of terminating decimals is
+  not closed under division. `NonZeroInteger` follows the same principle — only
+  operations that keep results within the modeled set are exposed.
 - **`times` and `unaryMinus` stay because closure holds.** The product of two
-  non-zero integers is always non-zero, and the negation of a non-zero
-  integer is always non-zero, so both operations are safe to expose as total
-  functions returning `NonZeroInteger`.
-- **Explicit delegation to the caller.** Users who need addition or
-  subtraction can convert to `Integer` via `toInteger`,
-  perform the operation there, and convert back with
-  `fromInteger` (or its `OrNull` variant) if they need to
-  re-establish the non-zero invariant, making the zero case an explicit
-  decision at the call site rather than a silent one inside
-  `NonZeroInteger`.
+  non-zero integers is always non-zero, and the negation of a non-zero integer
+  is always non-zero, so both operations are safe to expose as total functions
+  returning `NonZeroInteger`.
+- **Explicit delegation to the caller.** Users who need addition or subtraction
+  can convert to `Integer` via `toInteger`, perform the operation there, and
+  convert back with `fromInteger` (or its `OrNull` variant) if they need to
+  re-establish the non-zero invariant, making the zero case an explicit decision
+  at the call site rather than a silent one inside `NonZeroInteger`.
 
 ## 🔗 Consequences
 
 - The KDoc of `NonZeroInteger` documents this design choice so users are not
   left guessing why `+` and `-` are missing compared to `Integer`.
-- The two provided operations (unary minus and `*`) are both closed over the
-  set of non-zero integers.
+- The two provided operations (unary minus and `*`) are both closed over the set
+  of non-zero integers.
 - Converting to `Integer` remains the documented path for any arithmetic that
   isn't closed under "non-zero", consistent with how `Decimal` documents
   converting to `Double`/`BigDecimal` for division.

--- a/documentation/decisions/ADR-014-nonnegativeinteger-subtractive-exclusion.md
+++ b/documentation/decisions/ADR-014-nonnegativeinteger-subtractive-exclusion.md
@@ -1,17 +1,17 @@
 # ⚖️ ADR-014: Exclusion of subtraction from `NonNegativeInteger` arithmetic
 
 This document records the decision to omit subtraction from the
-[`NonNegativeInteger`][NonNegativeInteger] type's arithmetic API.
+`NonNegativeInteger` type's arithmetic API.
 
 ## 🤔 Context
 
-`NonNegativeInteger` represents an [`Integer`][Integer] that is greater than or
+`NonNegativeInteger` represents an `Integer` that is greater than or
 equal to zero. Addition (`plus`) and multiplication (`times`) both keep results
 within this set: the sum and the product of two non-negative integers are always
 non-negative.
 
 The question that arose during design was: should `NonNegativeInteger` also
-provide a `minus` operator, like [`Integer`][Integer] does?
+provide a `minus` operator, like `Integer` does?
 
 ## ✅ Decision: Subtraction is excluded
 
@@ -40,8 +40,8 @@ operations provided are addition (`x + y`) and multiplication (`x * y`).
   two non-negative integers are always non-negative, so both operations are safe
   to expose as total functions returning `NonNegativeInteger`.
 - **Explicit delegation to the caller.** Users who need subtraction can convert
-  to [`Integer`][Integer] via [`toInteger`][toInteger], perform the operation
-  there, and convert back with [`fromInteger`][fromInteger] (or its `OrNull`
+  to `Integer` via `toInteger`, perform the operation
+  there, and convert back with `fromInteger` (or its `OrNull`
   variant) if they need to re-establish the non-negative invariant, making the
   negative case an explicit decision at the call site rather than a silent one
   inside `NonNegativeInteger`.
@@ -58,8 +58,4 @@ operations provided are addition (`x + y`) and multiplication (`x * y`).
 
 <!----------------------------------- Links ----------------------------------->
 
-[NonNegativeInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
-[Integer]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
 [ADR-013]: ADR-013-nonzerointeger-additive-exclusion.md
-[toInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
-[fromInteger]: ../../subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt

--- a/documentation/decisions/ADR-014-nonnegativeinteger-subtractive-exclusion.md
+++ b/documentation/decisions/ADR-014-nonnegativeinteger-subtractive-exclusion.md
@@ -5,9 +5,9 @@ This document records the decision to omit subtraction from the
 
 ## 🤔 Context
 
-`NonNegativeInteger` represents an `Integer` that is greater than or
-equal to zero. Addition (`plus`) and multiplication (`times`) both keep results
-within this set: the sum and the product of two non-negative integers are always
+`NonNegativeInteger` represents an `Integer` that is greater than or equal to
+zero. Addition (`plus`) and multiplication (`times`) both keep results within
+this set: the sum and the product of two non-negative integers are always
 non-negative.
 
 The question that arose during design was: should `NonNegativeInteger` also
@@ -31,20 +31,19 @@ operations provided are addition (`x + y`) and multiplication (`x * y`).
   Widening the return type to `Integer` would also be inconsistent: callers
   expecting closure under arithmetic operations would have to special-case
   `minus` among the type's operators.
-- **Consistent with `NonZeroInteger` design.** [ADR-013][ADR-013] excludes
-  addition and subtraction from `NonZeroInteger` for the same underlying
-  reason: the set of non-zero integers is not closed under these operations.
-  `NonNegativeInteger` follows the same principle — only operations that keep
-  results within the modeled set are exposed.
+- **Consistent with `NonZeroInteger` design.** [ADR-013] excludes addition and
+  subtraction from `NonZeroInteger` for the same underlying reason: the set of
+  non-zero integers is not closed under these operations. `NonNegativeInteger`
+  follows the same principle — only operations that keep results within the
+  modeled set are exposed.
 - **`plus` and `times` stay because closure holds.** The sum and the product of
   two non-negative integers are always non-negative, so both operations are safe
   to expose as total functions returning `NonNegativeInteger`.
 - **Explicit delegation to the caller.** Users who need subtraction can convert
-  to `Integer` via `toInteger`, perform the operation
-  there, and convert back with `fromInteger` (or its `OrNull`
-  variant) if they need to re-establish the non-negative invariant, making the
-  negative case an explicit decision at the call site rather than a silent one
-  inside `NonNegativeInteger`.
+  to `Integer` via `toInteger`, perform the operation there, and convert back
+  with `fromInteger` (or its `OrNull` variant) if they need to re-establish the
+  non-negative invariant, making the negative case an explicit decision at the
+  call site rather than a silent one inside `NonNegativeInteger`.
 
 ## 🔗 Consequences
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -44,11 +44,11 @@ example of this convention.
 ## 🚫 No links to source files
 
 ADRs must not link to source files (e.g. `*.kt`). Source files are mutable
-implementation details that get renamed, moved, or restructured over time,
-while an ADR is a historical record of a decision at a point in time. A link
-to a source file may keep resolving after such a change while silently
-pointing to code that no longer matches what the ADR described, creating a
-false impression of accuracy.
+implementation details that get renamed, moved, or restructured over time, while
+an ADR is a historical record of a decision at a point in time. A link to a
+source file may keep resolving after such a change while silently pointing to
+code that no longer matches what the ADR described, creating a false impression
+of accuracy.
 
 Cross-references in an ADR must instead target either:
 

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -40,3 +40,18 @@ outdated, it is **not** edited in place. Instead:
 [ADR-003](ADR-003-euclidean-division-platform-impl.md) →
 [ADR-008](ADR-008-euclidean-division-platform-impl-v2.md) is the first
 example of this convention.
+
+## 🚫 No links to source files
+
+ADRs must not link to source files (e.g. `*.kt`). Source files are mutable
+implementation details that get renamed, moved, or restructured over time,
+while an ADR is a historical record of a decision at a point in time. A link
+to a source file may keep resolving after such a change while silently
+pointing to code that no longer matches what the ADR described, creating a
+false impression of accuracy.
+
+Cross-references in an ADR must instead target either:
+
+- another ADR, by number and title (e.g. "Supersedes ADR-003"), or
+- the published API documentation, when a link to a type's current
+  definition is genuinely needed.


### PR DESCRIPTION
## Summary

- Added a "No links to source files" rule to `documentation/decisions/README.md`: ADRs must not link to `.kt`/source files; cross-references must target another ADR (number + title) or published API documentation.
- Removed reference-style links to source files from all 13 affected ADRs (001–011, 013, 014), keeping the referenced type/function names as plain inline code.
- Reworded two plain-text source/build file path mentions in ADR-007 so the record no longer depends on file paths that can move independently of it.
- Docs-only change: no code, tests, ABI, or changelog touched.

Closes #1036

Generated with [Claude Code](https://claude.ai/code)