### PR TITLE
🔥 Remove `Integer`-accepting division from `Integer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ The format is based on [Keep a Changelog], and this project adheres to its own
   `of` function instead. (module: `types`, refs: [#871], [#872])
 - `com.ionspin.kotlin:bignum` dependency, previously used internally by
   `Integer` on Kotlin/Native. (module: `types`, ref: [#962])
+- **Breaking:** `div(Integer)`, `divOrNull(Integer)`, `rem(Integer)` and
+  `remOrNull(Integer)` **experimental** functions from `Integer` class. Use
+  `div(NonZeroInteger)` and `rem(NonZeroInteger)` instead, as their signature
+  rules out division by zero at compile time. (module: `types`, ref: [#1001])
 
 ### 🐛 Fixed
 
@@ -165,6 +169,7 @@ The format is based on [Keep a Changelog], and this project adheres to its own
 [#992]: https://github.com/kotools/types/issues/992
 [#998]: https://github.com/kotools/types/issues/998
 [#999]: https://github.com/kotools/types/issues/999
+[#1001]: https://github.com/kotools/types/issues/1001
 [#1010]: https://github.com/kotools/types/issues/1010
 [#1011]: https://github.com/kotools/types/issues/1011
 [#1013]: https://github.com/kotools/types/issues/1013

--- a/documentation/decisions/ADR-018-integer-division-removal.md
+++ b/documentation/decisions/ADR-018-integer-division-removal.md
@@ -1,0 +1,54 @@
+# 🔥 ADR-018: Removal of `Integer`-accepting division from `Integer`
+
+This document records the decision to remove the `div(Integer)`,
+`divOrNull(Integer)`, `rem(Integer)` and `remOrNull(Integer)` overloads from
+the `Integer` type's arithmetic API.
+
+## 🤔 Context
+
+Since [ADR-015], `Integer` division has had two overlapping APIs for the same
+operation:
+
+- The original partial one: `div(Integer)`/`rem(Integer)`, which throw an
+  `ArithmeticException` on a zero divisor, and `divOrNull(Integer)`/
+  `remOrNull(Integer)`, which return `null` instead.
+- The newer total one: `div(NonZeroInteger)`/`rem(NonZeroInteger)`, which can
+  never fail because their parameter type rules out zero by construction.
+
+Keeping both means callers have two different failure stories for the same
+arithmetic operation, depending on which overload they happen to call.
+
+## ✅ Decision: Remove the `Integer`-accepting division overloads
+
+`Integer` loses `div(Integer)`, `divOrNull(Integer)`, `rem(Integer)` and
+`remOrNull(Integer)`. Callers needing a typed divisor now construct a
+`NonZeroInteger` once (validated at the boundary) and reuse the total
+`div(NonZeroInteger)`/`rem(NonZeroInteger)` overloads instead.
+
+**Rationale:**
+
+- **Rejecting zero at construction removes a runtime failure mode entirely.**
+  `NonZeroInteger` rejects zero with an `IllegalArgumentException` at
+  construction time, instead of `div`/`rem` throwing an `ArithmeticException`
+  (or returning `null`) every time a division is performed. There is no
+  longer a need to document or test that failure mode at all.
+- **`Integer` is still experimental.** Per the
+  [declarations lifecycle policy], experimental declarations can be removed
+  directly, without a deprecation cycle.
+
+## 🔗 Consequences
+
+- Internal callers depending on the removed overloads (e.g.
+  `Decimal.normalize()`) migrate to `NonZeroInteger`.
+- The class-level KDoc "Division by zero" motivation section is rewritten to
+  demonstrate the structural guarantee provided by `NonZeroInteger`, instead
+  of a caught `ArithmeticException`.
+- [ADR-015]'s total `div(NonZeroInteger)`/`rem(NonZeroInteger)` overloads
+  become the only way to divide an `Integer` by a typed divisor.
+- Future `Integer` arithmetic taking a divisor should default to
+  `NonZeroInteger`, not `Integer`.
+
+<!----------------------------------- Links ----------------------------------->
+
+[ADR-015]: ADR-015-integer-typed-divisor-division.md
+[declarations lifecycle policy]: ../declarations-lifecycle.md

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -25,6 +25,7 @@ rationale behind it, and its consequences.
 | [ADR-015](ADR-015-integer-typed-divisor-division.md)           | Typed-divisor Euclidean division for `Integer`                    | ✅ Accepted               |
 | [ADR-016](ADR-016-nonnegativeinteger-cross-type-closure.md)    | Cross-type closure for `NonNegativeInteger` arithmetic            | ✅ Accepted               |
 | [ADR-017](ADR-017-nonpositiveinteger-exclusions.md)            | Exclusions from `NonPositiveInteger` arithmetic                   | ✅ Accepted               |
+| [ADR-018](ADR-018-integer-division-removal.md)                 | Removal of `Integer`-accepting division from `Integer`            | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -388,18 +388,14 @@ public final class org/kotools/types/number/Integer {
 	public static final field Companion Lorg/kotools/types/number/Integer$Companion;
 	public synthetic fun <init> (Lorg/kotools/types/internal/number/PlatformInteger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun compareTo (Lorg/kotools/types/number/Integer;)I
-	public final fun div (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun div (Lorg/kotools/types/number/NonZeroInteger;)Lorg/kotools/types/number/Integer;
-	public final synthetic fun divOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun equals (Ljava/lang/Object;)Z
 	public static final fun fromLong (J)Lorg/kotools/types/number/Integer;
 	public final fun hashCode ()I
 	public final fun minus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/Integer;
 	public final fun plus (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
-	public final fun rem (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun rem (Lorg/kotools/types/number/NonZeroInteger;)Lorg/kotools/types/number/NonNegativeInteger;
-	public final synthetic fun remOrNull (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun times (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/Integer;
 	public final fun toLong ()J
 	public final synthetic fun toLongOrNull ()Ljava/lang/Long;

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -584,9 +584,8 @@ public class Decimal private constructor(
      */
     private fun scaleUpTo(targetScale: Int): Integer {
         if (this.scale == targetScale) return this.unscaledValue
-        val ten: Integer = Integer.fromLong(10)
         var result: Integer = this.unscaledValue
-        repeat(targetScale - this.scale) { result *= ten }
+        repeat(targetScale - this.scale) { result *= Integer.TEN }
         return result
     }
 
@@ -602,7 +601,7 @@ public class Decimal private constructor(
      */
     private fun normalize(): Decimal {
         if (this.scale == 0) return this
-        val ten: NonZeroInteger = NonZeroInteger.fromLong(10)
+        val ten: NonZeroInteger = NonZeroInteger.fromInteger(Integer.TEN)
         var current: Decimal = this
         while (current.scale > 0) {
             val remainder: Integer = (current.unscaledValue % ten).toInteger()

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Decimal.kt
@@ -602,10 +602,11 @@ public class Decimal private constructor(
      */
     private fun normalize(): Decimal {
         if (this.scale == 0) return this
-        val ten: Integer = Integer.fromLong(10)
+        val ten: NonZeroInteger = NonZeroInteger.fromLong(10)
         var current: Decimal = this
         while (current.scale > 0) {
-            if (current.unscaledValue % ten != Integer.ZERO) break
+            val remainder: Integer = (current.unscaledValue % ten).toInteger()
+            if (remainder != Integer.ZERO) break
             val unscaledValue: Integer = current.unscaledValue / ten
             val scale: Int = current.scale - 1
             current = Decimal(unscaledValue, scale)

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -120,6 +120,9 @@ public class Integer private constructor(
         @get:JvmSynthetic
         internal val ZERO: Integer = this.fromLong(0)
 
+        @get:JvmSynthetic
+        internal val TEN: Integer = this.fromLong(10)
+
         /**
          * Returns an [Integer] representing the specified [value].
          *

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -65,8 +65,10 @@ import kotlin.jvm.JvmSynthetic
  *
  * SAMPLE: org.kotools.types.number.IntegerJsSample.divisionByZeroProblem
  *
- * **Solution:** [Division][div] and [remainder][rem] operations by zero on
- * [Integer] type throw an [ArithmeticException] on all platforms.
+ * **Solution:** [Division][div] and [remainder][rem] operations on [Integer]
+ * type take a [NonZeroInteger] divisor, which rejects zero at construction.
+ * This makes dividing by zero unrepresentable: these operations can never
+ * throw or return `null` because of a zero divisor.
  *
  * SAMPLE: org.kotools.types.number.IntegerSample.divisionByZeroSolution
  *
@@ -81,7 +83,7 @@ import kotlin.jvm.JvmSynthetic
  * **Solution:** Division and remainder operations on [Integer] type follow
  * Euclidean semantics: the remainder is always non-negative (`0 ≤ r < |b|`).
  *
- * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivision
+ * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivisionByNonZeroInteger
  * </details>
  *
  * <br>
@@ -532,75 +534,6 @@ public class Integer private constructor(
         Integer(this.delegate / other.toInteger().delegate)
 
     /**
-     * Returns the Euclidean quotient of dividing this integer by the [other]
-     * one, or throws an [ArithmeticException] if the [other] integer is zero.
-     *
-     * This function uses Euclidean division: the remainder is always
-     * non-negative, regardless of the sign of this integer.
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivision
-     * </details>
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Java</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Java code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerJavaSample.euclideanDivision
-     * </details>
-     * <br>
-     *
-     * See also:
-     * - [divOrNull] for returning `null` when dividing this integer by zero
-     * - [rem] or [remOrNull] for returning Euclidean remainder
-     */
-    public operator fun div(other: Integer): Integer =
-        if (other == ZERO) this.divisionByZeroError()
-        else Integer(this.delegate / other.delegate)
-
-    /**
-     * Returns the Euclidean quotient of dividing this integer by the [other]
-     * one, or returns `null` if the [other] integer is zero.
-     *
-     * This function uses Euclidean division: the remainder is always
-     * non-negative, regardless of the sign of this integer.
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivisionOrNull
-     * </details>
-     * <br>
-     *
-     * This function is hidden from Java, because nullability is not explicit in
-     * its type system.
-     *
-     * See also:
-     * - [div] for throwing an exception when dividing this integer by zero
-     * - [rem] or [remOrNull] for returning Euclidean remainder
-     */
-    @JvmSynthetic
-    public fun divOrNull(other: Integer): Integer? =
-        if (other == ZERO) null
-        else Integer(this.delegate / other.delegate)
-
-    /**
      * Returns the Euclidean remainder of dividing this integer by the [other]
      * one.
      *
@@ -640,82 +573,6 @@ public class Integer private constructor(
     public operator fun rem(other: NonZeroInteger): NonNegativeInteger {
         val remainder = Integer(this.delegate % other.toInteger().delegate)
         return NonNegativeInteger.fromInteger(remainder)
-    }
-
-    /**
-     * Returns the Euclidean remainder of dividing this integer by the [other]
-     * one, or throws an [ArithmeticException] if the [other] integer is zero.
-     *
-     * This function uses Euclidean division: the remainder is always
-     * non-negative and less than the absolute value of [other]
-     * (`0 <= remainder < |other|`), regardless of the sign of this integer.
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivision
-     * </details>
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Java</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Java code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerJavaSample.euclideanDivision
-     * </details>
-     * <br>
-     *
-     * See also:
-     * - [remOrNull] for returning `null` when dividing this integer by zero
-     * - [div] or [divOrNull] for returning Euclidean quotient
-     */
-    public operator fun rem(other: Integer): Integer =
-        if (other == ZERO) this.divisionByZeroError()
-        else Integer(this.delegate % other.delegate)
-
-    /**
-     * Returns the Euclidean remainder of dividing this integer by the [other]
-     * one, or returns `null` if the [other] integer is zero.
-     *
-     * This function uses Euclidean division: the remainder is always
-     * non-negative and less than the absolute value of [other]
-     * (`0 <= remainder < |other|`), regardless of the sign of this integer.
-     *
-     * <br>
-     * <details>
-     * <summary>
-     *     <b>Calling from Kotlin</b>
-     * </summary>
-     *
-     * Here's an example of calling this function from Kotlin code:
-     *
-     * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivisionOrNull
-     * </details>
-     * <br>
-     *
-     * This function is hidden from Java, because nullability is not explicit in
-     * its type system.
-     *
-     * See also:
-     * - [rem] for throwing an exception when dividing this integer by zero
-     * - [div] or [divOrNull] for returning Euclidean quotient
-     */
-    @JvmSynthetic
-    public fun remOrNull(other: Integer): Integer? =
-        if (other == ZERO) null
-        else Integer(this.delegate % other.delegate)
-
-    private fun divisionByZeroError(): Nothing {
-        val message: String = errorMessage("Division by zero")
-        throw ArithmeticException(message)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerSample.kt
@@ -28,13 +28,9 @@ class IntegerSample {
 
     @Test
     fun divisionByZeroSolution() {
-        // Common code
-        val x: Integer = Integer.fromLong(12)
-        val y: Integer = Integer.fromLong(0)
-        val quotient: Result<Integer> = runCatching { x / y }
-        val remainder: Result<Integer> = runCatching { x % y }
-        check(quotient.exceptionOrNull() is ArithmeticException)
-        check(remainder.exceptionOrNull() is ArithmeticException)
+        val exception: Throwable? = runCatching { NonZeroInteger.fromLong(0) }
+            .exceptionOrNull()
+        check(exception is IllegalArgumentException)
     }
 
     @Test
@@ -185,19 +181,6 @@ class IntegerSample {
     }
 
     @Test
-    fun euclideanDivision() {
-        val x: Integer = Integer.fromLong(-7)
-        val y: Integer = Integer.fromLong(2)
-
-        val quotient: Integer = x / y
-        val remainder: Integer = x % y
-
-        check(quotient == Integer.fromLong(-4))
-        check(remainder == Integer.fromLong(1))
-        check(x == quotient * y + remainder)
-    }
-
-    @Test
     fun euclideanDivisionByNonZeroInteger() {
         val x: Integer = Integer.fromLong(-7)
         val y: NonZeroInteger = NonZeroInteger.fromLong(2)
@@ -208,21 +191,6 @@ class IntegerSample {
         check(quotient == Integer.fromLong(-4))
         check(remainder == NonNegativeInteger.fromLong(1))
         check(x == quotient * y.toInteger() + remainder.toInteger())
-    }
-
-    @Test
-    fun euclideanDivisionOrNull() {
-        val x: Integer = Integer.fromLong(-7)
-        val y: Integer = Integer.fromLong(2)
-
-        val quotient: Integer? = x.divOrNull(y)
-        val remainder: Integer? = x.remOrNull(y)
-
-        checkNotNull(quotient)
-        checkNotNull(remainder)
-        check(quotient == Integer.fromLong(-4))
-        check(remainder == Integer.fromLong(1))
-        check(x == quotient * y + remainder)
     }
 
     // ------------------------------ Conversions ------------------------------

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/IntegerTest.kt
@@ -632,169 +632,6 @@ class IntegerTest {
     }
 
     @Test
-    fun divSanityCheck() {
-        val x: Integer = Integer.parse("922337203685477580700")
-        val y: Integer = Integer.fromLong(10)
-
-        val actual: Integer = x / y
-
-        val expected: Integer = Integer.parse("92233720368547758070")
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun divHasRightIdentity(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val one: Integer = Integer.fromLong(1)
-
-        val actual: Integer = x / one
-
-        assertEquals(expected = x, actual, message = "Input: $x")
-    }
-
-    @Test
-    fun divHasAbsorbingZeroDividend(): Unit = repeatTest {
-        val zero: Integer = Integer.ZERO
-        val other: Integer = Random.integerExcept(illegal = zero)
-
-        val actual: Integer = zero / other
-
-        assertEquals(expected = zero, actual, message = "Input: $other")
-    }
-
-    @Test
-    fun divOfSameIntegerIsOne(): Unit = repeatTest {
-        val x: Integer = Random.integerExcept(illegal = Integer.ZERO)
-
-        val actual: Integer = x / x
-
-        val one: Integer = Integer.fromLong(1)
-        assertEquals(expected = one, actual, message = "Input: $x")
-    }
-
-    @Test
-    fun divSatisfiesDivisionAlgorithm(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.ZERO)
-
-        val quotient: Integer = x / y
-        val remainder: Integer = x % y
-        val actual: Integer = quotient * y + remainder
-
-        assertEquals(expected = x, actual, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
-    fun divAndRemSanityCheckWithNegativeDividend() {
-        val x: Integer = Integer.fromLong(-7)
-        val y: Integer = Integer.fromLong(2)
-
-        val quotient: Integer = x / y
-        val remainder: Integer = x % y
-
-        assertEquals(expected = Integer.fromLong(-4), actual = quotient)
-        assertEquals(expected = Integer.fromLong(1), actual = remainder)
-    }
-
-    @Test
-    fun divAndRemSanityCheckWithNegativeDivisor() {
-        val x: Integer = Integer.fromLong(7)
-        val y: Integer = Integer.fromLong(-2)
-
-        val quotient: Integer = x / y
-        val remainder: Integer = x % y
-
-        assertEquals(expected = Integer.fromLong(-3), actual = quotient)
-        assertEquals(expected = Integer.fromLong(1), actual = remainder)
-    }
-
-    @Test
-    fun divAndRemSanityCheckWithNegativeOperands() {
-        val x: Integer = Integer.fromLong(-7)
-        val y: Integer = Integer.fromLong(-2)
-
-        val quotient: Integer = x / y
-        val remainder: Integer = x % y
-
-        assertEquals(expected = Integer.fromLong(4), actual = quotient)
-        assertEquals(expected = Integer.fromLong(1), actual = remainder)
-    }
-
-    @Test
-    fun divIsConsistentWithTimes(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.ZERO)
-
-        val actual: Integer = (x * y) / y
-
-        assertEquals(expected = x, actual, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
-    fun divByZeroThrowsException(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Integer.ZERO
-
-        val exception: ArithmeticException = assertFailsWith { x / y }
-
-        val expected = "Division by zero"
-        val message = "Input: $x"
-        assertEquals(expected, actual = exception.message, message)
-    }
-
-    @Test
-    fun divOrNullSanityCheck() {
-        val x: Integer = Integer.parse("922337203685477580700")
-        val y: Integer = Integer.fromLong(10)
-
-        val actual: Integer? = x.divOrNull(y)
-
-        val expected: Integer = Integer.parse("92233720368547758070")
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun divOrNullHasRightIdentity(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val one: Integer = Integer.fromLong(1)
-
-        val actual: Integer? = x.divOrNull(one)
-
-        assertEquals(expected = x, actual, message = "Input: $x")
-    }
-
-    @Test
-    fun divOrNullHasAbsorbingZeroDividend(): Unit = repeatTest {
-        val zero: Integer = Integer.ZERO
-        val other: Integer = Random.integerExcept(illegal = zero)
-
-        val actual: Integer? = zero.divOrNull(other)
-
-        assertEquals(expected = zero, actual, message = "Input: $other")
-    }
-
-    @Test
-    fun divOrNullIsConsistentWithDiv(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.ZERO)
-
-        val actual: Integer? = x.divOrNull(y)
-
-        val expected: Integer = x / y
-        assertEquals(expected, actual, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
-    fun divOrNullWithZero(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Integer.ZERO
-
-        val actual: Integer? = x.divOrNull(y)
-
-        assertNull(actual)
-    }
-
-    @Test
     fun divByNonZeroIntegerSanityCheck() {
         val x: Integer = Integer.parse("922337203685477580700")
         val y: NonZeroInteger = NonZeroInteger.fromLong(10)
@@ -816,24 +653,13 @@ class IntegerTest {
     }
 
     @Test
-    fun divByNonZeroIntegerIsConsistentWithDiv(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: NonZeroInteger = Random.nonZeroInteger()
-
-        val actual: Integer = x / y
-
-        val expected: Integer = x / y.toInteger()
-        assertEquals(expected, actual, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
     fun divByNonZeroIntegerSatisfiesDivisionAlgorithm(): Unit = repeatTest {
         val x: Integer = Random.integer()
         val y: NonZeroInteger = Random.nonZeroInteger()
 
         val quotient: Integer = x / y
-        val remainder: Integer = x % y.toInteger()
-        val actual: Integer = quotient * y.toInteger() + remainder
+        val remainder: NonNegativeInteger = x % y
+        val actual: Integer = quotient * y.toInteger() + remainder.toInteger()
 
         assertEquals(expected = x, actual, message = "Inputs: x = $x, y = $y")
     }
@@ -847,18 +673,6 @@ class IntegerTest {
 
         val expected: NonNegativeInteger = NonNegativeInteger.fromLong(2)
         assertEquals(expected, actual)
-    }
-
-    @Test
-    fun remByNonZeroIntegerIsConsistentWithRem(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: NonZeroInteger = Random.nonZeroInteger()
-
-        val actual: NonNegativeInteger = x % y
-
-        val expected: Integer = x % y.toInteger()
-        val message = "Inputs: x = $x, y = $y"
-        assertEquals(expected, actual = actual.toInteger(), message)
     }
 
     @Test
@@ -890,106 +704,6 @@ class IntegerTest {
             val message = "Inputs: x = $x, y = $y"
             assertEquals(expected = x, actual, message)
         }
-
-    @Test
-    fun remSanityCheck() {
-        val x: Integer = Integer.fromLong(42)
-        val y: Integer = Integer.fromLong(5)
-
-        val actual: Integer = x % y
-
-        val expected: Integer = Integer.fromLong(2)
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun remByItselfIsZero(): Unit = repeatTest {
-        val zero: Integer = Integer.ZERO
-        val x: Integer = Random.integerExcept(illegal = zero)
-
-        val actual: Integer = x % x
-
-        assertEquals(expected = zero, actual, message = "Input: $x")
-    }
-
-    @Test
-    fun remHasZeroForDivisibleIntegers(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val zero: Integer = Integer.ZERO
-        val y: Integer = Random.integerExcept(illegal = zero)
-
-        val actual: Integer = (x * y) % y
-
-        val message = "Inputs: x = $x, y = $y"
-        assertEquals(expected = zero, actual, message)
-    }
-
-    @Test
-    fun remIsAlwaysNonNegative(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val zero: Integer = Integer.ZERO
-        val y: Integer = Random.integerExcept(illegal = zero)
-
-        val remainder: Integer = x % y
-
-        assertTrue(remainder >= zero, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
-    fun remIsBoundedByAbsoluteValueOfDivisor(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val zero: Integer = Integer.ZERO
-        val y: Integer = Random.integerExcept(illegal = zero)
-
-        val remainder: Integer = x % y
-
-        val absY: Integer = if (y > zero) y else -y
-        assertTrue(remainder < absY, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
-    fun remByZeroThrowsException(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Integer.ZERO
-
-        val exception: ArithmeticException = assertFailsWith { x % y }
-
-        val expected = "Division by zero"
-        val message = "Input: $x"
-        assertEquals(expected, actual = exception.message, message)
-    }
-
-    @Test
-    fun remOrNullSanityCheck() {
-        val x: Integer = Integer.fromLong(42)
-        val y: Integer = Integer.fromLong(5)
-
-        val actual: Integer? = x.remOrNull(y)
-
-        val expected: Integer = Integer.fromLong(2)
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun remOrNullIsConsistentWithRem(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Random.integerExcept(illegal = Integer.ZERO)
-
-        val actual: Integer? = x.remOrNull(y)
-
-        val expected: Integer = x % y
-        assertEquals(expected, actual, message = "Inputs: x = $x, y = $y")
-    }
-
-    @Test
-    fun remOrNullWithZeroReturnsNull(): Unit = repeatTest {
-        val x: Integer = Random.integer()
-        val y: Integer = Integer.ZERO
-
-        val actual: Integer? = x.remOrNull(y)
-
-        assertNull(actual)
-    }
 
     // ------------------------------ Conversions ------------------------------
 

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/IntegerJavaSample.java
@@ -148,19 +148,6 @@ public class IntegerJavaSample {
     }
 
     @Test
-    void euclideanDivision() {
-        final Integer x = Integer.fromLong(-7);
-        final Integer y = Integer.fromLong(2);
-
-        final Integer quotient = x.div(y);
-        final Integer remainder = x.rem(y);
-
-        final boolean check = quotient.equals(Integer.fromLong(-4))
-                && remainder.equals(Integer.fromLong(1));
-        if (!check) throw new IllegalStateException("Check failed.");
-    }
-
-    @Test
     void euclideanDivisionByNonZeroInteger() {
         final Integer x = Integer.fromLong(-7);
         final NonZeroInteger y = NonZeroInteger.fromLong(2);


### PR DESCRIPTION
## Summary

Removes `div(Integer)`, `divOrNull(Integer)`, `rem(Integer)` and `remOrNull(Integer)` from `Integer`, in favor of the total `div(NonZeroInteger)`/`rem(NonZeroInteger)` overloads, whose signature rules out division by zero at compile time.

- Adds ADR-018 documenting the decision
- Migrates `Decimal.normalize()`'s internal division to `NonZeroInteger`
- Removes the overloads, rewrites affected KDoc/samples/tests, regenerates the ABI dump
- Updates the changelog

Closes #1001

🤖 Generated with [Claude Code](https://claude.ai/code)