### PR TITLE
✨ Add `minus(NonPositiveInteger)` to `NonNegativeInteger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog], and this project adheres to its own
   representing an `Integer` other than zero. (module: `types`, ref: [#1011])
 - `NonNegativeInteger` **experimental** class to `org.kotools.types.number`
   package, representing an `Integer` that is greater than or equal to zero.
-  (module: `types`, refs: [#998], [#1014])
+  (module: `types`, refs: [#998], [#1014], [#1032])
 - `NonPositiveInteger` **experimental** class to `org.kotools.types.number`
   package, representing an `Integer` that is less than or equal to zero.
   (module: `types`, refs: [#1013], [#1024])
@@ -175,3 +175,4 @@ The format is based on [Keep a Changelog], and this project adheres to its own
 [#1013]: https://github.com/kotools/types/issues/1013
 [#1014]: https://github.com/kotools/types/issues/1014
 [#1024]: https://github.com/kotools/types/issues/1024
+[#1032]: https://github.com/kotools/types/issues/1032

--- a/documentation/decisions/ADR-019-nonnegativeinteger-subtractive-exclusion-v2.md
+++ b/documentation/decisions/ADR-019-nonnegativeinteger-subtractive-exclusion-v2.md
@@ -1,0 +1,66 @@
+# ⚖️ ADR-019: Exclusion of subtraction from `NonNegativeInteger` arithmetic (v2)
+
+> **Supersedes:** [ADR-014], whose decision excluded all subtraction from
+> `NonNegativeInteger`. This record narrows that exclusion to only
+> `minus(NonNegativeInteger)`.
+
+This document records the decision to add a `minus(NonPositiveInteger)`
+operator to the `NonNegativeInteger` type's arithmetic API, while keeping
+`minus(NonNegativeInteger)` excluded.
+
+## 🤔 Context
+
+[ADR-014] excluded all subtraction from `NonNegativeInteger`, reasoning that
+the set of non-negative integers isn't closed under subtracting another
+non-negative integer. [ADR-016] later extended `NonNegativeInteger`'s
+arithmetic for cross-type closure (`unaryMinus`, `times(NonPositiveInteger)`),
+without revisiting `minus`.
+
+The question that arose was: should `NonNegativeInteger` also provide a
+`minus` overload accepting a `NonPositiveInteger`, mirroring
+`NonPositiveInteger.minus(NonNegativeInteger)` from [ADR-017]?
+
+## ✅ Decision: `minus(NonPositiveInteger)` is included
+
+A `minus` operator accepting a `NonPositiveInteger` is added to
+`NonNegativeInteger`. `minus(NonNegativeInteger)` remains excluded.
+
+**Rationale:**
+
+- **The set of non-negative integers is closed under subtracting a
+  non-positive integer.** For `x: NonNegativeInteger` and
+  `y: NonPositiveInteger`, `x - y == x + (-y)`, and since `-y >= 0`, the
+  result is always `>= x >= 0`. The result is always representable as a
+  `NonNegativeInteger`.
+- **Mirrors the symmetric case on `NonPositiveInteger`.** [ADR-017] includes
+  `minus(NonNegativeInteger)` on `NonPositiveInteger` for the same closure
+  reason. This decision applies the same principle in the other direction.
+- **`minus(NonNegativeInteger)` remains excluded.** [ADR-014]'s original
+  rationale still holds for this overload: for any two non-negative integers
+  `x` and `y` where `x < y`, `x - y` is negative (e.g., `1 - 2 = -1`), so the
+  result cannot always be represented as a `NonNegativeInteger`.
+- **A nullable, throwing, or widened return type would break the type's
+  contract.** As in [ADR-014] and [ADR-013], operators in this codebase are
+  total functions over their declared types, so `minus(NonNegativeInteger)`
+  is omitted entirely rather than weakened.
+
+## 🔗 Consequences
+
+- The KDoc of `NonNegativeInteger` is updated to document `minus` alongside
+  `plus` and `times`, and to clarify that only `minus(NonNegativeInteger)`
+  remains absent.
+- [ADR-014] is marked as superseded by this record in the decisions index.
+- `NonNegativeInteger`'s arithmetic set is now `plus`, `times`,
+  `times(NonPositiveInteger)`, `unaryMinus` ([ADR-016]), and
+  `minus(NonPositiveInteger)`.
+- Converting to `Integer` remains the documented path for
+  `minus(NonNegativeInteger)`, consistent with how `NonZeroInteger` and
+  `NonPositiveInteger` document converting to `Integer` for their own
+  excluded operations.
+
+<!----------------------------------- Links ----------------------------------->
+
+[ADR-013]: ADR-013-nonzerointeger-additive-exclusion.md
+[ADR-014]: ADR-014-nonnegativeinteger-subtractive-exclusion.md
+[ADR-016]: ADR-016-nonnegativeinteger-cross-type-closure.md
+[ADR-017]: ADR-017-nonpositiveinteger-exclusions.md

--- a/documentation/decisions/README.md
+++ b/documentation/decisions/README.md
@@ -6,26 +6,27 @@ rationale behind it, and its consequences.
 
 ## 📄 Index
 
-| ADR                                                            | Title                                                             | Status                   |
-|----------------------------------------------------------------|-------------------------------------------------------------------|--------------------------|
-| [ADR-001](ADR-001-integer-euclidean-division.md)               | Euclidean division for `Integer`                                  | ✅ Accepted               |
-| [ADR-002](ADR-002-integer-value-semantics.md)                  | Value semantics for `Integer` arithmetic operations               | ✅ Accepted               |
-| [ADR-003](ADR-003-euclidean-division-platform-impl.md)         | Platform implementation of Euclidean division                     | 🔄 Superseded by ADR-008 |
-| [ADR-004](ADR-004-decimal-scaled-integer-repr.md)              | Scaled-integer representation for `Decimal`                       | ✅ Accepted               |
-| [ADR-005](ADR-005-decimal-canonical-form.md)                   | Canonical form for `Decimal`                                      | ✅ Accepted               |
-| [ADR-006](ADR-006-decimal-division-exclusion.md)               | Exclusion of division from `Decimal` arithmetic                   | ✅ Accepted               |
-| [ADR-007](ADR-007-native-integer-sign-magnitude-repr.md)       | Sign-magnitude representation for `NativeInteger`                 | ✅ Accepted               |
-| [ADR-008](ADR-008-euclidean-division-platform-impl-v2.md)      | Platform implementation of Euclidean division (v2)                | ✅ Accepted               |
-| [ADR-009](ADR-009-default-serializer-serial-names.md)          | Explicit serial names for default serializers                     | ✅ Accepted               |
-| [ADR-010](ADR-010-error-message-format.md)                     | Error message format for `org.kotools.types`                      | ✅ Accepted               |
-| [ADR-011](ADR-011-error-message-quote-escaping.md)             | String value quote escaping for `org.kotools.types`               | ✅ Accepted               |
-| [ADR-012](ADR-012-native-decimal-io-chunking.md)               | 10⁹-chunk decimal I/O for `NativeInteger`                         | ✅ Accepted               |
-| [ADR-013](ADR-013-nonzerointeger-additive-exclusion.md)        | Exclusion of additive operations from `NonZeroInteger` arithmetic | ✅ Accepted               |
-| [ADR-014](ADR-014-nonnegativeinteger-subtractive-exclusion.md) | Exclusion of subtraction from `NonNegativeInteger` arithmetic     | ✅ Accepted               |
-| [ADR-015](ADR-015-integer-typed-divisor-division.md)           | Typed-divisor Euclidean division for `Integer`                    | ✅ Accepted               |
-| [ADR-016](ADR-016-nonnegativeinteger-cross-type-closure.md)    | Cross-type closure for `NonNegativeInteger` arithmetic            | ✅ Accepted               |
-| [ADR-017](ADR-017-nonpositiveinteger-exclusions.md)            | Exclusions from `NonPositiveInteger` arithmetic                   | ✅ Accepted               |
-| [ADR-018](ADR-018-integer-division-removal.md)                 | Removal of `Integer`-accepting division from `Integer`            | ✅ Accepted               |
+| ADR                                                               | Title                                                              | Status                   |
+|-------------------------------------------------------------------|--------------------------------------------------------------------|--------------------------|
+| [ADR-001](ADR-001-integer-euclidean-division.md)                  | Euclidean division for `Integer`                                   | ✅ Accepted               |
+| [ADR-002](ADR-002-integer-value-semantics.md)                     | Value semantics for `Integer` arithmetic operations                | ✅ Accepted               |
+| [ADR-003](ADR-003-euclidean-division-platform-impl.md)            | Platform implementation of Euclidean division                      | 🔄 Superseded by ADR-008 |
+| [ADR-004](ADR-004-decimal-scaled-integer-repr.md)                 | Scaled-integer representation for `Decimal`                        | ✅ Accepted               |
+| [ADR-005](ADR-005-decimal-canonical-form.md)                      | Canonical form for `Decimal`                                       | ✅ Accepted               |
+| [ADR-006](ADR-006-decimal-division-exclusion.md)                  | Exclusion of division from `Decimal` arithmetic                    | ✅ Accepted               |
+| [ADR-007](ADR-007-native-integer-sign-magnitude-repr.md)          | Sign-magnitude representation for `NativeInteger`                  | ✅ Accepted               |
+| [ADR-008](ADR-008-euclidean-division-platform-impl-v2.md)         | Platform implementation of Euclidean division (v2)                 | ✅ Accepted               |
+| [ADR-009](ADR-009-default-serializer-serial-names.md)             | Explicit serial names for default serializers                      | ✅ Accepted               |
+| [ADR-010](ADR-010-error-message-format.md)                        | Error message format for `org.kotools.types`                       | ✅ Accepted               |
+| [ADR-011](ADR-011-error-message-quote-escaping.md)                | String value quote escaping for `org.kotools.types`                | ✅ Accepted               |
+| [ADR-012](ADR-012-native-decimal-io-chunking.md)                  | 10⁹-chunk decimal I/O for `NativeInteger`                          | ✅ Accepted               |
+| [ADR-013](ADR-013-nonzerointeger-additive-exclusion.md)           | Exclusion of additive operations from `NonZeroInteger` arithmetic  | ✅ Accepted               |
+| [ADR-014](ADR-014-nonnegativeinteger-subtractive-exclusion.md)    | Exclusion of subtraction from `NonNegativeInteger` arithmetic      | 🔄 Superseded by ADR-019 |
+| [ADR-015](ADR-015-integer-typed-divisor-division.md)              | Typed-divisor Euclidean division for `Integer`                     | ✅ Accepted               |
+| [ADR-016](ADR-016-nonnegativeinteger-cross-type-closure.md)       | Cross-type closure for `NonNegativeInteger` arithmetic             | ✅ Accepted               |
+| [ADR-017](ADR-017-nonpositiveinteger-exclusions.md)               | Exclusions from `NonPositiveInteger` arithmetic                    | ✅ Accepted               |
+| [ADR-018](ADR-018-integer-division-removal.md)                    | Removal of `Integer`-accepting division from `Integer`             | ✅ Accepted               |
+| [ADR-019](ADR-019-nonnegativeinteger-subtractive-exclusion-v2.md) | Exclusion of subtraction from `NonNegativeInteger` arithmetic (v2) | ✅ Accepted               |
 
 ## 🔄 Superseding records
 

--- a/subprojects/library/src/api/types.api
+++ b/subprojects/library/src/api/types.api
@@ -416,6 +416,7 @@ public final class org/kotools/types/number/NonNegativeInteger {
 	public static final fun fromInteger (Lorg/kotools/types/number/Integer;)Lorg/kotools/types/number/NonNegativeInteger;
 	public static final fun fromLong (J)Lorg/kotools/types/number/NonNegativeInteger;
 	public final fun hashCode ()I
+	public final fun minus (Lorg/kotools/types/number/NonPositiveInteger;)Lorg/kotools/types/number/NonNegativeInteger;
 	public static final fun parse (Ljava/lang/String;)Lorg/kotools/types/number/NonNegativeInteger;
 	public final fun plus (Lorg/kotools/types/number/NonNegativeInteger;)Lorg/kotools/types/number/NonNegativeInteger;
 	public final fun times (Lorg/kotools/types/number/NonNegativeInteger;)Lorg/kotools/types/number/NonNegativeInteger;

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
@@ -29,10 +29,12 @@ import kotlin.jvm.JvmSynthetic
  * [structural equality][NonNegativeInteger.equals] (`x == y`, `x != y`).
  * - **Arithmetic operations:** [Add][plus] (`x + y`) or [multiply][times]
  * (`x * y`) non-negative integers, always producing another non-negative
- * integer. [Negating][unaryMinus] (`-x`) a non-negative integer, or
- * [multiplying][times] it by a [NonPositiveInteger], always produces a
- * [NonPositiveInteger]. Subtraction is intentionally absent, because the set of
- * non-negative integers isn't closed under this operation (e.g., `1 - 2 = -1`).
+ * integer. [Subtracting][minus] (`x - y`) a [NonPositiveInteger] also produces
+ * another non-negative integer. [Negating][unaryMinus] (`-x`) a non-negative
+ * integer, or [multiplying][times] it by a [NonPositiveInteger], always
+ * produces a [NonPositiveInteger]. Subtracting a [NonNegativeInteger] is
+ * intentionally absent, because the set of non-negative integers isn't closed
+ * under this operation (e.g., `1 - 2 = -1`).
  * - **Conversions:** Convert to its underlying [Integer] (see [toInteger]),
  * or to its decimal string representation (see
  * [NonNegativeInteger.toString]).
@@ -380,6 +382,34 @@ public class NonNegativeInteger private constructor(
      */
     public operator fun plus(other: NonNegativeInteger): NonNegativeInteger =
         fromInteger(this.value + other.value)
+
+    /**
+     * Subtracts the [other] integer from this one.
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Kotlin</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Kotlin code:
+     *
+     * SAMPLE: org.kotools.types.number.NonNegativeIntegerSample.minus
+     * </details>
+     *
+     * <br>
+     * <details>
+     * <summary>
+     *     <b>Calling from Java</b>
+     * </summary>
+     *
+     * Here's an example of calling this function from Java code:
+     *
+     * SAMPLE: org.kotools.types.number.NonNegativeIntegerJavaSample.minus
+     * </details>
+     */
+    public operator fun minus(other: NonPositiveInteger): NonNegativeInteger =
+        this + (-other)
 
     /**
      * Multiplies this integer by the [other] one.

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonNegativeIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonNegativeIntegerSample.kt
@@ -97,7 +97,9 @@ class NonNegativeIntegerSample {
     fun minus() {
         val x: NonNegativeInteger = NonNegativeInteger.fromLong(42)
         val y: NonPositiveInteger = NonPositiveInteger.fromLong(-8)
+
         val result: NonNegativeInteger = x - y
+
         val expected: NonNegativeInteger = NonNegativeInteger.fromLong(50)
         check(result == expected)
     }

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonNegativeIntegerSample.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonNegativeIntegerSample.kt
@@ -94,6 +94,15 @@ class NonNegativeIntegerSample {
     }
 
     @Test
+    fun minus() {
+        val x: NonNegativeInteger = NonNegativeInteger.fromLong(42)
+        val y: NonPositiveInteger = NonPositiveInteger.fromLong(-8)
+        val result: NonNegativeInteger = x - y
+        val expected: NonNegativeInteger = NonNegativeInteger.fromLong(50)
+        check(result == expected)
+    }
+
+    @Test
     fun timesWithNonNegativeInteger() {
         val x: NonNegativeInteger =
             NonNegativeInteger.fromLong(99999999999999999)

--- a/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonNegativeIntegerTest.kt
+++ b/subprojects/library/src/commonTest/kotlin/org/kotools/types/number/NonNegativeIntegerTest.kt
@@ -347,6 +347,36 @@ class NonNegativeIntegerTest {
     }
 
     @Test
+    fun minusHasZeroAsIdentityElement(): Unit = repeatTest {
+        val x: NonNegativeInteger = Random.nonNegativeInteger()
+        val zero: NonPositiveInteger = NonPositiveInteger.fromLong(0)
+        val actual: NonNegativeInteger = x - zero
+        assertEquals(x, actual, message = "Input: $x")
+    }
+
+    @Test
+    fun minusIsAlwaysNonNegative(): Unit = repeatTest {
+        val x: NonNegativeInteger = Random.nonNegativeInteger()
+        val y: NonPositiveInteger = Random.nonPositiveInteger()
+
+        val difference: NonNegativeInteger = x - y
+
+        val actual: Boolean = difference.toInteger() >= Integer.ZERO
+        assertTrue(actual, message = "Inputs: x = $x, y = $y")
+    }
+
+    @Test
+    fun minusSanityCheck() {
+        val x: NonNegativeInteger =
+            NonNegativeInteger.parse("99999999999999999999")
+        val y: NonPositiveInteger = NonPositiveInteger.parse("-1")
+        val actual: NonNegativeInteger = x - y
+        val expected: NonNegativeInteger =
+            NonNegativeInteger.parse("100000000000000000000")
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun timesWithNonNegativeIntegerIsCommutative(): Unit = repeatTest {
         val x: NonNegativeInteger = Random.nonNegativeInteger()
         val y: NonNegativeInteger = Random.nonNegativeInteger()

--- a/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonNegativeIntegerJavaSample.java
+++ b/subprojects/library/src/jvmTest/java/org/kotools/types/number/NonNegativeIntegerJavaSample.java
@@ -98,6 +98,18 @@ public class NonNegativeIntegerJavaSample {
     }
 
     @Test
+    void minus() {
+        final NonNegativeInteger x = NonNegativeInteger.fromLong(42L);
+        final NonPositiveInteger y = NonPositiveInteger.fromLong(-8L);
+
+        final NonNegativeInteger result = x.minus(y);
+
+        final NonNegativeInteger expected = NonNegativeInteger.fromLong(50L);
+        final boolean check = result.equals(expected);
+        if (!check) throw new IllegalStateException("Check failed.");
+    }
+
+    @Test
     void timesWithNonNegativeInteger() {
         final NonNegativeInteger x =
                 NonNegativeInteger.fromLong(99999999999999999L);


### PR DESCRIPTION
## Summary

Adds the experimental `minus(NonPositiveInteger)` function to `NonNegativeInteger`, the mirror counterpart of `NonPositiveInteger.minus(NonNegativeInteger)`. Subtracting a non-positive integer from a non-negative integer always produces a non-negative integer, so this overload is closed under `NonNegativeInteger`.

- Source change, KDoc rewording, Kotlin/Java samples, tests, and ABI dump
- New ADR-019, superseding ADR-014, documenting the decision
- Changelog update

Closes #1032.

🤖 Generated with [Claude Code](https://claude.ai/code)