### PR TITLE
📝 Document motivations behind Integer variants

### DIFF
--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -88,9 +88,9 @@ import kotlin.jvm.JvmSynthetic
  * This guarantee covers both halves of the Euclidean division theorem, each
  * encoded directly in the signature of [div] and [rem] rather than asserted
  * in documentation prose: the divisor can never be zero, because both
- * functions require a [NonZeroInteger] (see its Motivations section), and the
- * remainder can never be negative, because [rem] returns a
- * [NonNegativeInteger] instead of an [Integer] (see its Motivations section).
+ * functions require a [NonZeroInteger], and the remainder can never be
+ * negative, because [rem] returns a [NonNegativeInteger] instead of an
+ * [Integer].
  * </details>
  *
  * <br>

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/Integer.kt
@@ -84,6 +84,13 @@ import kotlin.jvm.JvmSynthetic
  * Euclidean semantics: the remainder is always non-negative (`0 ≤ r < |b|`).
  *
  * SAMPLE: org.kotools.types.number.IntegerSample.euclideanDivisionByNonZeroInteger
+ *
+ * This guarantee covers both halves of the Euclidean division theorem, each
+ * encoded directly in the signature of [div] and [rem] rather than asserted
+ * in documentation prose: the divisor can never be zero, because both
+ * functions require a [NonZeroInteger] (see its Motivations section), and the
+ * remainder can never be negative, because [rem] returns a
+ * [NonNegativeInteger] instead of an [Integer] (see its Motivations section).
  * </details>
  *
  * <br>

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonNegativeInteger.kt
@@ -18,6 +18,52 @@ import kotlin.jvm.JvmSynthetic
  * <br>
  * <details>
  * <summary>
+ *     <b>Motivations</b>
+ * </summary>
+ *
+ * ### Motivations
+ *
+ * #### A standalone type instead of a runtime check
+ *
+ * Whether an integer is non-negative could be checked at runtime, inline,
+ * wherever such a guarantee is needed. Instead, this library models "an
+ * [Integer] that is greater than or equal to zero" as its own type. This is
+ * what lets [Integer.rem] express the non-negative half of the Euclidean
+ * division theorem directly in its return type, rather than merely asserting
+ * it in documentation prose: any value of type [NonNegativeInteger] is
+ * already known to satisfy `>= 0`, so callers of [Integer.rem] get that
+ * guarantee statically instead of having to trust and re-verify it
+ * themselves.
+ *
+ * #### A closure-driven arithmetic surface
+ *
+ * [plus] and [times] stay within [NonNegativeInteger], because the set of
+ * non-negative integers is closed under addition and under multiplication by
+ * another non-negative integer.
+ *
+ * [unaryMinus] and [times] with a [NonPositiveInteger] operand cross over to
+ * [NonPositiveInteger] instead of staying within [NonNegativeInteger]:
+ * negating a non-negative integer, or multiplying it by a non-positive one,
+ * never stays non-negative (except for zero), but its result is always
+ * representable as a [NonPositiveInteger]. Returning [NonPositiveInteger]
+ * keeps both operations total instead of omitting them or widening their
+ * result to the unconstrained [Integer].
+ *
+ * [minus] only accepts a [NonPositiveInteger] operand, not a
+ * [NonNegativeInteger] one: subtracting a non-positive integer from a
+ * non-negative one always stays non-negative (`x - y == x + (-y)`, and
+ * `-y >= 0`), but subtracting another non-negative integer can produce a
+ * negative result (e.g. `1 - 2 = -1`), which isn't representable as a
+ * [NonNegativeInteger]. Use [toInteger] together with [Integer.minus] for
+ * that case.
+ *
+ * Division and remainder operations are absent, since they would only
+ * duplicate the semantics already covered by [Integer.div] and [Integer.rem].
+ * </details>
+ *
+ * <br>
+ * <details>
+ * <summary>
  *     <b>Key features</b>
  * </summary>
  *

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonPositiveInteger.kt
@@ -18,6 +18,48 @@ import kotlin.jvm.JvmSynthetic
  * <br>
  * <details>
  * <summary>
+ *     <b>Motivations</b>
+ * </summary>
+ *
+ * ### Motivations
+ *
+ * #### Completing the sign trichotomy
+ *
+ * Once [NonZeroInteger] and [NonNegativeInteger] exist as standalone types,
+ * "non-positive" is the natural remaining case: together, the three types
+ * make the sign of an [Integer] fully and symmetrically expressible in the
+ * type system, instead of leaving "less than or equal to zero" as a runtime
+ * check that callers would otherwise perform inline on an [Integer].
+ *
+ * #### A closure-driven arithmetic surface
+ *
+ * [unaryMinus], [plus], [minus] with a [NonNegativeInteger] operand, and both
+ * [times] overloads are defined because each always produces a value
+ * representable as a [NonPositiveInteger] or a [NonNegativeInteger]:
+ * negating a non-positive integer is always non-negative; adding two
+ * non-positive integers stays non-positive; subtracting a non-negative
+ * integer from a non-positive one stays non-positive (`x - y == x + (-y)`,
+ * and `-y <= 0`); multiplying a non-positive integer by a non-negative one
+ * stays non-positive; and multiplying two non-positive integers becomes
+ * non-negative.
+ *
+ * [minus] with a [NonPositiveInteger], [NonZeroInteger], or [Integer]
+ * operand is absent, because the set of non-positive integers isn't closed
+ * under any of them: for two non-positive integers `x` and `y` where
+ * `x > y`, `x - y` is positive (e.g. `-1 - (-5) = 4`), and the same
+ * unrestricted sign applies when subtracting a [NonZeroInteger] or an
+ * [Integer]. A [times] overload accepting a [NonZeroInteger] is absent for
+ * the same reason: a non-zero integer can be positive or negative, so the
+ * sign of the product is indeterminate. Use [toInteger] together with
+ * [Integer.minus] or [Integer.times] for these cases.
+ *
+ * Division and remainder operations are absent, since they would only
+ * duplicate the semantics already covered by [Integer.div] and [Integer.rem].
+ * </details>
+ *
+ * <br>
+ * <details>
+ * <summary>
  *     <b>Key features</b>
  * </summary>
  *

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -49,7 +49,7 @@ import kotlin.jvm.JvmSynthetic
  * as a [NonZeroInteger]. Use [toInteger] together with [Integer.plus] or
  * [Integer.minus] if you need to add or subtract non-zero integers.
  *
- * Division and remainder operations are also absent, since they would only
+ * Division and remainder operations are absent, since they would only
  * duplicate the semantics already covered by [Integer.div] and [Integer.rem].
  * </details>
  *

--- a/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
+++ b/subprojects/library/src/commonMain/kotlin/org/kotools/types/number/NonZeroInteger.kt
@@ -18,6 +18,44 @@ import kotlin.jvm.JvmSynthetic
  * <br>
  * <details>
  * <summary>
+ *     <b>Motivations</b>
+ * </summary>
+ *
+ * ### Motivations
+ *
+ * #### A standalone type instead of a runtime check
+ *
+ * Whether a divisor is zero could be checked at runtime, inline, every time a
+ * division is about to happen. Instead, this library models "an [Integer]
+ * that is other than zero" as its own type. This turns "the divisor isn't
+ * zero" from a precondition that [Integer.div] and [Integer.rem] would
+ * otherwise need to verify (and that callers would need to trust was
+ * verified) into a guarantee carried by the [NonZeroInteger] type itself: any
+ * value of this type is already known to be non-zero, so [Integer.div] and
+ * [Integer.rem] can accept it as a divisor and never throw or return `null`
+ * because of a zero divisor.
+ *
+ * #### A closure-driven arithmetic surface
+ *
+ * Only [unaryMinus] and [times] are defined as arithmetic operations on this
+ * type, because the set of non-zero integers is closed under negation and
+ * multiplication: negating or multiplying non-zero integers always produces
+ * another non-zero integer.
+ *
+ * Addition and subtraction are intentionally absent, because the set of
+ * non-zero integers isn't closed under either operation: for any non-zero
+ * integer `x`, `x + (-x) = 0` and `x - x = 0`, so the result of these
+ * operations on two non-zero integers can be zero, which isn't representable
+ * as a [NonZeroInteger]. Use [toInteger] together with [Integer.plus] or
+ * [Integer.minus] if you need to add or subtract non-zero integers.
+ *
+ * Division and remainder operations are also absent, since they would only
+ * duplicate the semantics already covered by [Integer.div] and [Integer.rem].
+ * </details>
+ *
+ * <br>
+ * <details>
+ * <summary>
  *     <b>Key features</b>
  * </summary>
  *


### PR DESCRIPTION
Adds a prose-only "Motivations" KDoc section to `NonZeroInteger`, `NonNegativeInteger`, and `NonPositiveInteger`, explaining:

- why each exists as a standalone type instead of a runtime check on `Integer`;
- the closure argument for each arithmetic operation it exposes or omits;
- why `div`/`rem` are absent from all three.

Also ties `Integer`'s Euclidean division Motivations subsection to both halves of the theorem (non-zero divisor, non-negative remainder), linking to the two types' own Motivations sections.

Documentation-only change: no API, ADR, or CHANGELOG changes.

Closes #1037.

🤖 Generated with [Claude Code](https://claude.ai/code)